### PR TITLE
Manage hegel binary via pinned .hegel/venv

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Build Commands
 
 ```bash
-just setup       # Install dependencies and hegel binary into .venv/
+just setup       # Install opam dependencies (odoc)
 just test        # Run tests with 100% coverage enforcement
 just format      # Auto-format code with ocamlformat
 just lint        # Check formatting (fails if unformatted)

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -94,24 +94,6 @@ def set_version_hegel_ml(new_version: str) -> None:
     path.write_text(new_text)
 
 
-def pin_hegel_version(session_ml: Path) -> None:
-    """Pin hegel_version to the latest hegel-core release tag."""
-    tag = subprocess.check_output(
-        ["gh", "api", "repos/antithesishq/hegel-core/releases/latest", "--jq", ".tag_name"],
-        text=True,
-    ).strip()
-
-    text = session_ml.read_text()
-    new_text = re.sub(
-        r'^let hegel_version = ".*"',
-        f'let hegel_version = "{tag}"',
-        text,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    session_ml.write_text(new_text)
-
-
 def add_changelog(path: Path, *, version: str, content: str) -> None:
     date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     entry = f"## {version} - {date}\n\n{content}"
@@ -180,9 +162,6 @@ def release() -> None:
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
-    session_ml = ROOT / "lib" / "session.ml"
-    pin_hegel_version(session_ml)
-
     git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
     git("config", "user.email", "noreply@github.com", cwd=ROOT)
     git(
@@ -190,7 +169,6 @@ def release() -> None:
         "dune-project",
         "hegel.opam",
         "lib/hegel.ml",
-        "lib/session.ml",
         "CHANGELOG.md",
         cwd=ROOT,
     )

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -95,16 +95,16 @@ def set_version_hegel_ml(new_version: str) -> None:
 
 
 def pin_hegel_version(session_ml: Path) -> None:
-    """Pin hegel_version to the current HEAD of hegel-core main."""
-    sha = subprocess.check_output(
-        ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
+    """Pin hegel_version to the latest hegel-core release tag."""
+    tag = subprocess.check_output(
+        ["gh", "api", "repos/antithesishq/hegel-core/releases/latest", "--jq", ".tag_name"],
         text=True,
     ).strip()
 
     text = session_ml.read_text()
     new_text = re.sub(
         r'^let hegel_version = ".*"',
-        f'let hegel_version = "{sha}"',
+        f'let hegel_version = "{tag}"',
         text,
         count=1,
         flags=re.MULTILINE,

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -94,6 +94,24 @@ def set_version_hegel_ml(new_version: str) -> None:
     path.write_text(new_text)
 
 
+def pin_hegel_version(session_ml: Path) -> None:
+    """Pin hegel_version to the current HEAD of hegel-core main."""
+    sha = subprocess.check_output(
+        ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
+        text=True,
+    ).strip()
+
+    text = session_ml.read_text()
+    new_text = re.sub(
+        r'^let hegel_version = ".*"',
+        f'let hegel_version = "{sha}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    session_ml.write_text(new_text)
+
+
 def add_changelog(path: Path, *, version: str, content: str) -> None:
     date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     entry = f"## {version} - {date}\n\n{content}"
@@ -162,6 +180,9 @@ def release() -> None:
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
+    session_ml = ROOT / "lib" / "session.ml"
+    pin_hegel_version(session_ml)
+
     git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
     git("config", "user.email", "noreply@github.com", cwd=ROOT)
     git(
@@ -169,6 +190,7 @@ def release() -> None:
         "dune-project",
         "hegel.opam",
         "lib/hegel.ml",
+        "lib/session.ml",
         "CHANGELOG.md",
         cwd=ROOT,
     )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
         with:
           app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
+          repositories: hegel-ocaml,hegel-core
 
       - name: Re-checkout with app token # zizmor: ignore[artipacked]
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -68,7 +67,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
@@ -111,7 +110,6 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -119,7 +117,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-ocaml'
     needs: [lint, test, docs, conformance]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just
@@ -119,7 +119,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just
@@ -117,9 +117,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Install just
         run: sudo apt-get update && sudo apt-get install -y just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,6 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'hegeldev/hegel-ocaml'
     needs: [lint, test, docs, conformance]
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -83,7 +84,6 @@ jobs:
       - name: Install OCaml dependencies
         run: opam install . --deps-only --with-test --with-doc --yes
 
-      - run: just setup
       - name: Run tests
         run: just test
 
@@ -111,6 +111,7 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -126,10 +127,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y just
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.13"
-
       - name: Set up OCaml
         uses: ocaml/setup-ocaml@dec6499fef64fc5d7ed43d43a87251b7b1c306f5 # v3
         with:
@@ -138,8 +135,6 @@ jobs:
       - name: Install OCaml dependencies
         run: opam install . --deps-only --with-test --yes
 
-      - run: just setup
-      - run: pip install pytest
       - run: just conformance
 
   release:

--- a/README.md
+++ b/README.md
@@ -13,11 +13,22 @@ shrinks them to minimal counterexamples.
 opam pin add hegel "git+ssh://git@github.com/hegeldev/hegel-ocaml.git"
 ```
 
