### PR TITLE
Log server output to .hegel/server.log

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -101,12 +101,19 @@ let start session =
           session.temp_dir <- Some temp_dir;
           let socket_path = Filename.concat temp_dir "hegel.sock" in
           session.socket_path <- Some socket_path;
-          (* Start hegeld subprocess *)
+          (* Start hegeld subprocess, logging output to .hegel/server.log *)
+          (try Unix.mkdir ".hegel" 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+          let log_fd =
+            Unix.openfile ".hegel/server.log"
+              [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+          in
+          Unix.putenv "PYTHONUNBUFFERED" "1";
           let pid =
             Unix.create_process hegel_cmd
               [| hegel_cmd; socket_path |]
-              Unix.stdin Unix.stderr Unix.stderr
+              Unix.stdin log_fd log_fd
           in
+          Unix.close log_fd;
           session.process <- Some pid;
           (* Wait for socket to appear and connect *)
           let rec try_connect attempts =


### PR DESCRIPTION
## Summary

- Redirect hegel server subprocess stdout/stderr to `.hegel/server.log` (append mode) instead of inheriting parent's stdio
- Set `PYTHONUNBUFFERED=1` so log output is written promptly
- Pass the log file descriptor to `Unix.create_process` instead of `Unix.stderr`

Matches the approach taken in https://github.com/antithesishq/hegel-rust/pull/45.

## Test plan

- [ ] Run tests and verify they still pass
- [ ] Check that `.hegel/server.log` is created and contains server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)