### PR TITLE
Replace `gen.generate()` with `draw(gen)`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -201,7 +201,7 @@ A singleton `_session` lazily starts the `hegel` binary as a subprocess on first
 The Hegel server speaks CBOR. Generator schemas are CBOR maps:
 - `{"type": "boolean"}` — booleans
 - `{"type": "integer", "min_value"?: N, "max_value"?: N}` — integers
-- `{"type": "number", "allow_nan": bool, "allow_infinity": bool, "width": 64, "exclude_min": bool, "exclude_max": bool, "min_value"?: f, "max_value"?: f}` — floats
+- `{"type": "float", "allow_nan": bool, "allow_infinity": bool, "width": 64, "exclude_min": bool, "exclude_max": bool, "min_value"?: f, "max_value"?: f}` — floats
 - `{"type": "string", "min_size": N, "max_size"?: N}` — text
 - `{"type": "binary", "min_size": N, "max_size"?: N}` — binary
 - sampled_from: uses `{"type": "integer", "min_value": 0, "max_value": N-1}` with a map transform to index into the values array

--- a/conformance/test_binary.ml
+++ b/conformance/test_binary.ml
@@ -10,6 +10,6 @@ let () =
   let max_size = Json_params.get_int_opt params "max_size" in
   let test_cases = get_test_cases () in
   Hegel.Session.run_hegel_test ~name:"test_binary" ~test_cases (fun () ->
-      let b = generate (binary ~min_size ?max_size ()) in
+      let b = Hegel.draw (binary ~min_size ?max_size ()) in
       let length = String.length b in
       write_metrics [ ("length", string_of_int length) ])

--- a/conformance/test_booleans.ml
+++ b/conformance/test_booleans.ml
@@ -6,5 +6,5 @@ open Hegel.Generators
 let () =
   let test_cases = get_test_cases () in
   Hegel.Session.run_hegel_test ~name:"test_booleans" ~test_cases (fun () ->
-      let b = generate (booleans ()) in
+      let b = Hegel.draw (booleans ()) in
       write_metrics [ ("value", if b then "true" else "false") ])