-The SDK requires the `hegel` CLI on your PATH:
+### Hegel server
+
+The SDK automatically manages the `hegel` server binary. On first use it
+creates a project-local `.hegel/venv` virtualenv and installs the pinned
+version of [hegel-core](https://github.com/antithesishq/hegel-core) into it.
+Subsequent runs reuse the cached binary unless the pinned version changes.
+
+To use your own `hegel` binary instead (e.g. a local development build), set
+the `HEGEL_CMD` environment variable:
 
 ```bash
-pip install "hegel @ git+ssh://git@github.com/hegeldev/hegel-core.git"
+export HEGEL_CMD=/path/to/hegel
 ```
+
+The SDK also requires [`uv`](https://docs.astral.sh/uv/) to be installed for
+automatic server management.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ version of [hegel-core](https://github.com/antithesishq/hegel-core) into it.
 Subsequent runs reuse the cached binary unless the pinned version changes.
 
 To use your own `hegel` binary instead (e.g. a local development build), set
-the `HEGEL_CMD` environment variable:
+the `HEGEL_SERVER_COMMAND` environment variable:
 
 ```bash
-export HEGEL_CMD=/path/to/hegel
+export HEGEL_SERVER_COMMAND=/path/to/hegel
 ```
 
 The SDK also requires [`uv`](https://docs.astral.sh/uv/) to be installed for

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+Manage hegel binary via pinned .hegel/venv instead of relying on system installation.
+
+- `hegel_version` is now a plain git commit hash for hegel-core, hard-coded in `session.ml`
+- On first use, creates a project-local `.hegel/venv` virtualenv via `uv venv` and installs hegel into it via `uv pip install`
+- A `.hegel/venv/hegel-version` file tracks the installed hash; subsequent runs skip installation if it matches `hegel_version`
+- On version mismatch the venv is recreated and hegel is reinstalled
+- `HEGEL_CMD` environment variable overrides to a specific binary path, skipping installation entirely
+- The release script pins `hegel_version` to the current hegel-core main HEAD SHA at release time via `gh api`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,3 @@
 RELEASE_TYPE: minor
 
-Manage hegel binary via pinned .hegel/venv instead of relying on system installation.
-
-- `hegel_version` is now a plain git commit hash for hegel-core, hard-coded in `session.ml`
-- On first use, creates a project-local `.hegel/venv` virtualenv via `uv venv` and installs hegel into it via `uv pip install`
-- A `.hegel/venv/hegel-version` file tracks the installed hash; subsequent runs skip installation if it matches `hegel_version`
-- On version mismatch the venv is recreated and hegel is reinstalled
-- `HEGEL_CMD` environment variable overrides to a specific binary path, skipping installation entirely
-- The release script pins `hegel_version` to the current hegel-core main HEAD SHA at release time via `gh api`
+Automatically manage hegel server installation. Adds a runtime requirement on `uv`.

--- a/justfile
+++ b/justfile
@@ -63,5 +63,15 @@ conformance:
     # Run Python conformance tests
     .hegel/venv/bin/python -m pytest test/conformance/ -v
 
+# Update the pinned hegel-core version to the latest release.
+update-hegel-core-version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tag=$(gh api repos/antithesishq/hegel-core/releases/latest --jq '.tag_name')
+    sed -i '' "s/^let hegel_version = \".*\"/let hegel_version = \"${tag}\"/" lib/session.ml
+    echo "Updated hegel_version to ${tag}"
+    # Clear cached install so the next test run picks up the new version
+    rm -rf .hegel/venv
+
 # Run lint + docs + test (the full CI check).
 check: lint docs test

--- a/justfile
+++ b/justfile
@@ -1,26 +1,17 @@
 # Hegel SDK for OCaml
 # This justfile provides the standard build recipes.
 
-# Install dependencies and the hegel binary.
-# If HEGEL_BINARY is set, symlinks it into .venv/bin instead of installing from git.
+# Install dependencies.
 setup:
     #!/usr/bin/env bash
     set -euo pipefail
     eval $(opam env)
     opam install --yes odoc
-    uv venv .venv
-    if [ -n "${HEGEL_BINARY:-}" ]; then
-        mkdir -p .venv/bin
-        ln -sf "$HEGEL_BINARY" .venv/bin/hegel
-    else
-        uv pip install --python .venv/bin/python hegel@git+https://github.com/hegeldev/hegel-core
-    fi
 
 # Run tests with 100% code coverage enforcement.
 test:
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="$(pwd)/.venv/bin:$PATH"
     eval $(opam env)
     # Clean previous coverage data
     find _build -name '*.coverage' -delete 2>/dev/null || true
@@ -54,16 +45,23 @@ docs:
 conformance:
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="$(pwd)/.venv/bin:$PATH"
     eval $(opam env 2>/dev/null || true)
-    # Install pytest if not already available
-    if ! .venv/bin/python -c "import pytest" 2>/dev/null; then
-        uv pip install --python .venv/bin/python pytest
+    # Ensure .hegel/venv exists with hegel installed (same venv the SDK uses)
+    if [ ! -f .hegel/venv/bin/hegel ]; then
+        mkdir -p .hegel
+        uv venv --clear .hegel/venv
+        uv pip install --python .hegel/venv/bin/python \
+            "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git"
     fi
+    # Install pytest if not already available
+    if ! .hegel/venv/bin/python -c "import pytest" 2>/dev/null; then
+        uv pip install --python .hegel/venv/bin/python pytest
+    fi
+    export PATH="$(pwd)/.hegel/venv/bin:$PATH"
     # Build conformance binaries
     dune build conformance/
     # Run Python conformance tests
-    .venv/bin/python -m pytest test/conformance/ -v
+    .hegel/venv/bin/python -m pytest test/conformance/ -v
 
 # Run lint + docs + test (the full CI check).
 check: lint docs test

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -176,12 +176,21 @@ let start session =
           session.temp_dir <- Some temp_dir;
           let socket_path = Filename.concat temp_dir "hegel.sock" in
           session.socket_path <- Some socket_path;
-          (* Start hegeld subprocess *)
+          (* Start hegeld subprocess, logging output to .hegel/server.log *)
+          (try Unix.mkdir hegel_dir 0o755
+           with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+          let log_fd =
+            Unix.openfile
+              (Filename.concat hegel_dir "server.log")
+              [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+          in
+          Unix.putenv "PYTHONUNBUFFERED" "1";
           let pid =
             Unix.create_process hegel_cmd
               [| hegel_cmd; socket_path |]
-              Unix.stdin Unix.stderr Unix.stderr
+              Unix.stdin log_fd log_fd
           in
+          Unix.close log_fd;
           session.process <- Some pid;
           (* Wait for socket to appear and connect *)
           let rec try_connect attempts =

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -9,7 +9,7 @@
 open Connection
 
 (** The hegel-core commit this SDK is designed to work with. *)
-let hegel_version = "6e327df2dd42553de12ace94cfbddfbbd9e4bf50"
+let hegel_version = "v0.3.3"
 
 (** Environment variable name for overriding the hegel binary path. *)
 let hegel_cmd_env = "HEGEL_CMD"
@@ -73,7 +73,7 @@ let ensure_hegel_installed () =
       (try Unix.mkdir hegel_dir 0o755
        with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
       Printf.eprintf "Installing hegel (%s) into %s...\n%!"
-        (String.sub hegel_version 0 12)
+        hegel_version
         venv_dir;
       if not (run_command [ "uv"; "venv"; "--clear"; venv_dir ]) then
         failwith "Failed to create venv. Is uv installed?";

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -97,9 +97,9 @@ let ensure_hegel_installed () =
       write_file_contents version_file hegel_version);
   hegel_bin
 
-(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_SERVER_COMMAND] is set,
-    uses that path directly (the user is responsible for providing the right
-    binary). Otherwise, ensures hegel is installed in [.hegel/venv] at the
+(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_SERVER_COMMAND] is
+    set, uses that path directly (the user is responsible for providing the
+    right binary). Otherwise, ensures hegel is installed in [.hegel/venv] at the
     version specified by [hegel_version] and returns the path to that binary. *)
 let find_hegeld () =
   match Sys.getenv_opt hegel_server_command_env with
@@ -182,7 +182,8 @@ let start session =
           let log_fd =
             Unix.openfile
               (Filename.concat hegel_dir "server.log")
-              [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+              [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ]
+              0o644
           in
           Unix.putenv "PYTHONUNBUFFERED" "1";
           let pid =

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -72,8 +72,7 @@ let ensure_hegel_installed () =
       (* Need to install *)
       (try Unix.mkdir hegel_dir 0o755
        with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-      Printf.eprintf "Installing hegel (%s) into %s...\n%!"
-        hegel_version
+      Printf.eprintf "Installing hegel (%s) into %s...\n%!" hegel_version
         venv_dir;
       if not (run_command [ "uv"; "venv"; "--clear"; venv_dir ]) then
         failwith "Failed to create venv. Is uv installed?";

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -12,7 +12,7 @@ open Connection
 let hegel_version = "v0.3.3"
 
 (** Environment variable name for overriding the hegel binary path. *)
-let hegel_cmd_env = "HEGEL_CMD"
+let hegel_server_command_env = "HEGEL_SERVER_COMMAND"
 
 (** Directory for managed hegel installation. *)
 let hegel_dir = ".hegel"
@@ -90,19 +90,19 @@ let ensure_hegel_installed () =
           (Printf.sprintf
              "Failed to install hegel (version: %s). Set %s to a hegel binary \
               path to skip installation."
-             hegel_version hegel_cmd_env);
+             hegel_version hegel_server_command_env);
       if not (Sys.file_exists hegel_bin) then
         failwith
           (Printf.sprintf "hegel not found at %s after installation" hegel_bin);
       write_file_contents version_file hegel_version);
   hegel_bin
 
-(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_CMD] is set, uses that
-    path directly (the user is responsible for providing the right binary).
-    Otherwise, ensures hegel is installed in [.hegel/venv] at the version
-    specified by [hegel_version] and returns the path to that binary. *)
+(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_SERVER_COMMAND] is set,
+    uses that path directly (the user is responsible for providing the right
+    binary). Otherwise, ensures hegel is installed in [.hegel/venv] at the
+    version specified by [hegel_version] and returns the path to that binary. *)
 let find_hegeld () =
-  match Sys.getenv_opt hegel_cmd_env with
+  match Sys.getenv_opt hegel_server_command_env with
   | Some path when path <> "" -> path
   | _ -> ensure_hegel_installed ()
 

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -8,28 +8,104 @@
 
 open Connection
 
-(** [find_hegeld ()] locates the hegeld binary. Checks, in order:
-    - [HEGEL_BINARY] environment variable
-    - [hegel] on [PATH] Returns the path or raises [Failure]. *)
-let find_hegeld () =
-  match Sys.getenv_opt "HEGEL_BINARY" with
-  | Some path when path <> "" -> path
-  | _ -> (
-      (* Search PATH for hegel binary *)
-      let path_str = Option.value ~default:"" (Sys.getenv_opt "PATH") in
-      let path_dirs = String.split_on_char ':' path_str in
-      let found =
-        List.find_map
-          (fun dir ->
-            let candidate = Filename.concat dir "hegel" in
-            if Sys.file_exists candidate then Some candidate else None)
-          path_dirs
+(** The hegel-core commit this SDK is designed to work with. *)
+let hegel_version = "6e327df2dd42553de12ace94cfbddfbbd9e4bf50"
+
+(** Environment variable name for overriding the hegel binary path. *)
+let hegel_cmd_env = "HEGEL_CMD"
+
+(** Directory for managed hegel installation. *)
+let hegel_dir = ".hegel"
+
+(** Path to the managed virtualenv. *)
+let venv_dir = Filename.concat hegel_dir "venv"
+
+(** Path to the version tracking file. *)
+let version_file = Filename.concat venv_dir "hegel-version"
+
+(** [hegel_pip_spec ()] returns the pip install spec for the current
+    [hegel_version]. *)
+let hegel_pip_spec () =
+  Printf.sprintf
+    "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@%s"
+    hegel_version
+
+(** [run_command args] runs a command, returning [true] on success (exit code 0)
+    and [false] on any failure (non-zero exit, signal, or missing command). *)
+let run_command args =
+  try
+    let argv = Array.of_list args in
+    let pid =
+      Unix.create_process (List.hd args) argv Unix.stdin Unix.stderr Unix.stderr
+    in
+    let _, status = Unix.waitpid [] pid in
+    status = Unix.WEXITED 0
+  with Unix.Unix_error _ -> false
+
+(** [read_file_contents path] reads a file's contents, returning [None] if the
+    file does not exist. *)
+let read_file_contents path =
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () -> Some (String.trim (In_channel.input_all ic)))
+  with Sys_error _ -> None
+
+(** [write_file_contents path contents] writes [contents] to [path]. *)
+let write_file_contents path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc contents)
+
+(** [ensure_hegel_installed ()] ensures hegel is installed in [.hegel/venv] and
+    returns the path to the binary. Creates the venv and installs hegel if it
+    doesn't exist, or reinstalls if the version file doesn't match
+    [hegel_version]. *)
+let ensure_hegel_installed () =
+  let hegel_bin = Filename.concat (Filename.concat venv_dir "bin") "hegel" in
+  (* Check if already installed at the right version *)
+  (match read_file_contents version_file with
+  | Some v when v = hegel_version && Sys.file_exists hegel_bin -> ()
+  | _ ->
+      (* Need to install *)
+      (try Unix.mkdir hegel_dir 0o755
+       with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+      Printf.eprintf "Installing hegel (%s) into %s...\n%!"
+        (String.sub hegel_version 0 12)
+        venv_dir;
+      if not (run_command [ "uv"; "venv"; "--clear"; venv_dir ]) then
+        failwith "Failed to create venv. Is uv installed?";
+      let python_bin =
+        Filename.concat (Filename.concat venv_dir "bin") "python"
       in
-      match found with
-      | Some p -> p
-      | None ->
-          failwith
-            "Cannot find hegel binary. Set HEGEL_BINARY or add hegel to PATH.")
+      if
+        not
+          (run_command
+             [
+               "uv"; "pip"; "install"; "--python"; python_bin; hegel_pip_spec ();
+             ])
+      then
+        failwith
+          (Printf.sprintf
+             "Failed to install hegel (version: %s). Set %s to a hegel binary \
+              path to skip installation."
+             hegel_version hegel_cmd_env);
+      if not (Sys.file_exists hegel_bin) then
+        failwith
+          (Printf.sprintf "hegel not found at %s after installation" hegel_bin);
+      write_file_contents version_file hegel_version);
+  hegel_bin
+
+(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_CMD] is set, uses that
+    path directly (the user is responsible for providing the right binary).
+    Otherwise, ensures hegel is installed in [.hegel/venv] at the version
+    specified by [hegel_version] and returns the path to that binary. *)
+let find_hegeld () =
+  match Sys.getenv_opt hegel_cmd_env with
+  | Some path when path <> "" -> path
+  | _ -> ensure_hegel_installed ()
 
 type hegel_session = {
   mutable process : int option;

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -16,10 +16,13 @@ type hegel_session = {
 }
 (** Internal mutable session state. *)
 
+val hegel_version : string
+(** The hegel-core commit this SDK is designed to work with. *)
+
 val find_hegeld : unit -> string
-(** [find_hegeld ()] locates the hegeld binary. Checks, in order:
-    - [HEGEL_BINARY] environment variable
-    - [hegel] on [PATH] Returns the path or raises [Failure]. *)
+(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_CMD] is set, uses that
+    path directly. Otherwise, ensures hegel is installed in [.hegel/venv] at the
+    version specified by [hegel_version] and returns the path to that binary. *)
 
 val has_working_client : hegel_session -> bool
 (** [has_working_client session] returns [true] if the session has a live

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -20,9 +20,10 @@ val hegel_version : string
 (** The hegel-core commit this SDK is designed to work with. *)
 
 val find_hegeld : unit -> string
-(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_CMD] is set, uses that
-    path directly. Otherwise, ensures hegel is installed in [.hegel/venv] at the
-    version specified by [hegel_version] and returns the path to that binary. *)
+(** [find_hegeld ()] locates the hegeld binary. If [HEGEL_SERVER_COMMAND] is
+    set, uses that path directly. Otherwise, ensures hegel is installed in
+    [.hegel/venv] at the version specified by [hegel_version] and returns the
+    path to that binary. *)
 
 val has_working_client : hegel_session -> bool
 (** [has_working_client session] returns [true] if the session has a live

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -438,42 +438,105 @@ let test_unrecognised_event () =
   close client_conn;
   close peer_conn
 
-(** Test: find_hegeld fails when binary not on PATH. *)
-let test_find_hegeld_not_found () =
-  let orig_binary =
-    try Some (Sys.getenv "HEGEL_BINARY") with Not_found -> None
-  in
+(** Helper: run a function in a temporary directory, restoring cwd and env
+    after. *)
+let with_temp_install_dir f =
+  let orig_cmd = try Some (Sys.getenv "HEGEL_CMD") with Not_found -> None in
   let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
-  Unix.putenv "HEGEL_BINARY" "";
-  Unix.putenv "PATH" "/nonexistent";
-  let raised = ref false in
-  (try ignore (Session.find_hegeld ()) with Failure _ -> raised := true);
-  Alcotest.(check bool) "raised" true !raised;
-  (match orig_binary with
-  | Some v -> Unix.putenv "HEGEL_BINARY" v
-  | None -> Unix.putenv "HEGEL_BINARY" "");
-  match orig_path with
-  | Some v -> Unix.putenv "PATH" v
-  | None -> Unix.putenv "PATH" ""
+  let temp_dir = Filename.temp_dir "hegel-test-install-" "" in
+  let orig_cwd = Sys.getcwd () in
+  Sys.chdir temp_dir;
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.chdir orig_cwd;
+      (* Clean up .hegel dir recursively *)
+      let hegel_dir = Filename.concat temp_dir ".hegel" in
+      let rec rm path =
+        if Sys.is_directory path then begin
+          Array.iter (fun f -> rm (Filename.concat path f)) (Sys.readdir path);
+          Unix.rmdir path
+        end
+        else Sys.remove path
+      in
+      (try rm hegel_dir with _ -> ());
+      (try Unix.rmdir temp_dir with _ -> ());
+      (match orig_cmd with
+      | Some v -> Unix.putenv "HEGEL_CMD" v
+      | None -> Unix.putenv "HEGEL_CMD" "");
+      match orig_path with
+      | Some v -> Unix.putenv "PATH" v
+      | None -> Unix.putenv "PATH" "")
+    (fun () -> f temp_dir)
 
-(** Test: find_hegeld when PATH is not set at all. *)
-let test_find_hegeld_no_path () =
-  let orig_binary =
-    try Some (Sys.getenv "HEGEL_BINARY") with Not_found -> None
-  in
-  let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
-  Unix.putenv "HEGEL_BINARY" "";
-  (* We can't truly unset PATH in OCaml, but set to empty *)
-  Unix.putenv "PATH" "";
-  let raised = ref false in
-  (try ignore (Session.find_hegeld ()) with Failure _ -> raised := true);
-  Alcotest.(check bool) "raised" true !raised;
-  (match orig_binary with
-  | Some v -> Unix.putenv "HEGEL_BINARY" v
-  | None -> Unix.putenv "HEGEL_BINARY" "");
-  match orig_path with
-  | Some v -> Unix.putenv "PATH" v
-  | None -> Unix.putenv "PATH" ""
+(** Test: find_hegeld fails when uv is not on PATH (install fails at venv
+    creation). *)
+let test_find_hegeld_install_fails () =
+  with_temp_install_dir (fun _temp_dir ->
+      Unix.putenv "HEGEL_CMD" "";
+      Unix.putenv "PATH" "/nonexistent";
+      let raised = ref false in
+      (try ignore (Session.find_hegeld ()) with Failure _ -> raised := true);
+      Alcotest.(check bool) "raised" true !raised)
+
+(** Test: find_hegeld fails when uv pip install fails. Uses a fake uv that
+    succeeds for venv but fails for pip. Also covers the mkdir EEXIST path. *)
+let test_find_hegeld_pip_install_fails () =
+  with_temp_install_dir (fun temp_dir ->
+      Unix.putenv "HEGEL_CMD" "";
+      (* Create .hegel dir so mkdir hits EEXIST *)
+      let hegel_dir = Filename.concat temp_dir ".hegel" in
+      (try Unix.mkdir hegel_dir 0o755 with _ -> ());
+      (* Create a fake uv script that succeeds for venv but fails for pip *)
+      let bin_dir = Filename.concat temp_dir "bin" in
+      Unix.mkdir bin_dir 0o755;
+      let uv_script = Filename.concat bin_dir "uv" in
+      let oc = open_out uv_script in
+      output_string oc
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"venv\" ]; then mkdir -p \"$3/bin\"; exit 0; fi\n\
+         exit 1\n";
+      close_out oc;
+      Unix.chmod uv_script 0o755;
+      Unix.putenv "PATH" bin_dir;
+      let raised = ref false in
+      let msg = ref "" in
+      (try ignore (Session.find_hegeld ())
+       with Failure m ->
+         raised := true;
+         msg := m);
+      Alcotest.(check bool) "raised" true !raised;
+      Alcotest.(check bool)
+        "has 'Failed to install'" true
+        (contains_substring !msg "Failed to install"))
+
+(** Test: find_hegeld fails when hegel binary not found after install. Uses a
+    fake uv that creates the venv but not the hegel binary. *)
+let test_find_hegeld_binary_not_found () =
+  with_temp_install_dir (fun temp_dir ->
+      Unix.putenv "HEGEL_CMD" "";
+      (* Create a fake uv script that succeeds for both venv and pip *)
+      let bin_dir = Filename.concat temp_dir "bin" in
+      Unix.mkdir bin_dir 0o755;
+      let uv_script = Filename.concat bin_dir "uv" in
+      let oc = open_out uv_script in
+      output_string oc
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"venv\" ]; then mkdir -p \"$3/bin\"; touch \
+         \"$3/bin/python\"; exit 0; fi\n\
+         exit 0\n";
+      close_out oc;
+      Unix.chmod uv_script 0o755;
+      Unix.putenv "PATH" bin_dir;
+      let raised = ref false in
+      let msg = ref "" in
+      (try ignore (Session.find_hegeld ())
+       with Failure m ->
+         raised := true;
+         msg := m);
+      Alcotest.(check bool) "raised" true !raised;
+      Alcotest.(check bool)
+        "has 'not found at'" true
+        (contains_substring !msg "not found at"))
 
 (** Test: session start timeout (unreachable hegeld). Also covers the
     Unix.Unix_error retry path by creating a non-socket file at the socket path.
@@ -489,10 +552,10 @@ let test_session_start_timeout () =
       lock = Mutex.create ();
     }
   in
-  (* Set HEGEL_BINARY to a script that creates a regular file (not socket)
+  (* Set HEGEL_CMD to a script that creates a regular file (not socket)
      at the socket path, which will cause Unix.Unix_error on connect. *)
   let orig_binary =
-    try Some (Sys.getenv "HEGEL_BINARY") with Not_found -> None
+    try Some (Sys.getenv "HEGEL_CMD") with Not_found -> None
   in
   let script_path = Filename.temp_file "hegel-test-" ".sh" in
   let oc = open_out script_path in
@@ -502,7 +565,7 @@ let test_session_start_timeout () =
   output_string oc "#!/bin/sh\ntouch \"$1\"\n";
   close_out oc;
   Unix.chmod script_path 0o755;
-  Unix.putenv "HEGEL_BINARY" script_path;
+  Unix.putenv "HEGEL_CMD" script_path;
   let raised = ref false in
   (try Session.start session
    with Failure msg ->
@@ -514,8 +577,8 @@ let test_session_start_timeout () =
   Session.cleanup session;
   (try Sys.remove script_path with _ -> ());
   match orig_binary with
-  | Some v -> Unix.putenv "HEGEL_BINARY" v
-  | None -> Unix.putenv "HEGEL_BINARY" ""
+  | Some v -> Unix.putenv "HEGEL_CMD" v
+  | None -> Unix.putenv "HEGEL_CMD" ""
 
 (** Test: run_hegel_test when session is None (unreachable in normal usage, but
     covers the branch). *)
@@ -705,19 +768,22 @@ let test_run_test_case_nest () =
 (* ---- find_hegeld ---- *)
 
 let test_find_hegeld_via_env () =
-  Unix.putenv "HEGEL_BINARY" "/tmp/fake-hegel";
+  Unix.putenv "HEGEL_CMD" "/tmp/fake-hegel";
   let path = Session.find_hegeld () in
   Alcotest.(check string) "path" "/tmp/fake-hegel" path;
-  Unix.putenv "HEGEL_BINARY" ""
+  Unix.putenv "HEGEL_CMD" ""
 
-let test_find_hegeld_on_path () =
-  let orig = try Some (Sys.getenv "HEGEL_BINARY") with Not_found -> None in
-  Unix.putenv "HEGEL_BINARY" "";
+let test_find_hegeld_auto_install () =
+  let orig = try Some (Sys.getenv "HEGEL_CMD") with Not_found -> None in
+  Unix.putenv "HEGEL_CMD" "";
   let path = Session.find_hegeld () in
   Alcotest.(check bool) "found hegel" true (String.length path > 0);
+  Alcotest.(check bool)
+    "path contains .hegel/venv" true
+    (contains_substring path ".hegel/venv");
   match orig with
-  | Some v -> Unix.putenv "HEGEL_BINARY" v
-  | None -> Unix.putenv "HEGEL_BINARY" ""
+  | Some v -> Unix.putenv "HEGEL_CMD" v
+  | None -> Unix.putenv "HEGEL_CMD" ""
 
 (* ---- Session lifecycle ---- *)
 
@@ -772,9 +838,14 @@ let tests =
     Alcotest.test_case "unrecognised event" `Quick test_unrecognised_event;
     (* find_hegeld *)
     Alcotest.test_case "find_hegeld via env" `Quick test_find_hegeld_via_env;
-    Alcotest.test_case "find_hegeld on path" `Quick test_find_hegeld_on_path;
-    Alcotest.test_case "find_hegeld not found" `Quick test_find_hegeld_not_found;
-    Alcotest.test_case "find_hegeld no path" `Quick test_find_hegeld_no_path;
+    Alcotest.test_case "find_hegeld auto install" `Quick
+      test_find_hegeld_auto_install;
+    Alcotest.test_case "find_hegeld install fails" `Quick
+      test_find_hegeld_install_fails;
+    Alcotest.test_case "find_hegeld pip install fails" `Quick
+      test_find_hegeld_pip_install_fails;
+    Alcotest.test_case "find_hegeld binary not found" `Quick
+      test_find_hegeld_binary_not_found;
     (* Session *)
     Alcotest.test_case "session cleanup" `Quick test_session_cleanup;
     Alcotest.test_case "session cleanup with resources" `Quick

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -441,7 +441,7 @@ let test_unrecognised_event () =
 (** Helper: run a function in a temporary directory, restoring cwd and env
     after. *)
 let with_temp_install_dir f =
-  let orig_cmd = try Some (Sys.getenv "HEGEL_CMD") with Not_found -> None in
+  let orig_cmd = try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None in
   let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
   let temp_dir = Filename.temp_dir "hegel-test-install-" "" in
   let orig_cwd = Sys.getcwd () in
@@ -461,8 +461,8 @@ let with_temp_install_dir f =
       (try rm hegel_dir with _ -> ());
       (try Unix.rmdir temp_dir with _ -> ());
       (match orig_cmd with
-      | Some v -> Unix.putenv "HEGEL_CMD" v
-      | None -> Unix.putenv "HEGEL_CMD" "");
+      | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
+      | None -> Unix.putenv "HEGEL_SERVER_COMMAND" "");
       match orig_path with
       | Some v -> Unix.putenv "PATH" v
       | None -> Unix.putenv "PATH" "")
@@ -472,7 +472,7 @@ let with_temp_install_dir f =
     creation). *)
 let test_find_hegeld_install_fails () =
   with_temp_install_dir (fun _temp_dir ->
-      Unix.putenv "HEGEL_CMD" "";
+      Unix.putenv "HEGEL_SERVER_COMMAND" "";
       Unix.putenv "PATH" "/nonexistent";
       let raised = ref false in
       (try ignore (Session.find_hegeld ()) with Failure _ -> raised := true);
@@ -482,7 +482,7 @@ let test_find_hegeld_install_fails () =
     succeeds for venv but fails for pip. Also covers the mkdir EEXIST path. *)
 let test_find_hegeld_pip_install_fails () =
   with_temp_install_dir (fun temp_dir ->
-      Unix.putenv "HEGEL_CMD" "";
+      Unix.putenv "HEGEL_SERVER_COMMAND" "";
       (* Create .hegel dir so mkdir hits EEXIST *)
       let hegel_dir = Filename.concat temp_dir ".hegel" in
       (try Unix.mkdir hegel_dir 0o755 with _ -> ());
@@ -513,7 +513,7 @@ let test_find_hegeld_pip_install_fails () =
     fake uv that creates the venv but not the hegel binary. *)
 let test_find_hegeld_binary_not_found () =
   with_temp_install_dir (fun temp_dir ->
-      Unix.putenv "HEGEL_CMD" "";
+      Unix.putenv "HEGEL_SERVER_COMMAND" "";
       (* Create a fake uv script that succeeds for both venv and pip *)
       let bin_dir = Filename.concat temp_dir "bin" in
       Unix.mkdir bin_dir 0o755;
@@ -552,10 +552,10 @@ let test_session_start_timeout () =
       lock = Mutex.create ();
     }
   in
-  (* Set HEGEL_CMD to a script that creates a regular file (not socket)
+  (* Set HEGEL_SERVER_COMMAND to a script that creates a regular file (not socket)
      at the socket path, which will cause Unix.Unix_error on connect. *)
   let orig_binary =
-    try Some (Sys.getenv "HEGEL_CMD") with Not_found -> None
+    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
   in
   let script_path = Filename.temp_file "hegel-test-" ".sh" in
   let oc = open_out script_path in
@@ -565,7 +565,7 @@ let test_session_start_timeout () =
   output_string oc "#!/bin/sh\ntouch \"$1\"\n";
   close_out oc;
   Unix.chmod script_path 0o755;
-  Unix.putenv "HEGEL_CMD" script_path;
+  Unix.putenv "HEGEL_SERVER_COMMAND" script_path;
   let raised = ref false in
   (try Session.start session
    with Failure msg ->
@@ -577,8 +577,8 @@ let test_session_start_timeout () =
   Session.cleanup session;
   (try Sys.remove script_path with _ -> ());
   match orig_binary with
-  | Some v -> Unix.putenv "HEGEL_CMD" v
-  | None -> Unix.putenv "HEGEL_CMD" ""
+  | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
+  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" ""
 
 (** Test: run_hegel_test when session is None (unreachable in normal usage, but
     covers the branch). *)
@@ -768,22 +768,22 @@ let test_run_test_case_nest () =
 (* ---- find_hegeld ---- *)
 
 let test_find_hegeld_via_env () =
-  Unix.putenv "HEGEL_CMD" "/tmp/fake-hegel";
+  Unix.putenv "HEGEL_SERVER_COMMAND" "/tmp/fake-hegel";
   let path = Session.find_hegeld () in
   Alcotest.(check string) "path" "/tmp/fake-hegel" path;
-  Unix.putenv "HEGEL_CMD" ""
+  Unix.putenv "HEGEL_SERVER_COMMAND" ""
 
 let test_find_hegeld_auto_install () =
-  let orig = try Some (Sys.getenv "HEGEL_CMD") with Not_found -> None in
-  Unix.putenv "HEGEL_CMD" "";
+  let orig = try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None in
+  Unix.putenv "HEGEL_SERVER_COMMAND" "";
   let path = Session.find_hegeld () in
   Alcotest.(check bool) "found hegel" true (String.length path > 0);
   Alcotest.(check bool)
     "path contains .hegel/venv" true
     (contains_substring path ".hegel/venv");
   match orig with
-  | Some v -> Unix.putenv "HEGEL_CMD" v
-  | None -> Unix.putenv "HEGEL_CMD" ""
+  | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
+  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" ""
 
 (* ---- Session lifecycle ---- *)
 

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -441,7 +441,9 @@ let test_unrecognised_event () =
 (** Helper: run a function in a temporary directory, restoring cwd and env
     after. *)
 let with_temp_install_dir f =
-  let orig_cmd = try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None in
+  let orig_cmd =
+    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
+  in
   let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
   let temp_dir = Filename.temp_dir "hegel-test-install-" "" in
   let orig_cwd = Sys.getcwd () in
@@ -566,6 +568,11 @@ let test_session_start_timeout () =
   close_out oc;
   Unix.chmod script_path 0o755;
   Unix.putenv "HEGEL_SERVER_COMMAND" script_path;
+  (* Run from a temp directory where .hegel doesn't exist yet, so the mkdir in
+     start() creates the directory fresh (covering the non-EEXIST path). *)
+  let orig_cwd = Sys.getcwd () in
+  let test_dir = Filename.temp_dir "hegel-start-test-" "" in
+  Sys.chdir test_dir;
   let raised = ref false in
   (try Session.start session
    with Failure msg ->
@@ -575,10 +582,22 @@ let test_session_start_timeout () =
        (contains_substring msg "Timeout"));
   Alcotest.(check bool) "raised timeout" true !raised;
   Session.cleanup session;
+  Sys.chdir orig_cwd;
+  (* Clean up the .hegel dir and temp dir *)
+  let hegel_dir = Filename.concat test_dir ".hegel" in
+  let rec rm path =
+    if Sys.is_directory path then begin
+      Array.iter (fun f -> rm (Filename.concat path f)) (Sys.readdir path);
+      Unix.rmdir path
+    end
+    else Sys.remove path
+  in
+  (try rm hegel_dir with _ -> ());
+  (try Unix.rmdir test_dir with _ -> ());
   (try Sys.remove script_path with _ -> ());
-  match orig_binary with
+  (match orig_binary with
   | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
-  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" ""
+  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" "")
 
 (** Test: run_hegel_test when session is None (unreachable in normal usage, but
     covers the branch). *)
@@ -774,7 +793,9 @@ let test_find_hegeld_via_env () =
   Unix.putenv "HEGEL_SERVER_COMMAND" ""
 
 let test_find_hegeld_auto_install () =
-  let orig = try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None in
+  let orig =
+    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
+  in
   Unix.putenv "HEGEL_SERVER_COMMAND" "";
   let path = Session.find_hegeld () in
   Alcotest.(check bool) "found hegel" true (String.length path > 0);


### PR DESCRIPTION
## Summary

- Manage hegel server binary via a pinned `.hegel/venv` virtualenv that auto-installs hegel-core, replacing ad-hoc pip installs in CI and local dev
- Pin hegel-core version to release tags (e.g. `v0.3.3`) instead of commit hashes, with a `just update-hegel-core-version` recipe to bump it
- Redirect hegel server stdout/stderr to `.hegel/server.log` (append mode, `PYTHONUNBUFFERED=1`) for debuggability
- Rename `HEGEL_CMD` env var to `HEGEL_SERVER_COMMAND` (aligns with hegel-rust convention)
- Remove auto-pinning of hegel-core version from the release script (it ran after tests, so the released version was untested)
- Clean up CI workflow: remove `environment: ci` declarations, suppress zizmor `secrets-outside-env` via `.github/zizmor.yml` config, fix release job token scoping for hegel-core API access
- Simplify release notes template

## Test plan

- [ ] `just check` passes
- [ ] Server log appears at `.hegel/server.log` after test run
- [ ] `HEGEL_SERVER_COMMAND=/path/to/hegel` overrides auto-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)