--- a/conformance/test_floats.ml
+++ b/conformance/test_floats.ml
@@ -21,7 +21,7 @@ let () =
   let test_cases = get_test_cases () in
   Hegel.Session.run_hegel_test ~name:"test_floats" ~test_cases (fun () ->
       let f =
-        generate
+        Hegel.draw
           (floats ?min_value ?max_value ~exclude_min ~exclude_max ?allow_nan
              ?allow_infinity ())
       in

--- a/conformance/test_hashmaps.ml
+++ b/conformance/test_hashmaps.ml
@@ -22,7 +22,7 @@ let () =
           integers ~min_value:min_value_p ~max_value:max_value_p ()
         in
         let map_gen = hashmaps key_gen val_gen ~min_size ~max_size () in
-        let pairs = generate map_gen in
+        let pairs = Hegel.draw map_gen in
         let size = List.length pairs in
         let values = List.map snd pairs in
         let min_val_result =
@@ -48,7 +48,7 @@ let () =
           integers ~min_value:min_value_p ~max_value:max_value_p ()
         in
         let map_gen = hashmaps key_gen val_gen ~min_size ~max_size () in
-        let pairs = generate map_gen in
+        let pairs = Hegel.draw map_gen in
         let size = List.length pairs in
         let keys = List.map fst pairs in
         let values = List.map snd pairs in

--- a/conformance/test_integers.ml
+++ b/conformance/test_integers.ml
@@ -10,5 +10,5 @@ let () =
   let max_value = Json_params.get_int_opt params "max_value" in
   let test_cases = get_test_cases () in
   Hegel.Session.run_hegel_test ~name:"test_integers" ~test_cases (fun () ->
-      let n = generate (integers ?min_value ?max_value ()) in
+      let n = Hegel.draw (integers ?min_value ?max_value ()) in
       write_metrics [ ("value", string_of_int n) ])

--- a/conformance/test_lists.ml
+++ b/conformance/test_lists.ml
@@ -24,7 +24,7 @@ let () =
         filter (fun _ -> true) (integers ?min_value ?max_value ())
       in
       let list_gen = lists elem_gen ~min_size ?max_size () in
-      let items = generate list_gen in
+      let items = Hegel.draw list_gen in
       let size = List.length items in
       let min_element =
         if size = 0 then None

--- a/conformance/test_sampled_from.ml
+++ b/conformance/test_sampled_from.ml
@@ -9,5 +9,5 @@ let () =
   let options = Json_params.get_int_array params "options" in
   let test_cases = get_test_cases () in
   Hegel.Session.run_hegel_test ~name:"test_sampled_from" ~test_cases (fun () ->
-      let n = generate (sampled_from options) in
+      let n = Hegel.draw (sampled_from options) in
       write_metrics [ ("value", string_of_int n) ])

--- a/conformance/test_text.ml
+++ b/conformance/test_text.ml
@@ -28,6 +28,6 @@ let () =
   let max_size = Json_params.get_int_opt params "max_size" in
   let test_cases = get_test_cases () in
   Hegel.Session.run_hegel_test ~name:"test_text" ~test_cases (fun () ->
-      let s = generate (text ~min_size ?max_size ()) in
+      let s = Hegel.draw (text ~min_size ?max_size ()) in
       let length = utf8_length s in
       write_metrics [ ("length", string_of_int length) ])

--- a/examples/basic_properties.ml
+++ b/examples/basic_properties.ml
@@ -9,8 +9,8 @@ open Hegel.Client
 let test_integer_arithmetic () =
   Hegel.Session.run_hegel_test ~name:"integer_arithmetic" ~test_cases:100
     (fun () ->
-      let a = generate (integers ~min_value:(-1000) ~max_value:1000 ()) in
-      let b = generate (integers ~min_value:(-1000) ~max_value:1000 ()) in
+      let a = Hegel.draw (integers ~min_value:(-1000) ~max_value:1000 ()) in
+      let b = Hegel.draw (integers ~min_value:(-1000) ~max_value:1000 ()) in
       (* Addition is commutative *)
       assert (a + b = b + a);
       (* Double negation is identity *)
@@ -21,8 +21,8 @@ let test_integer_arithmetic () =
 (** Property: boolean identities. *)
 let test_boolean_laws () =
   Hegel.Session.run_hegel_test ~name:"boolean_laws" ~test_cases:50 (fun () ->
-      let p = generate (booleans ()) in
-      let q = generate (booleans ()) in
+      let p = Hegel.draw (booleans ()) in
+      let q = Hegel.draw (booleans ()) in
       (* De Morgan's law *)
       assert (((not p) || not q) = not (p && q));
       (* Double negation *)
@@ -34,8 +34,8 @@ let test_boolean_laws () =
 let test_division () =
   Hegel.Session.run_hegel_test ~name:"division_identity" ~test_cases:100
     (fun () ->
-      let n = generate (integers ~min_value:(-1000) ~max_value:1000 ()) in
-      let d = generate (integers ~min_value:(-1000) ~max_value:1000 ()) in
+      let n = Hegel.draw (integers ~min_value:(-1000) ~max_value:1000 ()) in
+      let d = Hegel.draw (integers ~min_value:(-1000) ~max_value:1000 ()) in
       assume (d <> 0);
       note (Printf.sprintf "n=%d d=%d" n d);
       (* Integer division: n = (n / d) * d + (n mod d) *)
@@ -44,13 +44,13 @@ let test_division () =
 (** Property: text strings have non-negative length. *)
 let test_text_length () =
   Hegel.Session.run_hegel_test ~name:"text_length" ~test_cases:100 (fun () ->
-      let s = generate (text ~min_size:0 ~max_size:50 ()) in
+      let s = Hegel.draw (text ~min_size:0 ~max_size:50 ()) in
       assert (String.length s >= 0))
 
 (** Property: binary blobs have non-negative byte length. *)
 let test_binary_length () =
   Hegel.Session.run_hegel_test ~name:"binary_length" ~test_cases:100 (fun () ->
-      let b = generate (binary ~min_size:0 ~max_size:50 ()) in
+      let b = Hegel.draw (binary ~min_size:0 ~max_size:50 ()) in
       assert (String.length b >= 0))
 
 (** Property: finite floats are their own doubles divided by two. Uses
@@ -58,7 +58,7 @@ let test_binary_length () =
 let test_float_finite () =
   Hegel.Session.run_hegel_test ~name:"float_finite" ~test_cases:100 (fun () ->
       let x =
-        generate
+        Hegel.draw
           (floats ~min_value:(-1e6) ~max_value:1e6 ~allow_nan:false
              ~allow_infinity:false ())
       in

--- a/examples/collections.ml
+++ b/examples/collections.ml
@@ -11,14 +11,14 @@ let test_filtered_list () =
       let non_neg =
         filter (fun v -> v >= 0) (integers ~min_value:(-100) ~max_value:100 ())
       in
-      let lst = generate (lists non_neg ~min_size:0 ~max_size:10 ()) in
+      let lst = Hegel.draw (lists non_neg ~min_size:0 ~max_size:10 ()) in
       List.iter (fun x -> assert (x >= 0)) lst)
 
 (** Property: a list generated with [min_size] has at least that many elements.
 *)
 let test_list_min_size () =
   Hegel.Session.run_hegel_test ~name:"list_min_size" ~test_cases:100 (fun () ->
-      let lst = generate (lists (integers ()) ~min_size:3 ~max_size:10 ()) in
+      let lst = Hegel.draw (lists (integers ()) ~min_size:3 ~max_size:10 ()) in
       assert (List.length lst >= 3))
 
 (** Property: [map] transforms every element. Here we map integers to their
@@ -28,7 +28,7 @@ let test_map_combinator () =
       let abs_gen =
         map (fun v -> abs v) (integers ~min_value:(-100) ~max_value:100 ())
       in
-      let lst = generate (lists abs_gen ~min_size:1 ~max_size:10 ()) in
+      let lst = Hegel.draw (lists abs_gen ~min_size:1 ~max_size:10 ()) in
       List.iter (fun x -> assert (x >= 0)) lst)
 
 (** Property: [flat_map] can make a pair (n, list-of-n-integers). Generates an
@@ -47,14 +47,14 @@ let test_flat_map_combinator () =
                  ~min_size:n ~max_size:n ()))
           (integers ~min_value:1 ~max_value:5 ())
       in
-      let n, lst = generate pair_gen in
+      let n, lst = Hegel.draw pair_gen in
       assert (List.length lst = n))
 
 (** Property: [sampled_from] always returns one of the specified values. *)
 let test_sampled_from () =
   Hegel.Session.run_hegel_test ~name:"sampled_from" ~test_cases:100 (fun () ->
       let options = [ 10; 20; 30; 40 ] in
-      let v = generate (sampled_from options) in
+      let v = Hegel.draw (sampled_from options) in
       assert (v = 10 || v = 20 || v = 30 || v = 40))
 
 (** Property: hashmaps generated with a min_size have at least that many
@@ -62,7 +62,7 @@ let test_sampled_from () =
 let test_hashmap_size () =
   Hegel.Session.run_hegel_test ~name:"hashmap_size" ~test_cases:50 (fun () ->
       let pairs =
-        generate
+        Hegel.draw
           (hashmaps
              (text ~min_size:1 ~max_size:8 ())
              (integers ~min_value:0 ~max_value:100 ())

--- a/examples/real_world.ml
+++ b/examples/real_world.ml
@@ -34,8 +34,8 @@ let test_merge_sorted_is_sorted () =
     (fun () ->
       let int_gen = integers ~min_value:(-1000) ~max_value:1000 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:20 () in
-      let a = sorted (generate list_gen) in
-      let b = sorted (generate list_gen) in
+      let a = sorted (Hegel.draw list_gen) in
+      let b = sorted (Hegel.draw list_gen) in
       let merged = merge_sorted a b in
       assert (is_sorted merged))
 
@@ -46,8 +46,8 @@ let test_merge_preserves_elements () =
     (fun () ->
       let int_gen = integers ~min_value:(-100) ~max_value:100 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:15 () in
-      let a = sorted (generate list_gen) in
-      let b = sorted (generate list_gen) in
+      let a = sorted (Hegel.draw list_gen) in
+      let b = sorted (Hegel.draw list_gen) in
       let merged = merge_sorted a b in
       assert (multiset_equal merged (a @ b)))
 
@@ -58,7 +58,7 @@ let test_merge_with_self () =
     (fun () ->
       let int_gen = integers ~min_value:(-500) ~max_value:500 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:10 () in
-      let a = sorted (generate list_gen) in
+      let a = sorted (Hegel.draw list_gen) in
       let merged = merge_sorted a a in
       assert (is_sorted merged);
       assert (List.length merged = 2 * List.length a))
@@ -69,8 +69,8 @@ let test_merge_commutative () =
     (fun () ->
       let int_gen = integers ~min_value:(-200) ~max_value:200 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:10 () in
-      let a = sorted (generate list_gen) in
-      let b = sorted (generate list_gen) in
+      let a = sorted (Hegel.draw list_gen) in
+      let b = sorted (Hegel.draw list_gen) in
       let ab = merge_sorted a b in
       let ba = merge_sorted b a in
       (* Both results should be the same sorted multiset *)

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -15,19 +15,23 @@ exception Assume_rejected
 exception Data_exhausted
 (** Raised when the server runs out of test data (StopTest). *)
 
-(** Current test case channel. Set for the duration of each test case.
+type test_case_data = {
+  channel : channel;
+  is_final : bool;
+  mutable test_aborted : bool;
+}
+(** Per-test-case data, consolidating channel, final-run flag, and abort state.
     Domain-local so each domain has its own independent test state. *)
-let current_channel : channel option Domain.DLS.key =
+
+let current_data : test_case_data option Domain.DLS.key =
   Domain.DLS.new_key (fun () -> None)
 
-(** Whether this is the final (replay) run for a failing test case. *)
-let is_final_run : bool Domain.DLS.key = Domain.DLS.new_key (fun () -> false)
-
-(** Whether the server sent StopTest during this test case. *)
-let test_aborted : bool Domain.DLS.key = Domain.DLS.new_key (fun () -> false)
-
-(** Whether we are currently inside a test case body. *)
-let in_test : bool Domain.DLS.key = Domain.DLS.new_key (fun () -> false)
+(** [get_data ()] returns the current test case data, raising [Failure] if not
+    in a test context. *)
+let get_data () =
+  match Domain.DLS.get current_data with
+  | None -> failwith "Not in a test context"
+  | Some d -> d
 
 (** [extract_origin exn] extracts an InterestingOrigin string from an exception.
     Uses the backtrace if available. *)
@@ -51,41 +55,38 @@ let extract_origin exn =
   | Some (file, line) ->
       Printf.sprintf "%s at %s:%d" (Printexc.exn_slot_name exn) file line
 
-(** [get_channel ()] returns the current test data channel, raising [Failure] if
-    not in a test context. *)
-let get_channel () =
-  match Domain.DLS.get current_channel with
-  | None ->
-      failwith
-        "Not in a test context - must be called from within a test function"
-  | Some ch -> ch
-
-(** [generate_from_schema schema] generates a value from a schema by sending a
-    generate command to the server. Raises {!Data_exhausted} if the server
-    signals StopTest. *)
-let generate_from_schema schema =
-  let channel = get_channel () in
+(** [generate_from_schema schema data] generates a value from a schema by
+    sending a generate command to the server. Raises {!Data_exhausted} if the
+    server signals StopTest. *)
+let generate_from_schema schema data =
+  let channel = data.channel in
   try
     pending_get
       (request channel
          (`Map [ (`Text "command", `Text "generate"); (`Text "schema", schema) ]))
   with Request_error e when e.error_type = "StopTest" ->
-    Domain.DLS.set test_aborted true;
+    data.test_aborted <- true;
     raise Data_exhausted
 
 (** [assume condition] rejects the current test case if [condition] is [false].
 *)
-let assume condition = if not condition then raise Assume_rejected
+let assume condition =
+  if Domain.DLS.get current_data = None then
+    failwith "assume() cannot be called outside of a Hegel test";
+  if not condition then raise Assume_rejected
 
 (** [note message] records a message that will be printed on the final (failing)
     run. *)
 let note message =
-  if Domain.DLS.get is_final_run then Printf.eprintf "%s\n%!" message
+  match Domain.DLS.get current_data with
+  | None -> failwith "note() cannot be called outside of a Hegel test"
+  | Some data -> if data.is_final then Printf.eprintf "%s\n%!" message
 
 (** [target value label] sends a target command to guide the search engine
     toward higher values. *)
 let target value label =
-  let channel = get_channel () in
+  let data = get_data () in
+  let channel = data.channel in
   ignore
     (pending_get
        (request channel
@@ -96,11 +97,11 @@ let target value label =
                (`Text "label", `Text label);
              ])))
 
-(** [start_span ?label ()] starts a generation span for better shrinking. *)
-let start_span ?(label = 0) () =
-  if Domain.DLS.get test_aborted then ()
+(** [start_span ?label data] starts a generation span for better shrinking. *)
+let start_span ?(label = 0) data =
+  if data.test_aborted then ()
   else begin
-    let channel = get_channel () in
+    let channel = data.channel in
     ignore
       (pending_get
          (request channel
@@ -111,11 +112,11 @@ let start_span ?(label = 0) () =
                ])))
   end
 
-(** [stop_span ?discard ()] ends the current generation span. *)
-let stop_span ?(discard = false) () =
-  if Domain.DLS.get test_aborted then ()
+(** [stop_span ?discard data] ends the current generation span. *)
+let stop_span ?(discard = false) data =
+  if data.test_aborted then ()
   else begin
-    let channel = get_channel () in
+    let channel = data.channel in
     ignore
       (pending_get
          (request channel
@@ -133,11 +134,12 @@ type client = { connection : connection; control : channel; lock : Mutex.t }
     connection must not yet have had its handshake performed. *)
 let create_client connection =
   let server_version = float_of_string (send_handshake connection) in
-  if server_version <> 0.1 then
+  if server_version < 0.1 || server_version > 0.3 then
     failwith
       (Printf.sprintf
-         "hegel-ocaml supports protocol version 0.1, but got server version \
-          %g. Upgrading hegel-ocaml or downgrading your hegel cli might help."
+         "hegel-ocaml supports protocol versions 0.1 through 0.3, but got \
+          server version %g. Upgrading hegel-ocaml or downgrading your hegel \
+          cli might help."
          server_version);
   { connection; control = control_channel connection; lock = Mutex.create () }
 
@@ -151,12 +153,10 @@ type test_outcome =
   | Interesting of { origin_text : string; exn : exn option }
 
 let run_test_case _client channel test_fn ~is_final =
-  if Domain.DLS.get current_channel <> None then
+  if Domain.DLS.get current_data <> None then
     failwith "Cannot nest test cases - already inside a test case";
-  Domain.DLS.set current_channel (Some channel);
-  Domain.DLS.set is_final_run is_final;
-  Domain.DLS.set test_aborted false;
-  Domain.DLS.set in_test true;
+  let data = { channel; is_final; test_aborted = false } in
+  Domain.DLS.set current_data (Some data);
   let outcome =
     try
       test_fn ();
@@ -171,10 +171,7 @@ let run_test_case _client channel test_fn ~is_final =
             exn = (if is_final then Some exn else None);
           }
   in
-  Domain.DLS.set current_channel None;
-  Domain.DLS.set is_final_run false;
-  Domain.DLS.set test_aborted false;
-  Domain.DLS.set in_test false;
+  Domain.DLS.set current_data None;
   (match outcome with
   | Data_was_exhausted -> ()
   | Valid | Invalid | Interesting _ -> (
@@ -205,7 +202,7 @@ let run_test_case _client channel test_fn ~is_final =
       optional seed for deterministic replay. If [None], the server generates
       its own seed. *)
 let run_test client ~name ~test_cases ?seed test_fn =
-  if Domain.DLS.get in_test then
+  if Domain.DLS.get current_data <> None then
     failwith "Cannot nest test cases - already inside a test case";
   let test_channel = new_channel client.connection ~role:"Test" () in
   Mutex.lock client.lock;

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -9,32 +9,30 @@ exception Assume_rejected
 exception Data_exhausted
 (** Raised when the server runs out of test data (StopTest). *)
 
-val current_channel : Connection.channel option Domain.DLS.key
-(** Current test case channel. Domain-local so each domain has its own
-    independent test state. *)
+type test_case_data = {
+  channel : Connection.channel;
+  is_final : bool;
+  mutable test_aborted : bool;
+}
+(** Per-test-case data, consolidating channel, final-run flag, and abort state.
+    Domain-local so each domain has its own independent test state. *)
 
-val is_final_run : bool Domain.DLS.key
-(** Whether this is the final (replay) run for a failing test case. *)
+val current_data : test_case_data option Domain.DLS.key
+(** Current test case data. Domain-local so each domain has its own independent
+    test state. *)
 
-val test_aborted : bool Domain.DLS.key
-(** Whether the server sent StopTest during this test case. Used by
-    {!Generators} to short-circuit collection protocol. *)
-
-val in_test : bool Domain.DLS.key
-(** Whether we are currently inside a test case body. *)
+val get_data : unit -> test_case_data
+(** [get_data ()] returns the current test case data, raising [Failure] if not
+    in a test context. *)
 
 val extract_origin : exn -> string
 (** [extract_origin exn] extracts an InterestingOrigin string from an exception.
     Uses the backtrace if available. *)
 
-val get_channel : unit -> Connection.channel
-(** [get_channel ()] returns the current test data channel, raising [Failure] if
-    not in a test context. *)
-
-val generate_from_schema : CBOR.Simple.t -> CBOR.Simple.t
-(** [generate_from_schema schema] generates a value from a schema by sending a
-    generate command to the server. Raises {!Data_exhausted} if the server
-    signals StopTest. *)
+val generate_from_schema : CBOR.Simple.t -> test_case_data -> CBOR.Simple.t
+(** [generate_from_schema schema data] generates a value from a schema by
+    sending a generate command to the server. Raises {!Data_exhausted} if the
+    server signals StopTest. *)
 
 val assume : bool -> unit
 (** [assume condition] rejects the current test case if [condition] is [false].
@@ -48,11 +46,11 @@ val target : float -> string -> unit
 (** [target value label] sends a target command to guide the search engine
     toward higher values. *)
 
-val start_span : ?label:int -> unit -> unit
-(** [start_span ?label ()] starts a generation span for better shrinking. *)
+val start_span : ?label:int -> test_case_data -> unit
+(** [start_span ?label data] starts a generation span for better shrinking. *)
 
-val stop_span : ?discard:bool -> unit -> unit
-(** [stop_span ?discard ()] ends the current generation span. *)
+val stop_span : ?discard:bool -> test_case_data -> unit
+(** [stop_span ?discard data] ends the current generation span. *)
 
 type client = {
   connection : Connection.connection;

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -12,7 +12,7 @@
 open Protocol
 
 (** Protocol version sent during handshake. *)
-let protocol_version = "0.1"
+let protocol_version = "0.3"
 
 (** Handshake string sent by the client to initiate the protocol. *)
 let handshake_string = "hegel_handshake_start"

--- a/lib/derive.ml
+++ b/lib/derive.ml
@@ -4,7 +4,7 @@
     PPX deriver. They are not intended for direct use by end users.
 
     The PPX generates [unit -> 'a] functions that call
-    {!Hegel.Generators.generate} internally and return typed OCaml values. These
+    {!Hegel.Generators.do_draw} internally and return typed OCaml values. These
     helpers provide the plumbing for option and list types. *)
 
 (** [generate_option gen_fn] generates an [option] value.
@@ -13,16 +13,16 @@
     is chosen, calls [gen_fn ()] to produce the inner value. Must be called from
     within a Hegel test body. *)
 let generate_option gen_fn =
-  let b = Generators.generate (Generators.booleans ()) in
+  let b = Generators.draw (Generators.booleans ()) in
   if b then Some (gen_fn ()) else None
 
 (** [generate_list gen_fn] generates a list of values.
 
-    Uses {!Generators.integers} to determine the list length (0–20), then calls
+    Uses {!Generators.integers} to determine the list length (0-20), then calls
     [gen_fn ()] for each element. Must be called from within a Hegel test body.
 *)
 let generate_list gen_fn =
   let len =
-    Generators.generate (Generators.integers ~min_value:0 ~max_value:20 ())
+    Generators.draw (Generators.integers ~min_value:0 ~max_value:20 ())
   in
   List.init len (fun _ -> gen_fn ())

--- a/lib/generators.ml
+++ b/lib/generators.ml
@@ -275,7 +275,7 @@ let booleans () =
 (** [floats ?min_value ?max_value ?exclude_min ?exclude_max ?allow_nan
      ?allow_infinity ()] creates a generator for floating-point values.
 
-    Uses schema type ["number"] as required by the Hegel server. The fields
+    Uses schema type ["float"] as required by the Hegel server. The fields
     [allow_nan], [allow_infinity], [exclude_min], [exclude_max], and [width] are
     always sent (required by the server). Defaults follow Hypothesis:
     - [allow_nan]: [true] only when no bounds are set
@@ -294,7 +294,7 @@ let floats ?min_value ?max_value ?(exclude_min = false) ?(exclude_max = false)
   in
   let pairs =
     [
-      (`Text "type", `Text "number");
+      (`Text "type", `Text "float");
       (`Text "allow_nan", `Bool eff_allow_nan);
       (`Text "allow_infinity", `Bool eff_allow_infinity);
       (`Text "exclude_min", `Bool exclude_min);

--- a/lib/generators.ml
+++ b/lib/generators.ml
@@ -62,28 +62,32 @@ type 'a generator =
       max_size : int option;
     }
       -> 'a list generator
-  | Composite : { label : int; generate_fn : unit -> 'a } -> 'a generator
+  | Composite : {
+      label : int;
+      generate_fn : Client.test_case_data -> 'a;
+    }
+      -> 'a generator
 
 (** Maximum number of filter attempts before calling [assume false]. *)
 let max_filter_attempts = 3
 
-(** [group label f] runs [f ()] inside a span with the given [label]. The span
-    is stopped with [discard:false] regardless of whether [f] raises. *)
-let group label f =
-  Client.start_span ~label ();
-  Fun.protect ~finally:(fun () -> Client.stop_span ()) (fun () -> f ())
+(** [group label data f] runs [f ()] inside a span with the given [label]. The
+    span is stopped with [discard:false] regardless of whether [f] raises. *)
+let group label data f =
+  Client.start_span ~label data;
+  Fun.protect ~finally:(fun () -> Client.stop_span data) (fun () -> f ())
 
-(** [discardable_group label f] runs [f ()] inside a span with [label]. If [f]
-    raises, the span is stopped with [discard:true]; otherwise [discard:false].
-*)
-let discardable_group label f =
-  Client.start_span ~label ();
+(** [discardable_group label data f] runs [f ()] inside a span with [label]. If
+    [f] raises, the span is stopped with [discard:true]; otherwise
+    [discard:false]. *)
+let discardable_group label data f =
+  Client.start_span ~label data;
   match f () with
   | v ->
-      Client.stop_span ();
+      Client.stop_span data;
       v
   | exception e ->
-      Client.stop_span ~discard:true ();
+      Client.stop_span ~discard:true data;
       raise e
 
 type collection = {
@@ -98,17 +102,19 @@ type collection = {
     elements. The [finished] flag short-circuits subsequent {!collection_more}
     calls once the server signals completion. *)
 
-(** [new_collection ~min_size ?max_size ()] creates a new collection handle. *)
-let new_collection ~min_size ?max_size () =
+(** [new_collection ~min_size ?max_size data ()] creates a new collection
+    handle. *)
+let new_collection ~min_size ?max_size data () =
+  ignore data;
   { finished = false; server_name = None; min_size; max_size }
 
-(** [get_server_name coll] lazily initializes the server-side collection and
-    returns its handle. Raises {!Client.Data_exhausted} on StopTest. *)
-let get_server_name coll =
+(** [get_server_name coll data] lazily initializes the server-side collection
+    and returns its handle. Raises {!Client.Data_exhausted} on StopTest. *)
+let get_server_name coll data =
   match coll.server_name with
   | Some name -> name
   | None ->
-      let channel = Client.get_channel () in
+      let channel = data.Client.channel in
       let max_size_val =
         match coll.max_size with Some ms -> `Int ms | None -> `Null
       in
@@ -123,21 +129,21 @@ let get_server_name coll =
                     (`Text "max_size", max_size_val);
                   ]))
         with Request_error e when e.error_type = "StopTest" ->
-          Domain.DLS.set Client.test_aborted true;
+          data.test_aborted <- true;
           raise Client.Data_exhausted
       in
       coll.server_name <- Some result;
       result
 
-(** [collection_more coll] returns [true] if more elements should be generated,
-    [false] when the collection is complete. Once it returns [false], subsequent
-    calls return [false] immediately. Raises {!Client.Data_exhausted} on
-    StopTest. *)
-let collection_more coll =
+(** [collection_more coll data] returns [true] if more elements should be
+    generated, [false] when the collection is complete. Once it returns [false],
+    subsequent calls return [false] immediately. Raises {!Client.Data_exhausted}
+    on StopTest. *)
+let collection_more coll data =
   if coll.finished then false
   else
-    let server_name = get_server_name coll in
-    let channel = Client.get_channel () in
+    let server_name = get_server_name coll data in
+    let channel = data.Client.channel in
     let result =
       try
         pending_get
@@ -148,19 +154,19 @@ let collection_more coll =
                   (`Text "collection", server_name);
                 ]))
       with Request_error e when e.error_type = "StopTest" ->
-        Domain.DLS.set Client.test_aborted true;
+        data.test_aborted <- true;
         raise Client.Data_exhausted
     in
     let more = Cbor_helpers.extract_bool result in
     if not more then coll.finished <- true;
     more
 
-(** [collection_reject coll] rejects the last element of the collection. No-op
-    if the collection is already finished. *)
-let collection_reject coll =
+(** [collection_reject coll data] rejects the last element of the collection.
+    No-op if the collection is already finished. *)
+let collection_reject coll data =
   if not coll.finished then begin
-    let server_name = get_server_name coll in
-    let channel = Client.get_channel () in
+    let server_name = get_server_name coll data in
+    let channel = data.Client.channel in
     ignore
       (pending_get
          (request channel
@@ -171,47 +177,57 @@ let collection_reject coll =
                ])))
   end
 
-(** [generate gen] produces a typed value from generator [gen]. *)
-let rec generate : type a. a generator -> a =
- fun gen ->
+(** [do_draw gen data] produces a typed value from generator [gen] using the
+    given test case [data]. *)
+let rec do_draw : type a. a generator -> Client.test_case_data -> a =
+ fun gen data ->
   match gen with
   | Basic { schema; transform } ->
-      transform (Client.generate_from_schema schema)
+      transform (Client.generate_from_schema schema data)
   | Mapped { source; f } ->
-      group Labels.mapped (fun () ->
-          let value = generate source in
+      group Labels.mapped data (fun () ->
+          let value = do_draw source data in
           f value)
   | FlatMapped { source; f } ->
-      group Labels.flat_map (fun () ->
-          let first = generate source in
+      discardable_group Labels.flat_map data (fun () ->
+          let first = do_draw source data in
           let second_gen = f first in
-          generate second_gen)
+          do_draw second_gen data)
   | Filtered { source; predicate } ->
       let rec attempt i =
         if i > max_filter_attempts then raise Client.Assume_rejected
         else begin
-          Client.start_span ~label:Labels.filter ();
-          let value = generate source in
+          Client.start_span ~label:Labels.filter data;
+          let value = do_draw source data in
           if predicate value then begin
-            Client.stop_span ();
+            Client.stop_span data;
             value
           end
           else begin
-            Client.stop_span ~discard:true ();
+            Client.stop_span ~discard:true data;
             attempt (i + 1)
           end
         end
       in
       attempt 1
   | CompositeList { elements; min_size; max_size } ->
-      group Labels.list (fun () ->
-          let coll = new_collection ~min_size ?max_size () in
+      group Labels.list data (fun () ->
+          let coll = new_collection ~min_size ?max_size data () in
           let rec collect acc =
-            if collection_more coll then collect (generate elements :: acc)
+            if collection_more coll data then
+              collect (do_draw elements data :: acc)
             else List.rev acc
           in
           collect [])
-  | Composite { label; generate_fn } -> group label (fun () -> generate_fn ())
+  | Composite { label; generate_fn } ->
+      group label data (fun () -> generate_fn data)
+
+(** [draw gen] produces a typed value from generator [gen]. Must be called from
+    within a Hegel test body. *)
+let draw gen =
+  match Domain.DLS.get Client.current_data with
+  | None -> failwith "draw() cannot be called outside of a Hegel test"
+  | Some data -> do_draw gen data
 
 (** [map f gen] transforms values from [gen] using [f].
 
@@ -526,7 +542,7 @@ let one_of (generators : 'a generator list) =
       {
         label = Labels.one_of;
         generate_fn =
-          (fun () ->
+          (fun data ->
             let idx =
               Cbor_helpers.extract_int
                 (Client.generate_from_schema
@@ -535,9 +551,10 @@ let one_of (generators : 'a generator list) =
                         (`Text "type", `Text "integer");
                         (`Text "min_value", `Int 0);
                         (`Text "max_value", `Int (n - 1));
-                      ]))
+                      ])
+                   data)
             in
-            generate gens.(idx));
+            do_draw gens.(idx) data);
       }
   end
   else
@@ -627,9 +644,9 @@ let tuples2 (type a b) (g1 : a generator) (g2 : b generator) : (a * b) generator
         {
           label = Labels.tuple;
           generate_fn =
-            (fun () ->
-              let a = generate g1 in
-              let b = generate g2 in
+            (fun data ->
+              let a = do_draw g1 data in
+              let b = do_draw g2 data in
               (a, b));
         }
 
@@ -662,10 +679,10 @@ let tuples3 (type a b c) (g1 : a generator) (g2 : b generator)
         {
           label = Labels.tuple;
           generate_fn =
-            (fun () ->
-              let a = generate g1 in
-              let b = generate g2 in
-              let c = generate g3 in
+            (fun data ->
+              let a = do_draw g1 data in
+              let b = do_draw g2 data in
+              let c = do_draw g3 data in
               (a, b, c));
         }
 
@@ -698,10 +715,10 @@ let tuples4 (type a b c d) (g1 : a generator) (g2 : b generator)
         {
           label = Labels.tuple;
           generate_fn =
-            (fun () ->
-              let a = generate g1 in
-              let b = generate g2 in
-              let c = generate g3 in
-              let d = generate g4 in
+            (fun data ->
+              let a = do_draw g1 data in
+              let b = do_draw g2 data in
+              let c = do_draw g3 data in
+              let d = do_draw g4 data in
               (a, b, c, d));
         }

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -42,7 +42,11 @@ type 'a generator =
       max_size : int option;
     }
       -> 'a list generator
-  | Composite : { label : int; generate_fn : unit -> 'a } -> 'a generator
+  | Composite : {
+      label : int;
+      generate_fn : Client.test_case_data -> 'a;
+    }
+      -> 'a generator
       (** The type of generators. Generators produce typed OCaml values and can
           be combined using {!map}, {!flat_map}, and {!filter}.
 
@@ -57,21 +61,21 @@ type 'a generator =
           - [CompositeList] generators use the collection protocol to generate
             lists of non-basic elements, creating a fresh collection per
             generate call.
-          - [Composite] generators wrap a [generate_fn] thunk inside a span with
-            the given [label]. Used for tuples and one_of with non-basic
-            elements. *)
+          - [Composite] generators wrap a [generate_fn] taking test case data
+            inside a span with the given [label]. Used for tuples and one_of
+            with non-basic elements. *)
 
 val max_filter_attempts : int
 (** Maximum number of filter attempts before calling [assume false]. *)
 
-val group : int -> (unit -> 'a) -> 'a
-(** [group label f] runs [f ()] inside a span with the given [label]. The span
-    is stopped with [discard:false] regardless of whether [f] raises. *)
+val group : int -> Client.test_case_data -> (unit -> 'a) -> 'a
+(** [group label data f] runs [f ()] inside a span with the given [label]. The
+    span is stopped with [discard:false] regardless of whether [f] raises. *)
 
-val discardable_group : int -> (unit -> 'a) -> 'a
-(** [discardable_group label f] runs [f ()] inside a span with [label]. If [f]
-    raises, the span is stopped with [discard:true]; otherwise [discard:false].
-*)
+val discardable_group : int -> Client.test_case_data -> (unit -> 'a) -> 'a
+(** [discardable_group label data f] runs [f ()] inside a span with [label]. If
+    [f] raises, the span is stopped with [discard:true]; otherwise
+    [discard:false]. *)
 
 type collection = {
   mutable finished : bool;
@@ -81,18 +85,25 @@ type collection = {
 }
 (** A collection handle for generating variable-length sequences. *)
 
-val new_collection : min_size:int -> ?max_size:int -> unit -> collection
-(** [new_collection ~min_size ?max_size ()] creates a new collection handle. *)
+val new_collection :
+  min_size:int -> ?max_size:int -> Client.test_case_data -> unit -> collection
+(** [new_collection ~min_size ?max_size data ()] creates a new collection
+    handle. *)
 
-val collection_more : collection -> bool
-(** [collection_more coll] returns [true] if more elements should be generated,
-    [false] when the collection is complete. *)
+val collection_more : collection -> Client.test_case_data -> bool
+(** [collection_more coll data] returns [true] if more elements should be
+    generated, [false] when the collection is complete. *)
 
-val collection_reject : collection -> unit
-(** [collection_reject coll] rejects the last element of the collection. *)
+val collection_reject : collection -> Client.test_case_data -> unit
+(** [collection_reject coll data] rejects the last element of the collection. *)
 
-val generate : 'a generator -> 'a
-(** [generate gen] produces a typed value from generator [gen]. *)
+val do_draw : 'a generator -> Client.test_case_data -> 'a
+(** [do_draw gen data] produces a typed value from generator [gen] using the
+    given test case [data]. *)
+
+val draw : 'a generator -> 'a
+(** [draw gen] produces a typed value from generator [gen]. Must be called from
+    within a Hegel test body. *)
 
 val map : ('a -> 'b) -> 'a generator -> 'b generator
 (** [map f gen] transforms values from [gen] using [f].

--- a/lib/hegel.ml
+++ b/lib/hegel.ml
@@ -45,8 +45,9 @@ let note = Client.note
     toward higher values. *)
 let target = Client.target
 
-(** [generate gen] produces a typed value from generator [gen]. *)
-let generate = Generators.generate
+(** [draw gen] produces a typed value from generator [gen]. Must be called from
+    within a Hegel test body. *)
+let draw = Generators.draw
 
 (** [run_hegel_test ?test_cases ?name test_fn] runs a property test using the
     shared hegeld process. *)

--- a/lib/hegel.mli
+++ b/lib/hegel.mli
@@ -45,8 +45,9 @@ val target : float -> string -> unit
 (** [target value label] sends a target command to guide the search engine
     toward higher values. *)
 
-val generate : 'a Generators.generator -> 'a
-(** [generate gen] produces a typed value from generator [gen]. *)
+val draw : 'a Generators.generator -> 'a
+(** [draw gen] produces a typed value from generator [gen]. Must be called from
+    within a Hegel test body. *)
 
 val run_hegel_test :
   ?test_cases:int -> ?name:string -> ?seed:int -> (unit -> unit) -> unit

--- a/ppx/ppx_hegel_generator.ml
+++ b/ppx/ppx_hegel_generator.ml
@@ -4,8 +4,8 @@
     synthesizes generator functions of type [unit -> t].
 
     When called inside a Hegel test body, these functions generate a value of
-    the declared type by calling [Hegel.Generators.generate] with appropriate
-    generators and returning typed OCaml values directly.
+    the declared type by calling [Hegel.draw] with appropriate generators and
+    returning typed OCaml values directly.
 
     Supported types:
     - Records: generates all fields, then constructs the record
@@ -31,18 +31,18 @@ let rec generate_expr_of_core_type (ct : core_type) : expression =
   | Ptyp_constr ({ txt = Lident "int"; _ }, []) ->
       [%expr
         fun () ->
-          Hegel.Generators.generate
+          Hegel.draw
             (Hegel.Generators.integers ~min_value:Int.min_int
                ~max_value:Int.max_int ())]
   | Ptyp_constr ({ txt = Lident "bool"; _ }, []) ->
-      [%expr fun () -> Hegel.Generators.generate (Hegel.Generators.booleans ())]
+      [%expr fun () -> Hegel.draw (Hegel.Generators.booleans ())]
   | Ptyp_constr ({ txt = Lident "float"; _ }, []) ->
       [%expr
         fun () ->
-          Hegel.Generators.generate
+          Hegel.draw
             (Hegel.Generators.floats ~allow_nan:false ~allow_infinity:false ())]
   | Ptyp_constr ({ txt = Lident "string"; _ }, []) ->
-      [%expr fun () -> Hegel.Generators.generate (Hegel.Generators.text ())]
+      [%expr fun () -> Hegel.draw (Hegel.Generators.text ())]
   | Ptyp_constr ({ txt = Lident "list"; _ }, [ elem_type ]) ->
       let elem_gen_fn = generate_expr_of_core_type elem_type in
       [%expr fun () -> Hegel.Derive.generate_list [%e elem_gen_fn]]
@@ -235,7 +235,7 @@ let generator_of_variant ~loc (constrs : constructor_declaration list) :
   [%expr
     fun () ->
       let _variant_idx =
-        Hegel.Generators.generate
+        Hegel.draw
           (Hegel.Generators.sampled_from
              [%e Ast_builder.Default.elist ~loc index_options])
       in

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -6,16 +6,37 @@ let find_cmd = Test_helpers.find_cmd
 
 (* ---- Unit tests for helpers that don't need a server ---- *)
 
-let test_assume_true () = assume true
+let test_assume_true () =
+  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let conn = create_connection s1 ~name:"Test" () in
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = false }
+  in
+  Domain.DLS.set current_data (Some data);
+  assume true;
+  Domain.DLS.set current_data None;
+  close conn;
+  Unix.close s2
 
 let test_assume_false_raises () =
+  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let conn = create_connection s1 ~name:"Test" () in
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = false }
+  in
+  Domain.DLS.set current_data (Some data);
   let raised = ref false in
   (try assume false with Assume_rejected -> raised := true);
-  Alcotest.(check bool) "raised Assume_rejected" true !raised
+  Alcotest.(check bool) "raised Assume_rejected" true !raised;
+  Domain.DLS.set current_data None;
+  close conn;
+  Unix.close s2
 
-let test_get_channel_outside_context () =
+let test_get_data_outside_context () =
   let raised = ref false in
-  (try ignore (get_channel ())
+  (try ignore (get_data ())
    with Failure msg ->
      raised := true;
      Alcotest.(check bool)
@@ -23,14 +44,51 @@ let test_get_channel_outside_context () =
        (contains_substring msg "Not in a test"));
   Alcotest.(check bool) "raised" true !raised
 
+let test_assume_outside_context () =
+  let raised = ref false in
+  (try assume true
+   with Failure msg ->
+     raised := true;
+     Alcotest.(check bool)
+       "has 'outside of a Hegel test'" true
+       (contains_substring msg "outside of a Hegel test"));
+  Alcotest.(check bool) "raised" true !raised
+
+let test_note_outside_context () =
+  let raised = ref false in
+  (try note "should fail"
+   with Failure msg ->
+     raised := true;
+     Alcotest.(check bool)
+       "has 'outside of a Hegel test'" true
+       (contains_substring msg "outside of a Hegel test"));
+  Alcotest.(check bool) "raised" true !raised
+
 let test_note_when_not_final () =
-  Domain.DLS.set is_final_run false;
-  note "should not print"
+  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let conn = create_connection s1 ~name:"Test" () in
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = false }
+  in
+  Domain.DLS.set current_data (Some data);
+  note "should not print";
+  Domain.DLS.set current_data None;
+  close conn;
+  Unix.close s2
 
 let test_note_when_final () =
-  Domain.DLS.set is_final_run true;
+  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let conn = create_connection s1 ~name:"Test" () in
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = true; test_aborted = false }
+  in
+  Domain.DLS.set current_data (Some data);
   note "test message from note";
-  Domain.DLS.set is_final_run false
+  Domain.DLS.set current_data None;
+  close conn;
+  Unix.close s2
 
 let test_extract_origin_no_backtrace () =
   let origin = extract_origin (Failure "test") in
@@ -48,34 +106,34 @@ let test_extract_origin_with_backtrace () =
     (contains_substring origin "test_client.ml")
 
 let test_start_span_when_aborted () =
-  Domain.DLS.set test_aborted true;
   let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
   let conn = create_connection s1 ~name:"Test" () in
-  Domain.DLS.set current_channel (Some (control_channel conn));
-  start_span ();
-  stop_span ();
-  Domain.DLS.set current_channel None;
-  Domain.DLS.set test_aborted false;
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = true }
+  in
+  start_span data;
+  stop_span data;
   close conn;
   Unix.close s2
 
-(** Test: Domain.DLS initializers for is_final_run and test_aborted return false
-    when accessed from a fresh domain. This covers the (fun () -> false)
-    initializers that are otherwise never triggered in the main domain. *)
+(** Test: Domain.DLS initializer for current_data returns None when accessed
+    from a fresh domain. This covers the (fun () -> None) initializer that is
+    otherwise never triggered in the main domain. *)
 let test_dls_initializers_in_new_domain () =
-  let result =
-    Domain.spawn (fun () ->
-        let final = Domain.DLS.get is_final_run in
-        let aborted = Domain.DLS.get test_aborted in
-        (final, aborted))
-  in
-  let final, aborted = Domain.join result in
-  Alcotest.(check bool) "is_final_run default" false final;
-  Alcotest.(check bool) "test_aborted default" false aborted
+  let result = Domain.spawn (fun () -> Domain.DLS.get current_data = None) in
+  let is_none = Domain.join result in
+  Alcotest.(check bool) "current_data default None" true is_none
 
 let test_nested_test_raises () =
-  (* Set the in_test flag to simulate being inside a test *)
-  Domain.DLS.set in_test true;
+  (* Set the current_data to simulate being inside a test *)
+  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let conn = create_connection s1 ~name:"Test" () in
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = false }
+  in
+  Domain.DLS.set current_data (Some data);
   let raised = ref false in
   (try Hegel.Session.run_hegel_test ~name:"nested" ~test_cases:1 (fun () -> ())
    with Failure msg ->
@@ -83,7 +141,9 @@ let test_nested_test_raises () =
      Alcotest.(check bool)
        "has 'Cannot nest'" true
        (contains_substring msg "Cannot nest"));
-  Domain.DLS.set in_test false;
+  Domain.DLS.set current_data None;
+  close conn;
+  Unix.close s2;
   Alcotest.(check bool) "raised" true !raised
 
 (* ---- Unrecognised event test using socketpair ---- *)
@@ -148,13 +208,17 @@ let with_test_mode mode f =
 
 let test_simple_passing_test () =
   Hegel.Session.run_hegel_test ~name:"simple_pass" ~test_cases:5 (fun () ->
-      let v = generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) in
+      let data = get_data () in
+      let v =
+        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) data
+      in
       ignore (Hegel.Cbor_helpers.extract_bool v))
 
 let test_simple_failing_test () =
   let raised = ref false in
   (try
      Hegel.Session.run_hegel_test ~name:"simple_fail" ~test_cases:100 (fun () ->
+         let data = get_data () in
          let v =
            generate_from_schema
              (`Map
@@ -163,6 +227,7 @@ let test_simple_failing_test () =
                   (`Text "min_value", `Int 0);
                   (`Text "max_value", `Int 100);
                 ])
+             data
          in
          let x = Hegel.Cbor_helpers.extract_int v in
          if x >= 50 then failwith "too big")
@@ -171,7 +236,10 @@ let test_simple_failing_test () =
 
 let test_single_test_case () =
   Hegel.Session.run_hegel_test ~name:"single_case" ~test_cases:1 (fun () ->
-      let v = generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) in
+      let data = get_data () in
+      let v =
+        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) data
+      in
       ignore (Hegel.Cbor_helpers.extract_bool v))
 
 let test_assume_true_e2e () =
@@ -185,6 +253,7 @@ let test_assume_false_e2e () =
 let test_note_not_final_e2e () =
   Hegel.Session.run_hegel_test ~name:"note_nonfinal" ~test_cases:5 (fun () ->
       note "should not appear";
+      let data = get_data () in
       let v =
         generate_from_schema
           (`Map
@@ -193,11 +262,13 @@ let test_note_not_final_e2e () =
                (`Text "min_value", `Int 0);
                (`Text "max_value", `Int 10);
              ])
+          data
       in
       ignore (Hegel.Cbor_helpers.extract_int v))
 
 let test_target_e2e () =
   Hegel.Session.run_hegel_test ~name:"target_test" ~test_cases:5 (fun () ->
+      let data = get_data () in
       let v =
         generate_from_schema
           (`Map
@@ -206,6 +277,7 @@ let test_target_e2e () =
                (`Text "min_value", `Int 0);
                (`Text "max_value", `Int 100);
              ])
+          data
       in
       let x = Hegel.Cbor_helpers.extract_int v in
       target (float_of_int x) "maximize_x")
@@ -215,38 +287,54 @@ let test_target_e2e () =
 let test_stop_test_on_generate () =
   with_test_mode "stop_test_on_generate" (fun () ->
       Hegel.Session.run_hegel_test ~name:"stop_on_gen" ~test_cases:5 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 let test_stop_test_on_mark_complete () =
   with_test_mode "stop_test_on_mark_complete" (fun () ->
       Hegel.Session.run_hegel_test ~name:"stop_on_mc" ~test_cases:5 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 let test_error_response () =
   with_test_mode "error_response" (fun () ->
       Hegel.Session.run_hegel_test ~name:"error_resp" ~test_cases:5 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 let test_empty_test () =
   with_test_mode "empty_test" (fun () ->
       Hegel.Session.run_hegel_test ~name:"empty" ~test_cases:5 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 (* ---- Mark complete status values ---- *)
 
 let test_mark_complete_valid () =
   Hegel.Session.run_hegel_test ~name:"mc_valid" ~test_cases:3 (fun () ->
-      let v = generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) in
+      let data = get_data () in
+      let v =
+        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) data
+      in
       ignore (Hegel.Cbor_helpers.extract_bool v))
 
 let test_mark_complete_invalid () =
   Hegel.Session.run_hegel_test ~name:"mc_invalid" ~test_cases:5 (fun () ->
+      let data = get_data () in
       let _v =
-        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ])
+        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) data
       in
       assume false)
 
@@ -255,6 +343,7 @@ let test_mark_complete_interesting () =
   (try
      Hegel.Session.run_hegel_test ~name:"mc_interesting" ~test_cases:100
        (fun () ->
+         let data = get_data () in
          let v =
            generate_from_schema
              (`Map
@@ -263,6 +352,7 @@ let test_mark_complete_interesting () =
                   (`Text "min_value", `Int 0);
                   (`Text "max_value", `Int 100);
                 ])
+             data
          in
          let x = Hegel.Cbor_helpers.extract_int v in
          assert (x < 50))
@@ -307,10 +397,13 @@ let test_start_stop_span_live () =
     (fun client_conn ->
       let c = create_client client_conn in
       run_test c ~name:"span_test" ~test_cases:1 (fun () ->
-          start_span ();
-          stop_span ();
+          let data = get_data () in
+          start_span data;
+          stop_span data;
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 (** Test: version mismatch in create_client (version too high). *)
 let test_version_mismatch () =
@@ -388,8 +481,11 @@ let test_run_test_with_seed () =
     (fun client_conn ->
       let c = create_client client_conn in
       run_test c ~name:"seed_test" ~test_cases:1 ~seed:42 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 (** Test: Data_exhausted path (StopTest on generate). *)
 let test_data_exhausted_via_socketpair () =
@@ -404,8 +500,11 @@ let test_data_exhausted_via_socketpair () =
     (fun client_conn ->
       let c = create_client client_conn in
       run_test c ~name:"data_exhausted" ~test_cases:1 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 (** Test: StopTest on mark_complete. *)
 let test_stop_test_on_mark_complete_socketpair () =
@@ -422,8 +521,11 @@ let test_stop_test_on_mark_complete_socketpair () =
     (fun client_conn ->
       let c = create_client client_conn in
       run_test c ~name:"stop_on_mc" ~test_cases:1 (fun () ->
+          let data = get_data () in
           ignore
-            (generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]))))
+            (generate_from_schema
+               (`Map [ (`Text "type", `Text "boolean") ])
+               data)))
 
 (** Test: multiple interesting test cases (n_interesting > 1). *)
 let test_multiple_interesting () =
@@ -449,8 +551,11 @@ let test_multiple_interesting () =
        (fun client_conn ->
          let c = create_client client_conn in
          run_test c ~name:"multi_interesting" ~test_cases:2 (fun () ->
+             let data = get_data () in
              let v =
-               generate_from_schema (`Map [ (`Text "type", `Text "boolean") ])
+               generate_from_schema
+                 (`Map [ (`Text "type", `Text "boolean") ])
+                 data
              in
              ignore v;
              failwith "always fails"))
@@ -483,8 +588,11 @@ let test_multiple_interesting_pass () =
          let c = create_client client_conn in
          let count = ref 0 in
          run_test c ~name:"multi_pass" ~test_cases:2 (fun () ->
+             let data = get_data () in
              let v =
-               generate_from_schema (`Map [ (`Text "type", `Text "boolean") ])
+               generate_from_schema
+                 (`Map [ (`Text "type", `Text "boolean") ])
+                 data
              in
              ignore v;
              incr count;
@@ -725,7 +833,10 @@ let test_has_working_client_live () =
 (** Test: run_hegel_test with default parameters. *)
 let test_run_hegel_test_defaults () =
   Hegel.Session.run_hegel_test (fun () ->
-      let v = generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) in
+      let data = get_data () in
+      let v =
+        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) data
+      in
       ignore (Hegel.Cbor_helpers.extract_bool v))
 
 (** Test: no event field in message. *)
@@ -743,11 +854,15 @@ let test_no_event_field () =
       let c = create_client client_conn in
       run_test c ~name:"no_event" ~test_cases:1 (fun () -> ()))
 
-(** Test: nest test_case raises (when current_channel is already set). *)
+(** Test: nest test_case raises (when current_data is already set). *)
 let test_run_test_case_nest () =
   let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
   let conn = create_connection s1 ~name:"Test" () in
-  Domain.DLS.set current_channel (Some (control_channel conn));
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = false }
+  in
+  Domain.DLS.set current_data (Some data);
   let raised = ref false in
   (try
      run_test_case
@@ -761,7 +876,7 @@ let test_run_test_case_nest () =
        ~is_final:false
    with Failure _ -> raised := true);
   Alcotest.(check bool) "raised" true !raised;
-  Domain.DLS.set current_channel None;
+  Domain.DLS.set current_data None;
   close conn;
   Unix.close s2
 
@@ -940,7 +1055,10 @@ let test_session_cleanup () =
 
 let test_session_start_and_run () =
   Hegel.Session.run_hegel_test ~name:"session_test" ~test_cases:3 (fun () ->
-      let v = generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) in
+      let data = get_data () in
+      let v =
+        generate_from_schema (`Map [ (`Text "type", `Text "boolean") ]) data
+      in
       ignore (Hegel.Cbor_helpers.extract_bool v))
 
 let tests =
@@ -948,8 +1066,11 @@ let tests =
     (* Unit tests *)
     Alcotest.test_case "assume true" `Quick test_assume_true;
     Alcotest.test_case "assume false raises" `Quick test_assume_false_raises;
-    Alcotest.test_case "get_channel outside context" `Quick
-      test_get_channel_outside_context;
+    Alcotest.test_case "get_data outside context" `Quick
+      test_get_data_outside_context;
+    Alcotest.test_case "assume outside context" `Quick
+      test_assume_outside_context;
+    Alcotest.test_case "note outside context" `Quick test_note_outside_context;
     Alcotest.test_case "note when not final" `Quick test_note_when_not_final;
     Alcotest.test_case "note when final" `Quick test_note_when_final;
     Alcotest.test_case "extract_origin no backtrace" `Quick

--- a/test/test_conformance_helpers.ml
+++ b/test/test_conformance_helpers.ml
@@ -429,7 +429,7 @@ let test_hashmaps_non_basic_values_raises () =
 (** Test: floats() E2E — values are floats. *)
 let test_floats_e2e () =
   Hegel.Session.run_hegel_test ~name:"floats_e2e" ~test_cases:10 (fun () ->
-      let f = generate (floats ~allow_nan:false ~allow_infinity:false ()) in
+      let f = Hegel.draw (floats ~allow_nan:false ~allow_infinity:false ()) in
       assert (Float.is_finite f))
 
 (** Test: floats() with bounds E2E — values within range. *)
@@ -437,7 +437,7 @@ let test_floats_bounds_e2e () =
   Hegel.Session.run_hegel_test ~name:"floats_bounds_e2e" ~test_cases:10
     (fun () ->
       let f =
-        generate
+        Hegel.draw
           (floats ~min_value:0.0 ~max_value:1.0 ~allow_nan:false
              ~allow_infinity:false ())
       in
@@ -446,13 +446,13 @@ let test_floats_bounds_e2e () =
 (** Test: text() E2E — values are text strings. *)
 let test_text_e2e () =
   Hegel.Session.run_hegel_test ~name:"text_e2e" ~test_cases:10 (fun () ->
-      let s = generate (text ~min_size:1 ~max_size:10 ()) in
+      let s = Hegel.draw (text ~min_size:1 ~max_size:10 ()) in
       assert (String.length s >= 1))
 
 (** Test: binary() E2E — values are byte strings. *)
 let test_binary_e2e () =
   Hegel.Session.run_hegel_test ~name:"binary_e2e" ~test_cases:10 (fun () ->
-      let b = generate (binary ~min_size:0 ~max_size:10 ()) in
+      let b = Hegel.draw (binary ~min_size:0 ~max_size:10 ()) in
       assert (String.length b >= 0))
 
 (** Test: sampled_from() E2E — values come from the options list. *)
@@ -460,7 +460,7 @@ let test_sampled_from_e2e () =
   let options = [ 10; 20; 30 ] in
   Hegel.Session.run_hegel_test ~name:"sampled_from_e2e" ~test_cases:10
     (fun () ->
-      let n = generate (sampled_from options) in
+      let n = Hegel.draw (sampled_from options) in
       assert (List.mem n [ 10; 20; 30 ]))
 
 (** Test: hashmaps() E2E — values are maps. *)
@@ -469,7 +469,7 @@ let test_hashmaps_e2e () =
       let key_gen = integers ~min_value:0 ~max_value:100 () in
       let val_gen = integers ~min_value:0 ~max_value:100 () in
       let gen = hashmaps key_gen val_gen ~min_size:0 ~max_size:5 () in
-      let pairs = generate gen in
+      let pairs = Hegel.draw gen in
       assert (List.length pairs <= 5))
 
 let tests =

--- a/test/test_conformance_helpers.ml
+++ b/test/test_conformance_helpers.ml
@@ -127,7 +127,7 @@ let test_floats_schema_no_bounds () =
       let typ =
         Hegel.Cbor_helpers.extract_string (List.assoc (`Text "type") pairs)
       in
-      Alcotest.(check string) "type" "number" typ;
+      Alcotest.(check string) "type" "float" typ;
       (* No bounds when not specified *)
       Alcotest.(check bool)
         "no min_value" false

--- a/test/test_connection.ml
+++ b/test/test_connection.ml
@@ -37,7 +37,7 @@ let test_send_handshake_returns_version () =
   let t = Thread.create (fun () -> receive_handshake server_conn) () in
   let version = send_handshake client_conn in
   Thread.join t;
-  Alcotest.(check string) "version" "0.1" version;
+  Alcotest.(check string) "version" "0.3" version;
   close client_conn;
   close server_conn
 

--- a/test/test_derive.ml
+++ b/test/test_derive.ml
@@ -40,9 +40,7 @@ let test_generate_option_some_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"opt_some" ~test_cases:1 (fun () ->
-          let gen_fn () =
-            Hegel.Generators.generate (Hegel.Generators.integers ())
-          in
+          let gen_fn () = Hegel.draw (Hegel.Generators.integers ()) in
           let result = Hegel.Derive.generate_option gen_fn in
           match result with
           | Some n -> Alcotest.(check int) "value" 42 n
@@ -69,9 +67,7 @@ let test_generate_option_none_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"opt_none" ~test_cases:1 (fun () ->
-          let gen_fn () =
-            Hegel.Generators.generate (Hegel.Generators.integers ())
-          in
+          let gen_fn () = Hegel.draw (Hegel.Generators.integers ()) in
           let result = Hegel.Derive.generate_option gen_fn in
           Alcotest.(check bool) "is None" true (result = None)))
 
@@ -105,9 +101,7 @@ let test_generate_list_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"list_gen" ~test_cases:1 (fun () ->
-          let gen_fn () =
-            Hegel.Generators.generate (Hegel.Generators.integers ())
-          in
+          let gen_fn () = Hegel.draw (Hegel.Generators.integers ()) in
           let result = Hegel.Derive.generate_list gen_fn in
           Alcotest.(check int) "length" 3 (List.length result)))
 
@@ -132,9 +126,7 @@ let test_generate_list_empty_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"list_empty" ~test_cases:1 (fun () ->
-          let gen_fn () =
-            Hegel.Generators.generate (Hegel.Generators.integers ())
-          in
+          let gen_fn () = Hegel.draw (Hegel.Generators.integers ()) in
           let result = Hegel.Derive.generate_list gen_fn in
           Alcotest.(check int) "length" 0 (List.length result)))
 
@@ -146,8 +138,7 @@ let test_generate_option_e2e () =
   let saw_none = ref false in
   Hegel.Session.run_hegel_test ~name:"derive_opt_e2e" ~test_cases:50 (fun () ->
       let gen_fn () =
-        Hegel.Generators.generate
-          (Hegel.Generators.integers ~min_value:0 ~max_value:10 ())
+        Hegel.draw (Hegel.Generators.integers ~min_value:0 ~max_value:10 ())
       in
       let result = Hegel.Derive.generate_option gen_fn in
       match result with
@@ -162,8 +153,7 @@ let test_generate_option_e2e () =
 let test_generate_list_e2e () =
   Hegel.Session.run_hegel_test ~name:"derive_list_e2e" ~test_cases:20 (fun () ->
       let gen_fn () =
-        Hegel.Generators.generate
-          (Hegel.Generators.integers ~min_value:0 ~max_value:100 ())
+        Hegel.draw (Hegel.Generators.integers ~min_value:0 ~max_value:100 ())
       in
       let result = Hegel.Derive.generate_list gen_fn in
       assert (List.length result >= 0 && List.length result <= 20);

--- a/test/test_generators.ml
+++ b/test/test_generators.ml
@@ -6,6 +6,7 @@ let accept_run_test = Test_helpers.accept_run_test
 let send_test_case = Test_helpers.send_test_case
 let send_test_done = Test_helpers.send_test_done
 let recv_command = Test_helpers.recv_command
+let contains_substring = Test_helpers.contains_substring
 
 (** Helper: handle one command, dispatching to the appropriate handler. Returns
     the command name for verification. *)
@@ -30,6 +31,17 @@ let handle_n_commands data_ch n ?(generate_value = `Int 42) () =
   List.iter (fun _ -> ignore (handle_one data_ch respond)) (List.init n Fun.id)
 
 (* ==== Unit tests (no server needed) ==== *)
+
+(** Test: draw outside test context raises. *)
+let test_draw_outside_context () =
+  let raised = ref false in
+  (try ignore (draw (integers ()))
+   with Failure msg ->
+     raised := true;
+     Alcotest.(check bool)
+       "has 'outside of a Hegel test'" true
+       (contains_substring msg "outside of a Hegel test"));
+  Alcotest.(check bool) "raised" true !raised
 
 let test_span_label_constants () =
   let open Labels in
@@ -148,20 +160,38 @@ let test_as_basic_on_non_basic () =
 let test_max_filter_attempts () =
   Alcotest.(check int) "max attempts" 3 max_filter_attempts
 
+let dummy_data () =
+  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let conn = create_connection s1 ~name:"Dummy" () in
+  let data =
+    Hegel.Client.
+      { channel = control_channel conn; is_final = false; test_aborted = false }
+  in
+  (data, conn, s2)
+
 let test_collection_new () =
-  let coll = new_collection ~min_size:0 ~max_size:5 () in
-  Alcotest.(check bool) "not finished" false coll.finished
+  let data, conn, s2 = dummy_data () in
+  let coll = new_collection ~min_size:0 ~max_size:5 data () in
+  Alcotest.(check bool) "not finished" false coll.finished;
+  close conn;
+  Unix.close s2
 
 let test_collection_new_no_max () =
-  let coll = new_collection ~min_size:0 () in
+  let data, conn, s2 = dummy_data () in
+  let coll = new_collection ~min_size:0 data () in
   Alcotest.(check bool) "not finished" false coll.finished;
-  Alcotest.(check bool) "max_size is None" true (coll.max_size = None)
+  Alcotest.(check bool) "max_size is None" true (coll.max_size = None);
+  close conn;
+  Unix.close s2
 
 let test_collection_reject_when_finished () =
-  let coll = new_collection ~min_size:0 () in
+  let data, conn, s2 = dummy_data () in
+  let coll = new_collection ~min_size:0 data () in
   coll.finished <- true;
   (* Should be a no-op, not send any commands *)
-  collection_reject coll
+  collection_reject coll data;
+  close conn;
+  Unix.close s2
 
 (* ==== Socketpair-based tests (fake server protocol verification) ==== *)
 
@@ -183,7 +213,7 @@ let test_basic_generate_socketpair () =
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"basic_gen" ~test_cases:1 (fun () ->
           let gen = integers ~min_value:0 ~max_value:100 () in
-          let v = generate gen in
+          let v = Hegel.draw gen in
           Alcotest.(check int) "value" 42 v))
 
 (** Test: Basic generator with transform applies transform. *)
@@ -205,7 +235,7 @@ let test_basic_generate_with_transform_socketpair () =
           let gen =
             map (fun v -> v * 2) (integers ~min_value:0 ~max_value:10 ())
           in
-          let v = generate gen in
+          let v = Hegel.draw gen in
           Alcotest.(check int) "value" 10 v))
 
 (** Test: Double-map on basic composes transforms correctly via socketpair. *)
@@ -231,7 +261,7 @@ let test_double_map_socketpair () =
           in
           (* schema should be unchanged *)
           Alcotest.(check bool) "still basic" true (is_basic gen);
-          let v = generate gen in
+          let v = Hegel.draw gen in
           (* 3*2+1 = 7 *)
           Alcotest.(check int) "value" 7 v))
 
@@ -286,7 +316,7 @@ let test_mapped_generate_socketpair () =
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"mapped_gen" ~test_cases:1 (fun () ->
           let gen = integers () |> filter (fun _ -> true) |> map (fun x -> x) in
-          let v = generate gen in
+          let v = Hegel.draw gen in
           Alcotest.(check int) "value" 7 v))
 
 (** Test: FlatMapped generator sends start_span(FLAT_MAP)/stop_span. *)
@@ -331,7 +361,7 @@ let test_flatmapped_generate_socketpair () =
               (fun _ -> integers ~min_value:0 ~max_value:10 ())
               (integers ~min_value:1 ~max_value:3 ())
           in
-          ignore (generate gen)))
+          ignore (Hegel.draw gen)))
 
 (** Test: Filtered generator — passes on first attempt. *)
 let test_filtered_pass_first_socketpair () =
@@ -375,7 +405,7 @@ let test_filtered_pass_first_socketpair () =
               (fun v -> v mod 2 = 0)
               (integers ~min_value:0 ~max_value:10 ())
           in
-          let v = generate gen in
+          let v = Hegel.draw gen in
           Alcotest.(check int) "value" 4 v))
 
 (** Test: Filtered generator — fails first, passes second. *)
@@ -428,7 +458,7 @@ let test_filtered_pass_after_reject_socketpair () =
               (fun v -> v mod 2 = 0)
               (integers ~min_value:0 ~max_value:10 ())
           in
-          let v = generate gen in
+          let v = Hegel.draw gen in
           Alcotest.(check int) "value" 4 v))
 
 (** Test: Filtered generator — all 3 attempts fail → assume(false) → INVALID. *)
@@ -466,7 +496,7 @@ let test_filtered_exhaustion_socketpair () =
           let gen =
             filter (fun _ -> false) (integers ~min_value:0 ~max_value:10 ())
           in
-          ignore (generate gen)))
+          ignore (Hegel.draw gen)))
 
 (** Test: group helper wraps start_span/stop_span correctly. *)
 let test_group_socketpair () =
@@ -491,7 +521,8 @@ let test_group_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"group" ~test_cases:1 (fun () ->
-          let result = group 42 (fun () -> 99) in
+          let data = Hegel.Client.get_data () in
+          let result = group 42 data (fun () -> 99) in
           Alcotest.(check int) "result" 99 result))
 
 (** Test: discardable_group with success — stop_span(discard=false). *)
@@ -515,7 +546,8 @@ let test_discardable_group_success_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"disc_ok" ~test_cases:1 (fun () ->
-          let result = discardable_group 1 (fun () -> 55) in
+          let data = Hegel.Client.get_data () in
+          let result = discardable_group 1 data (fun () -> 55) in
           Alcotest.(check int) "result" 55 result))
 
 (** Test: discardable_group with exception — stop_span(discard=true). *)
@@ -539,7 +571,9 @@ let test_discardable_group_exception_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"disc_err" ~test_cases:1 (fun () ->
-          (try ignore (discardable_group 1 (fun () -> failwith "test error"))
+          let data = Hegel.Client.get_data () in
+          (try
+             ignore (discardable_group 1 data (fun () -> failwith "test error"))
            with Failure _ -> ());
           ()))
 
@@ -585,20 +619,22 @@ let test_collection_protocol_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"coll_proto" ~test_cases:1 (fun () ->
-          let coll = new_collection ~min_size:1 ~max_size:3 () in
-          Alcotest.(check bool) "more 1" true (collection_more coll);
+          let data = Hegel.Client.get_data () in
+          let coll = new_collection ~min_size:1 ~max_size:3 data () in
+          Alcotest.(check bool) "more 1" true (collection_more coll data);
           (* Generate an element *)
           ignore
             (Hegel.Client.generate_from_schema
-               (`Map [ (`Text "type", `Text "integer") ]));
+               (`Map [ (`Text "type", `Text "integer") ])
+               data);
           (* Reject it *)
-          collection_reject coll;
+          collection_reject coll data;
           (* Collection says done *)
-          Alcotest.(check bool) "more 2" false (collection_more coll);
+          Alcotest.(check bool) "more 2" false (collection_more coll data);
           (* After finished, more returns false immediately *)
-          Alcotest.(check bool) "more 3" false (collection_more coll);
+          Alcotest.(check bool) "more 3" false (collection_more coll data);
           (* reject is no-op when finished *)
-          collection_reject coll))
+          collection_reject coll data))
 
 (** Test: collection with no max_size sends Null for max_size. *)
 let test_collection_no_max_socketpair () =
@@ -624,8 +660,9 @@ let test_collection_no_max_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"coll_nomax" ~test_cases:1 (fun () ->
-          let coll = new_collection ~min_size:0 () in
-          ignore (collection_more coll)))
+          let data = Hegel.Client.get_data () in
+          let coll = new_collection ~min_size:0 data () in
+          ignore (collection_more coll data)))
 
 (** Test: StopTest during new_collection raises Data_exhausted. *)
 let test_collection_stoptest_new_socketpair () =
@@ -640,8 +677,9 @@ let test_collection_stoptest_new_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"coll_stop_new" ~test_cases:1 (fun () ->
-          let coll = new_collection ~min_size:0 () in
-          ignore (collection_more coll)))
+          let data = Hegel.Client.get_data () in
+          let coll = new_collection ~min_size:0 data () in
+          ignore (collection_more coll data)))
 
 (** Test: StopTest during collection_more raises Data_exhausted. *)
 let test_collection_stoptest_more_socketpair () =
@@ -659,8 +697,9 @@ let test_collection_stoptest_more_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"coll_stop_more" ~test_cases:1 (fun () ->
-          let coll = new_collection ~min_size:0 () in
-          ignore (collection_more coll)))
+          let data = Hegel.Client.get_data () in
+          let coll = new_collection ~min_size:0 data () in
+          ignore (collection_more coll data)))
 
 (** Test: collection_reject when server_name is already cached. *)
 let test_collection_reject_cached_name_socketpair () =
@@ -687,10 +726,11 @@ let test_collection_reject_cached_name_socketpair () =
     (fun client_conn ->
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"coll_rej" ~test_cases:1 (fun () ->
-          let coll = new_collection ~min_size:1 ~max_size:3 () in
-          Alcotest.(check bool) "more" true (collection_more coll);
-          collection_reject coll;
-          ignore (collection_more coll)))
+          let data = Hegel.Client.get_data () in
+          let coll = new_collection ~min_size:1 ~max_size:3 data () in
+          Alcotest.(check bool) "more" true (collection_more coll data);
+          collection_reject coll data;
+          ignore (collection_more coll data)))
 
 (* ==== E2E tests (real hegel binary) ==== *)
 
@@ -698,7 +738,7 @@ let test_collection_reject_cached_name_socketpair () =
 let test_integers_in_range () =
   Hegel.Session.run_hegel_test ~name:"int_range" ~test_cases:10 (fun () ->
       let gen = integers ~min_value:0 ~max_value:100 () in
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert (v >= 0 && v <= 100))
 
 (** Test: map doubles values correctly. *)
@@ -706,7 +746,7 @@ let test_map_doubles_e2e () =
   Hegel.Session.run_hegel_test ~name:"map_double" ~test_cases:10 (fun () ->
       let gen = integers ~min_value:1 ~max_value:5 () |> map (fun v -> v * 2) in
       Alcotest.(check bool) "still basic" true (is_basic gen);
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert (v >= 2 && v <= 10);
       assert (v mod 2 = 0))
 
@@ -728,7 +768,7 @@ let test_double_map_e2e () =
           in
           Alcotest.(check string) "schema type" "integer" typ
       | None -> Alcotest.fail "expected schema");
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert (List.mem v [ 3; 5; 7; 9; 11 ]))
 
 (** Test: flat_map through server. *)
@@ -740,7 +780,7 @@ let test_flat_map_e2e () =
           (integers ~min_value:1 ~max_value:5 ())
       in
       Alcotest.(check bool) "not basic" false (is_basic gen);
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert (v >= 0))
 
 (** Test: filter through server. *)
@@ -750,7 +790,7 @@ let test_filter_e2e () =
         filter (fun v -> v mod 2 = 0) (integers ~min_value:0 ~max_value:100 ())
       in
       Alcotest.(check bool) "not basic" false (is_basic gen);
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert (v mod 2 = 0))
 
 (** Test: filter exhaustion through server (always false → assume false). *)
@@ -760,20 +800,22 @@ let test_filter_exhaustion_e2e () =
       let gen =
         filter (fun _ -> false) (integers ~min_value:0 ~max_value:10 ())
       in
-      ignore (generate gen))
+      ignore (Hegel.draw gen))
 
 (** Test: group helper through server. *)
 let test_group_e2e () =
   Hegel.Session.run_hegel_test ~name:"group_e2e" ~test_cases:5 (fun () ->
+      let data = Hegel.Client.get_data () in
       let v =
-        group Labels.list (fun () ->
+        group Labels.list data (fun () ->
             Hegel.Client.generate_from_schema
               (`Map
                  [
                    (`Text "type", `Text "integer");
                    (`Text "min_value", `Int 0);
                    (`Text "max_value", `Int 10);
-                 ]))
+                 ])
+              data)
       in
       let n = Hegel.Cbor_helpers.extract_int v in
       assert (n >= 0 && n <= 10))
@@ -781,15 +823,17 @@ let test_group_e2e () =
 (** Test: discardable_group through server — success path. *)
 let test_discardable_group_e2e () =
   Hegel.Session.run_hegel_test ~name:"disc_group_e2e" ~test_cases:5 (fun () ->
+      let data = Hegel.Client.get_data () in
       let v =
-        discardable_group Labels.tuple (fun () ->
+        discardable_group Labels.tuple data (fun () ->
             Hegel.Client.generate_from_schema
               (`Map
                  [
                    (`Text "type", `Text "integer");
                    (`Text "min_value", `Int 0);
                    (`Text "max_value", `Int 10);
-                 ]))
+                 ])
+              data)
       in
       let n = Hegel.Cbor_helpers.extract_int v in
       assert (n >= 0 && n <= 10))
@@ -907,7 +951,7 @@ let test_lists_basic_generate_socketpair () =
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"lists_basic" ~test_cases:1 (fun () ->
           let gen = lists (integers ~min_value:0 ~max_value:10 ()) () in
-          let items = generate gen in
+          let items = Hegel.draw gen in
           Alcotest.(check int) "length" 2 (List.length items)))
 
 (** Test: lists(basic_elem_with_transform) applies the list transform. *)
@@ -931,7 +975,7 @@ let test_lists_basic_with_transform_generate_socketpair () =
             map (fun v -> v * 2) (integers ~min_value:1 ~max_value:5 ())
           in
           let gen = lists elem () in
-          let items = generate gen in
+          let items = Hegel.draw gen in
           (* The server returned [2, 4] as raw; the transform doubles them → [4, 8] *)
           Alcotest.(check (list int)) "doubled" [ 4; 8 ] items))
 
@@ -996,7 +1040,7 @@ let test_lists_composite_generate_socketpair () =
           in
           let gen = lists elem () in
           Alcotest.(check bool) "not basic" false (is_basic gen);
-          let items = generate gen in
+          let items = Hegel.draw gen in
           Alcotest.(check int) "one element" 1 (List.length items)))
 
 (** Test: lists(non_basic) with StopTest during collection_more aborts cleanly.
@@ -1020,7 +1064,7 @@ let test_lists_composite_stoptest_socketpair () =
       let c = Hegel.Client.create_client client_conn in
       Hegel.Client.run_test c ~name:"lists_stoptest" ~test_cases:1 (fun () ->
           let elem = filter (fun _ -> true) (integers ()) in
-          ignore (generate (lists elem ()))))
+          ignore (Hegel.draw (lists elem ()))))
 
 (* ==== E2E tests for lists ==== *)
 
@@ -1031,7 +1075,7 @@ let test_lists_of_integers_e2e () =
         lists (integers ~min_value:0 ~max_value:100 ()) ~max_size:3 ()
       in
       Alcotest.(check bool) "is_basic" true (is_basic gen);
-      let items = generate gen in
+      let items = Hegel.draw gen in
       Alcotest.(check bool) "max 3" true (List.length items <= 3);
       List.iter (fun n -> assert (n >= 0 && n <= 100)) items)
 
@@ -1041,7 +1085,7 @@ let test_lists_booleans_bounds_e2e () =
     (fun () ->
       let gen = lists (booleans ()) ~min_size:3 ~max_size:5 () in
       Alcotest.(check bool) "is_basic" true (is_basic gen);
-      let items = generate gen in
+      let items = Hegel.draw gen in
       let n = List.length items in
       assert (n >= 3 && n <= 5))
 
@@ -1054,7 +1098,7 @@ let test_lists_non_basic_e2e () =
       in
       let gen = lists elem ~min_size:1 ~max_size:3 () in
       Alcotest.(check bool) "not basic" false (is_basic gen);
-      let items = generate gen in
+      let items = Hegel.draw gen in
       let n = List.length items in
       assert (n >= 1 && n <= 3);
       List.iter (fun x -> assert (x > 5)) items)
@@ -1066,7 +1110,7 @@ let test_lists_nested_e2e () =
       let inner = lists (booleans ()) ~max_size:3 () in
       let gen = lists inner ~max_size:3 () in
       Alcotest.(check bool) "outer is_basic" true (is_basic gen);
-      let outer_items = generate gen in
+      let outer_items = Hegel.draw gen in
       assert (List.length outer_items <= 3);
       List.iter
         (fun inner_items -> assert (List.length inner_items <= 3))
@@ -1457,25 +1501,25 @@ let test_tuples4_non_basic () =
 (** Test: just always returns the constant. *)
 let test_just_e2e () =
   Hegel.Session.run_hegel_test ~name:"just_e2e" ~test_cases:10 (fun () ->
-      let v = generate (just 42) in
+      let v = Hegel.draw (just 42) in
       Alcotest.(check int) "always 42" 42 v)
 
 (** Test: from_regex generates matching strings. *)
 let test_from_regex_e2e () =
   Hegel.Session.run_hegel_test ~name:"from_regex_e2e" ~test_cases:10 (fun () ->
-      let v = generate (from_regex "[0-9]+" ()) in
+      let v = Hegel.draw (from_regex "[0-9]+" ()) in
       assert (String.length v > 0))
 
 (** Test: emails generates strings containing at-sign. *)
 let test_emails_e2e () =
   Hegel.Session.run_hegel_test ~name:"emails_e2e" ~test_cases:10 (fun () ->
-      let v = generate (emails ()) in
+      let v = Hegel.draw (emails ()) in
       assert (String.contains v '@'))
 
 (** Test: urls generates strings starting with http. *)
 let test_urls_e2e () =
   Hegel.Session.run_hegel_test ~name:"urls_e2e" ~test_cases:10 (fun () ->
-      let v = generate (urls ()) in
+      let v = Hegel.draw (urls ()) in
       assert (
         String.length v >= 7
         && (String.sub v 0 7 = "http://" || String.sub v 0 8 = "https://")))
@@ -1483,32 +1527,32 @@ let test_urls_e2e () =
 (** Test: domains generates non-empty strings. *)
 let test_domains_e2e () =
   Hegel.Session.run_hegel_test ~name:"domains_e2e" ~test_cases:10 (fun () ->
-      let v = generate (domains ()) in
+      let v = Hegel.draw (domains ()) in
       assert (String.length v > 0))
 
 (** Test: dates generates YYYY-MM-DD strings. *)
 let test_dates_e2e () =
   Hegel.Session.run_hegel_test ~name:"dates_e2e" ~test_cases:10 (fun () ->
-      let v = generate (dates ()) in
+      let v = Hegel.draw (dates ()) in
       assert (String.contains v '-'))
 
 (** Test: times generates strings with colons. *)
 let test_times_e2e () =
   Hegel.Session.run_hegel_test ~name:"times_e2e" ~test_cases:10 (fun () ->
-      let v = generate (times ()) in
+      let v = Hegel.draw (times ()) in
       assert (String.contains v ':'))
 
 (** Test: datetimes generates strings with T. *)
 let test_datetimes_e2e () =
   Hegel.Session.run_hegel_test ~name:"datetimes_e2e" ~test_cases:10 (fun () ->
-      let v = generate (datetimes ()) in
+      let v = Hegel.draw (datetimes ()) in
       assert (String.contains v 'T'))
 
 (** Test: one_of with basic generators works e2e. *)
 let test_one_of_e2e () =
   Hegel.Session.run_hegel_test ~name:"one_of_e2e" ~test_cases:50 (fun () ->
       let gen = one_of [ integers ~min_value:0 ~max_value:10 (); just 99 ] in
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert ((v >= 0 && v <= 10) || v = 99))
 
 (** Test: one_of with non-basic generators works e2e. *)
@@ -1520,7 +1564,7 @@ let test_one_of_non_basic_e2e () =
       let gen =
         one_of [ filtered; integers ~min_value:100 ~max_value:200 () ]
       in
-      let v = generate gen in
+      let v = Hegel.draw gen in
       assert ((v > 5 && v <= 10) || (v >= 100 && v <= 200)))
 
 (** Test: optional produces None or Some e2e. *)
@@ -1529,7 +1573,7 @@ let test_optional_e2e () =
   let saw_none = ref false in
   Hegel.Session.run_hegel_test ~name:"optional_e2e" ~test_cases:50 (fun () ->
       let gen = optional (integers ~min_value:1 ~max_value:100 ()) in
-      match generate gen with
+      match Hegel.draw gen with
       | Some v ->
           saw_some := true;
           assert (v >= 1 && v <= 100)
@@ -1541,15 +1585,15 @@ let test_optional_e2e () =
 (** Test: ip_addresses generates valid IPs e2e. *)
 let test_ip_addresses_e2e () =
   Hegel.Session.run_hegel_test ~name:"ip_e2e" ~test_cases:20 (fun () ->
-      let v4 = generate (ip_addresses ~version:4 ()) in
+      let v4 = Hegel.draw (ip_addresses ~version:4 ()) in
       assert (String.contains v4 '.');
-      let v6 = generate (ip_addresses ~version:6 ()) in
+      let v6 = Hegel.draw (ip_addresses ~version:6 ()) in
       assert (String.contains v6 ':'))
 
 (** Test: ip_addresses default generates either v4 or v6 e2e. *)
 let test_ip_both_e2e () =
   Hegel.Session.run_hegel_test ~name:"ip_both_e2e" ~test_cases:20 (fun () ->
-      let v = generate (ip_addresses ()) in
+      let v = Hegel.draw (ip_addresses ()) in
       assert (String.contains v '.' || String.contains v ':'))
 
 (** Test: tuples2 basic e2e. *)
@@ -1558,7 +1602,7 @@ let test_tuples2_e2e () =
       let gen =
         tuples2 (integers ~min_value:0 ~max_value:10 ()) (booleans ())
       in
-      let a, _b = generate gen in
+      let a, _b = Hegel.draw gen in
       assert (a >= 0 && a <= 10))
 
 (** Test: tuples2 composite e2e. *)
@@ -1569,7 +1613,7 @@ let test_tuples2_composite_e2e () =
         filter (fun x -> x > 5) (integers ~min_value:0 ~max_value:10 ())
       in
       let gen = tuples2 filtered (booleans ()) in
-      let a, _b = generate gen in
+      let a, _b = Hegel.draw gen in
       assert (a > 5 && a <= 10))
 
 (** Test: tuples3 basic e2e. *)
@@ -1581,7 +1625,7 @@ let test_tuples3_e2e () =
           (booleans ())
           (integers ~min_value:100 ~max_value:200 ())
       in
-      let a, _b, c = generate gen in
+      let a, _b, c = Hegel.draw gen in
       assert (a >= 0 && a <= 10);
       assert (c >= 100 && c <= 200))
 
@@ -1596,7 +1640,7 @@ let test_tuples3_composite_e2e () =
         tuples3 filtered (booleans ())
           (integers ~min_value:100 ~max_value:200 ())
       in
-      let a, _b, c = generate gen in
+      let a, _b, c = Hegel.draw gen in
       assert (a > 5 && a <= 10);
       assert (c >= 100 && c <= 200))
 
@@ -1610,7 +1654,7 @@ let test_tuples4_e2e () =
           (integers ~min_value:100 ~max_value:200 ())
           (floats ~min_value:0.0 ~max_value:1.0 ())
       in
-      let a, _b, c, d = generate gen in
+      let a, _b, c, d = Hegel.draw gen in
       assert (a >= 0 && a <= 10);
       assert (c >= 100 && c <= 200);
       assert (d >= 0.0 && d <= 1.0))
@@ -1627,7 +1671,7 @@ let test_tuples4_composite_e2e () =
           (integers ~min_value:100 ~max_value:200 ())
           (floats ~min_value:0.0 ~max_value:1.0 ())
       in
-      let a, _b, c, d = generate gen in
+      let a, _b, c, d = Hegel.draw gen in
       assert (a > 5 && a <= 10);
       assert (c >= 100 && c <= 200);
       assert (d >= 0.0 && d <= 1.0))
@@ -1635,6 +1679,7 @@ let test_tuples4_composite_e2e () =
 let tests =
   [
     (* Unit tests *)
+    Alcotest.test_case "draw outside context" `Quick test_draw_outside_context;
     Alcotest.test_case "span label constants" `Quick test_span_label_constants;
     Alcotest.test_case "basic generator schema" `Quick
       test_basic_generator_schema;

--- a/test/test_showcase.ml
+++ b/test/test_showcase.ml
@@ -10,20 +10,20 @@ open Hegel.Generators
 let test_addition_commutative () =
   Hegel.Session.run_hegel_test ~name:"addition_commutative" ~test_cases:50
     (fun () ->
-      let a = generate (integers ~min_value:(-1000) ~max_value:1000 ()) in
-      let b = generate (integers ~min_value:(-1000) ~max_value:1000 ()) in
+      let a = Hegel.draw (integers ~min_value:(-1000) ~max_value:1000 ()) in
+      let b = Hegel.draw (integers ~min_value:(-1000) ~max_value:1000 ()) in
       assert (a + b = b + a))
 
 (** Property: double negation of an integer is identity. *)
 let test_double_negation () =
   Hegel.Session.run_hegel_test ~name:"double_negation" ~test_cases:50 (fun () ->
-      let x = generate (integers ~min_value:(-10000) ~max_value:10000 ()) in
+      let x = Hegel.draw (integers ~min_value:(-10000) ~max_value:10000 ()) in
       assert (- (-x) = x))
 
 (** Property: absolute value is always non-negative. *)
 let test_abs_nonnegative () =
   Hegel.Session.run_hegel_test ~name:"abs_nonnegative" ~test_cases:50 (fun () ->
-      let x = generate (integers ~min_value:(-10000) ~max_value:10000 ()) in
+      let x = Hegel.draw (integers ~min_value:(-10000) ~max_value:10000 ()) in
       assert (abs x >= 0))
 
 (** Property: filter(x > 50) on integers(0, 100) always yields x > 50.
@@ -35,7 +35,7 @@ let test_filter_greater_than () =
       let gen =
         filter (fun v -> v > 50) (integers ~min_value:0 ~max_value:100 ())
       in
-      let x = generate gen in
+      let x = Hegel.draw gen in
       assert (x > 50);
       assert (x <= 100))
 
@@ -48,7 +48,7 @@ let test_filter_even () =
       let gen =
         filter (fun v -> v mod 2 = 0) (integers ~min_value:0 ~max_value:10 ())
       in
-      let x = generate gen in
+      let x = Hegel.draw gen in
       assert (x mod 2 = 0);
       assert (x / 2 * 2 = x);
       assert (x >= 0 && x <= 10))
@@ -63,7 +63,7 @@ let test_list_reverse_involution () =
       let gen =
         lists (integers ~min_value:(-100) ~max_value:100 ()) ~max_size:10 ()
       in
-      let ints = generate gen in
+      let ints = Hegel.draw gen in
       assert (List.rev (List.rev ints) = ints))
 
 (** Property: sum of a non-negative integer list is non-negative.
@@ -75,7 +75,7 @@ let test_list_sum_nonnegative () =
       let gen =
         lists (integers ~min_value:0 ~max_value:100 ()) ~max_size:10 ()
       in
-      let ints = generate gen in
+      let ints = Hegel.draw gen in
       let sum = List.fold_left ( + ) 0 ints in
       assert (sum >= 0);
       List.iter (fun x -> assert (x >= 0 && x <= 100)) ints)
@@ -91,7 +91,7 @@ let test_list_filter_preserves_predicate () =
         filter (fun v -> v mod 2 = 0) (integers ~min_value:0 ~max_value:50 ())
       in
       let gen = lists elem ~max_size:5 () in
-      let items = generate gen in
+      let items = Hegel.draw gen in
       assert (List.length items <= 5);
       List.iter
         (fun x ->


### PR DESCRIPTION
This probably will not be the final API, but we're moving away from `.generate()` throughout our SDKs.