### PR TITLE
Move hegel-ocaml over to Jane Street standard library

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release moves the library over to use the Jane Street standard library instead of the Inria one.

--- a/conformance/dune
+++ b/conformance/dune
@@ -6,39 +6,39 @@
 (executable
  (name test_booleans)
  (modules test_booleans)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_integers)
  (modules test_integers)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_floats)
  (modules test_floats)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_text)
  (modules test_text)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_binary)
  (modules test_binary)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_lists)
  (modules test_lists)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_sampled_from)
  (modules test_sampled_from)
- (libraries hegel json_params))
+ (libraries hegel json_params core))
 
 (executable
  (name test_hashmaps)
  (modules test_hashmaps)
- (libraries hegel json_params))
+ (libraries hegel json_params core))

--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,10 @@
    (>= 5.2))
   (dune
    (>= 3.16))
+  (core
+   (>= 0.17))
+  (core_unix
+   (>= 0.17))
   (alcotest
    (and
     :with-test

--- a/examples/dune
+++ b/examples/dune
@@ -1,9 +1,9 @@
 (executables
  (names basic_properties collections real_world)
- (libraries hegel))
+ (libraries hegel core))
 
 (executable
  (name derived_types)
- (libraries hegel)
+ (libraries hegel core)
  (preprocess
   (pps ppx_hegel_generator)))

--- a/hegel.opam
+++ b/hegel.opam
@@ -10,6 +10,8 @@ bug-reports: "https://github.com/hegeldev/hegel-ocaml/issues"
 depends: [
   "ocaml" {>= "5.2"}
   "dune" {>= "3.16" & >= "3.16"}
+  "core" {>= "0.17"}
+  "core_unix" {>= "0.17"}
   "alcotest" {with-test & >= "1.7"}
   "cbor" {>= "0.5"}
   "checkseum" {>= "0.5"}

--- a/lib/cbor_helpers.ml
+++ b/lib/cbor_helpers.ml
@@ -4,6 +4,8 @@
     values, plus type-safe extractor functions that produce clear error messages
     when a value has an unexpected type. *)
 
+open! Core
+
 type t = CBOR.Simple.t
 (** The type of CBOR values, re-exported from [CBOR.Simple]. *)
 
@@ -32,48 +34,42 @@ let type_name = function
     Raises [Failure] if [v] is not an [`Int]. *)
 let extract_int = function
   | `Int i -> i
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR int, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR int, got %s" (type_name other))
 
 (** [extract_float v] extracts a float from a CBOR value.
 
     Raises [Failure] if [v] is not a [`Float]. *)
 let extract_float = function
   | `Float f -> f
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR float, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR float, got %s" (type_name other))
 
 (** [extract_string v] extracts a text string from a CBOR value.
 
     Raises [Failure] if [v] is not a [`Text]. *)
 let extract_string = function
   | `Text s -> s
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR text, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR text, got %s" (type_name other))
 
 (** [extract_bool v] extracts a boolean from a CBOR value.
 
     Raises [Failure] if [v] is not a [`Bool]. *)
 let extract_bool = function
   | `Bool b -> b
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR bool, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR bool, got %s" (type_name other))
 
 (** [extract_bytes v] extracts a byte string from a CBOR value.
 
     Raises [Failure] if [v] is not a [`Bytes]. *)
 let extract_bytes = function
   | `Bytes b -> b
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR bytes, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR bytes, got %s" (type_name other))
 
 (** [extract_list v] extracts a list of CBOR values from a CBOR value.
 
     Raises [Failure] if [v] is not an [`Array]. *)
 let extract_list = function
   | `Array l -> l
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR array, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR array, got %s" (type_name other))
 
 (** [extract_dict v] extracts a key-value map from a CBOR value. Keys and values
     remain as CBOR values.
@@ -81,8 +77,7 @@ let extract_list = function
     Raises [Failure] if [v] is not a [`Map]. *)
 let extract_dict = function
   | `Map m -> m
-  | other ->
-      failwith (Printf.sprintf "Expected CBOR map, got %s" (type_name other))
+  | other -> failwith (sprintf "Expected CBOR map, got %s" (type_name other))
 
 (** [is_null v] returns [true] if [v] is [`Null]. *)
 let is_null = function `Null -> true | _ -> false

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -7,6 +7,8 @@
     - Helper functions (assume, note, target, generate_from_schema)
     - Origin extraction for error reporting *)
 
+open! Core
+module Mutex = Caml_threads.Mutex
 open Connection
 
 exception Assume_rejected
@@ -63,13 +65,11 @@ let ci_vars =
 
 (** [is_in_ci ()] returns [true] if a CI environment is detected. *)
 let is_in_ci () =
-  List.exists
-    (fun (key, expected) ->
-      match (Sys.getenv_opt key, expected) with
+  List.exists ci_vars ~f:(fun (key, expected) ->
+      match (Sys.getenv key, expected) with
       | Some _, None -> true
-      | Some v, Some exp -> v = exp
+      | Some v, Some exp -> String.equal v exp
       | None, _ -> false)
-    ci_vars
 
 (** [default_settings ()] creates settings with defaults. Detects CI
     environments automatically. *)
@@ -121,29 +121,27 @@ type test_case = {
     channel, final-run flag, and abort state. *)
 
 (** Domain-local flag to detect nested test cases. *)
-let in_test_context : bool Domain.DLS.key = Domain.DLS.new_key (fun () -> false)
+let in_test_context : bool Stdlib.Domain.DLS.key =
+  Stdlib.Domain.DLS.new_key (fun () -> false)
 
 (** [extract_origin exn] extracts an InterestingOrigin string from an exception.
     Uses the backtrace if available. *)
 let extract_origin exn =
-  let bt = Printexc.get_raw_backtrace () in
+  let bt = Stdlib.Printexc.get_raw_backtrace () in
   let file_line =
-    match Printexc.backtrace_slots bt with
+    match Stdlib.Printexc.backtrace_slots bt with
     | None -> None
     | Some slots ->
-        Array.fold_left
-          (fun acc slot ->
-            Option.fold ~none:acc
-              ~some:(fun loc -> Some loc)
-              (Printexc.Slot.location slot))
-          None slots
-        |> Option.map (fun (loc : Printexc.location) ->
+        Array.fold slots ~init:None ~f:(fun acc slot ->
+            Option.value_map (Stdlib.Printexc.Slot.location slot) ~default:acc
+              ~f:(fun loc -> Some loc))
+        |> Option.map ~f:(fun (loc : Stdlib.Printexc.location) ->
             (loc.filename, loc.line_number))
   in
   match file_line with
-  | None -> Printf.sprintf "%s at :0" (Printexc.exn_slot_name exn)
+  | None -> sprintf "%s at :0" (Stdlib.Printexc.exn_slot_name exn)
   | Some (file, line) ->
-      Printf.sprintf "%s at %s:%d" (Printexc.exn_slot_name exn) file line
+      sprintf "%s at %s:%d" (Stdlib.Printexc.exn_slot_name exn) file line
 
 (** [generate_from_schema schema tc] generates a value from a schema by sending
     a generate command to the server. Raises {!Data_exhausted} if the server
@@ -154,7 +152,7 @@ let generate_from_schema schema tc =
     pending_get
       (request channel
          (`Map [ (`Text "command", `Text "generate"); (`Text "schema", schema) ]))
-  with Request_error e when e.error_type = "StopTest" ->
+  with Request_error e when String.equal e.error_type "StopTest" ->
     tc.test_aborted <- true;
     raise Data_exhausted
 
@@ -164,7 +162,7 @@ let assume _tc condition = if not condition then raise Assume_rejected
 
 (** [note tc message] records a message that will be printed on the final
     (failing) run. *)
-let note tc message = if tc.is_final then Printf.eprintf "%s\n%!" message
+let note tc message = if tc.is_final then eprintf "%s\n%!" message
 
 (** [target tc value label] sends a target command to guide the search engine
     toward higher values. *)
@@ -221,13 +219,13 @@ type client = { connection : connection; control : channel; lock : Mutex.t }
 (** [create_client connection] creates a new client from a connection. The
     connection must not yet have had its handshake performed. *)
 let create_client connection =
-  let server_version = float_of_string (send_handshake connection) in
+  let server_version = Float.of_string (send_handshake connection) in
   if
-    server_version < supported_protocol_lo
-    || server_version > supported_protocol_hi
+    Float.( < ) server_version supported_protocol_lo
+    || Float.( > ) server_version supported_protocol_hi
   then
     failwith
-      (Printf.sprintf
+      (sprintf
          "hegel-ocaml supports protocol versions %.1f through %.1f, but got \
           server version %g. Upgrading hegel-ocaml or downgrading your hegel \
           cli might help."
@@ -245,7 +243,7 @@ type test_outcome =
 
 let run_test_case _client channel test_fn ~is_final =
   let tc = { channel; is_final; test_aborted = false } in
-  Domain.DLS.set in_test_context true;
+  Stdlib.Domain.DLS.set in_test_context true;
   let outcome =
     try
       test_fn tc;
@@ -260,7 +258,7 @@ let run_test_case _client channel test_fn ~is_final =
             exn = (if is_final then Some exn else None);
           }
   in
-  Domain.DLS.set in_test_context false;
+  Stdlib.Domain.DLS.set in_test_context false;
   (match outcome with
   | Data_was_exhausted -> ()
   | Valid | Invalid | Interesting _ -> (
@@ -281,7 +279,7 @@ let run_test_case _client channel test_fn ~is_final =
                      (`Text "status", `Text status);
                      (`Text "origin", origin);
                    ])))
-      with Request_error e when e.error_type = "StopTest" -> ()));
+      with Request_error e when String.equal e.error_type "StopTest" -> ()));
   close_channel channel;
   match outcome with Interesting { exn = Some e; _ } -> raise e | _ -> ()
 
@@ -291,13 +289,13 @@ let run_test_case _client channel test_fn ~is_final =
     @param database_key
       optional key for persistent failure storage (internal use). *)
 let run_test client ~settings ?database_key test_fn =
-  if Domain.DLS.get in_test_context then
+  if Stdlib.Domain.DLS.get in_test_context then
     failwith "Cannot nest test cases - already inside a test case";
   let test_channel = new_channel client.connection ~role:"Test" () in
   Mutex.lock client.lock;
-  Fun.protect
+  Exn.protect
     ~finally:(fun () -> Mutex.unlock client.lock)
-    (fun () ->
+    ~f:(fun () ->
       let seed_value =
         match settings.seed with Some s -> `Int s | None -> `Null
       in
@@ -309,7 +307,7 @@ let run_test client ~settings ?database_key test_fn =
           (`Text "command", `Text "run_test");
           (`Text "test_cases", `Int settings.test_cases);
           (`Text "seed", seed_value);
-          (`Text "channel_id", `Int (Int32.to_int (channel_id test_channel)));
+          (`Text "channel_id", `Int (Int32.to_int_exn (channel_id test_channel)));
           (`Text "database_key", database_key_value);
           (`Text "derandomize", `Bool settings.derandomize);
         ]
@@ -327,9 +325,8 @@ let run_test client ~settings ?database_key test_fn =
             [
               ( `Text "suppress_health_check",
                 `Array
-                  (List.map
-                     (fun hc -> `Text (health_check_to_string hc))
-                     checks) );
+                  (List.map checks ~f:(fun hc ->
+                       `Text (health_check_to_string hc))) );
             ]
       in
       let fields = base_fields @ database_field @ suppress_field in
@@ -338,8 +335,9 @@ let run_test client ~settings ?database_key test_fn =
     let message_id, message = receive_request test_channel () in
     let pairs = Cbor_helpers.extract_dict message in
     let ch_id =
-      Int32.of_int
-        (Cbor_helpers.extract_int (List.assoc (`Text "channel_id") pairs))
+      Int32.of_int_exn
+        (Cbor_helpers.extract_int
+           (List.Assoc.find_exn pairs ~equal:Poly.( = ) (`Text "channel_id")))
     in
     send_response_value test_channel message_id `Null;
     let test_case_channel =
@@ -351,12 +349,14 @@ let run_test client ~settings ?database_key test_fn =
     let message_id, message = receive_request test_channel () in
     let pairs = Cbor_helpers.extract_dict message in
     let event =
-      Cbor_helpers.extract_string (List.assoc (`Text "event") pairs)
+      Cbor_helpers.extract_string
+        (List.Assoc.find_exn pairs ~equal:Poly.( = ) (`Text "event"))
     in
-    if event = "test_case" then begin
+    if String.equal event "test_case" then begin
       let ch_id =
-        Int32.of_int
-          (Cbor_helpers.extract_int (List.assoc (`Text "channel_id") pairs))
+        Int32.of_int_exn
+          (Cbor_helpers.extract_int
+             (List.Assoc.find_exn pairs ~equal:Poly.( = ) (`Text "channel_id")))
       in
       send_response_value test_channel message_id `Null;
       let test_case_channel =
@@ -367,17 +367,17 @@ let run_test client ~settings ?database_key test_fn =
         failwith server_crashed_message;
       receive_events ()
     end
-    else if event = "test_done" then begin
+    else if String.equal event "test_done" then begin
       send_response_value test_channel message_id (`Bool true);
-      Cbor_helpers.extract_dict (List.assoc (`Text "results") pairs)
+      Cbor_helpers.extract_dict
+        (List.Assoc.find_exn pairs ~equal:Poly.( = ) (`Text "results"))
     end
     else begin
       send_response_raw test_channel message_id
         (CBOR.Simple.encode
            (`Map
               [
-                ( `Text "error",
-                  `Text (Printf.sprintf "Unrecognised event %s" event) );
+                (`Text "error", `Text (sprintf "Unrecognised event %s" event));
                 (`Text "type", `Text "InvalidMessage");
               ]));
       receive_events ()
@@ -385,32 +385,35 @@ let run_test client ~settings ?database_key test_fn =
   in
   let results = receive_events () in
   (* Check for server-side errors *)
-  (match List.assoc_opt (`Text "error") results with
+  (match List.Assoc.find results ~equal:Poly.( = ) (`Text "error") with
   | Some error_val ->
       let error_msg = Cbor_helpers.extract_string error_val in
-      failwith (Printf.sprintf "Server error: %s" error_msg)
+      failwith (sprintf "Server error: %s" error_msg)
   | None -> ());
   (* Check for health check failure *)
-  (match List.assoc_opt (`Text "health_check_failure") results with
+  (match
+     List.Assoc.find results ~equal:Poly.( = ) (`Text "health_check_failure")
+   with
   | Some failure_val ->
       let failure_msg = Cbor_helpers.extract_string failure_val in
-      failwith (Printf.sprintf "Health check failure:\n%s" failure_msg)
+      failwith (sprintf "Health check failure:\n%s" failure_msg)
   | None -> ());
   (* Check for flaky test detection *)
-  (match List.assoc_opt (`Text "flaky") results with
+  (match List.Assoc.find results ~equal:Poly.( = ) (`Text "flaky") with
   | Some flaky_val ->
       let flaky_msg = Cbor_helpers.extract_string flaky_val in
-      failwith (Printf.sprintf "Flaky test detected: %s" flaky_msg)
+      failwith (sprintf "Flaky test detected: %s" flaky_msg)
   | None -> ());
   (* Check passed flag *)
   let passed =
-    match List.assoc_opt (`Text "passed") results with
+    match List.Assoc.find results ~equal:Poly.( = ) (`Text "passed") with
     | Some (`Bool b) -> b
     | _ -> true
   in
   let n_interesting =
     Cbor_helpers.extract_int
-      (List.assoc (`Text "interesting_test_cases") results)
+      (List.Assoc.find_exn results ~equal:Poly.( = )
+         (`Text "interesting_test_cases"))
   in
   if n_interesting = 0 && passed then ()
   else if n_interesting <= 1 then begin
@@ -422,7 +425,7 @@ let run_test client ~settings ?database_key test_fn =
       if remaining = 0 then List.rev acc
       else
         let msg =
-          Printf.sprintf "Expected test case %d to fail but it didn't"
+          sprintf "Expected test case %d to fail but it didn't"
             (List.length acc)
         in
         let exn =
@@ -436,9 +439,7 @@ let run_test client ~settings ?database_key test_fn =
     let exns = replay_interesting n_interesting [] in
     raise
       (Failure
-         (Printf.sprintf "Multiple failures (%d):\n%s" (List.length exns)
-            (String.concat "\n"
-               (List.mapi
-                  (fun i e ->
-                    Printf.sprintf "  %d: %s" i (Printexc.to_string e))
-                  exns))))
+         (sprintf "Multiple failures (%d):\n%s" (List.length exns)
+            (String.concat ~sep:"\n"
+               (List.mapi exns ~f:(fun i e ->
+                    sprintf "  %d: %s" i (Exn.to_string e))))))

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -3,6 +3,8 @@
     This module implements the client-side logic for running property-based
     tests against a Hegel server. *)
 
+module Mutex = Caml_threads.Mutex
+
 exception Assume_rejected
 (** Raised when {!assume} condition is [false]. *)
 

--- a/lib/conformance.ml
+++ b/lib/conformance.ml
@@ -4,34 +4,37 @@
     - {!get_test_cases}: reads [CONFORMANCE_TEST_CASES] env var
     - {!write_metrics}: appends a JSON line to [CONFORMANCE_METRICS_FILE] *)
 
+open! Core
+
 (** [parse_test_cases s] parses an optional string to an integer test count,
     defaulting to 50 if [s] is [None] or not a valid integer. *)
 let parse_test_cases = function
   | None -> 50
-  | Some s -> Option.value ~default:50 (int_of_string_opt s)
+  | Some s -> Option.value ~default:50 (Int.of_string_opt s)
 
 (** [get_test_cases ()] returns the number of test cases to run. Reads
     [CONFORMANCE_TEST_CASES] env var; defaults to [50]. *)
-let get_test_cases () =
-  parse_test_cases (Sys.getenv_opt "CONFORMANCE_TEST_CASES")
+let get_test_cases () = parse_test_cases (Sys.getenv "CONFORMANCE_TEST_CASES")
 
 (** [format_metrics pairs] formats a list of [(key, value)] pairs as a JSON
     object line (including newline). Values must already be serialized as JSON
     (e.g. ["true"], ["42"], ["-3.14"]). *)
 let format_metrics pairs =
   let json_body =
-    String.concat ", "
-      (List.map (fun (k, v) -> Printf.sprintf "%S: %s" k v) pairs)
+    String.concat ~sep:", "
+      (List.map pairs ~f:(fun (k, v) -> sprintf "%S: %s" k v))
   in
-  Printf.sprintf "{%s}\n" json_body
+  sprintf "{%s}\n" json_body
 
 (** [write_metrics_to filename pairs] appends a JSON metrics line to [filename].
 *)
 let write_metrics_to filename pairs =
-  let oc = open_out_gen [ Open_append; Open_creat ] 0o644 filename in
-  Fun.protect
-    ~finally:(fun () -> close_out oc)
-    (fun () -> output_string oc (format_metrics pairs))
+  let oc =
+    Stdlib.open_out_gen [ Stdlib.Open_append; Stdlib.Open_creat ] 0o644 filename
+  in
+  Exn.protect
+    ~finally:(fun () -> Stdlib.close_out oc)
+    ~f:(fun () -> Stdlib.output_string oc (format_metrics pairs))
 
 (** [write_metrics metrics] appends a JSON line to the file indicated by the
     [CONFORMANCE_METRICS_FILE] env var. [metrics] is a list of [(key, value)]
@@ -39,6 +42,6 @@ let write_metrics_to filename pairs =
     strings, no quotes for numbers/booleans/null). Raises [Failure] if the env
     var is not set. *)
 let write_metrics pairs =
-  match Sys.getenv_opt "CONFORMANCE_METRICS_FILE" with
+  match Sys.getenv "CONFORMANCE_METRICS_FILE" with
   | None -> failwith "CONFORMANCE_METRICS_FILE env var not set"
   | Some filename -> write_metrics_to filename pairs

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -8,6 +8,11 @@
     writing) with multiplexed logical channels. {b Channel} provides
     request/response messaging over a single logical channel. *)
 
+open! Core
+module Unix = Core_unix
+module Mutex = Caml_threads.Mutex
+module Condition = Caml_threads.Condition
+module Thread = Caml_threads.Thread
 open Protocol
 
 (** Handshake string sent by the client to initiate the protocol. *)
@@ -38,25 +43,31 @@ exception
 let result_or_error body =
   let pairs = Cbor_helpers.extract_dict body in
   let find_text key =
-    match List.assoc_opt (`Text key) pairs with
+    match List.Assoc.find pairs ~equal:Poly.( = ) (`Text key) with
     | Some v -> Cbor_helpers.extract_string v
     | None -> ""
   in
-  if List.mem_assoc (`Text "error") pairs then begin
+  if List.Assoc.mem pairs ~equal:Poly.( = ) (`Text "error") then begin
     let msg = find_text "error" in
     let error_type = find_text "type" in
     let data =
-      List.filter (fun (k, _) -> k <> `Text "error" && k <> `Text "type") pairs
+      List.filter pairs ~f:(fun (k, _) ->
+          Poly.( <> ) k (`Text "error") && Poly.( <> ) k (`Text "type"))
     in
     raise (Request_error { message = msg; error_type; data })
   end
   else
-    match List.assoc_opt (`Text "result") pairs with
+    match List.Assoc.find pairs ~equal:Poly.( = ) (`Text "result") with
     | Some v -> v
     | None -> failwith "Response has neither 'result' nor 'error'"
 
 (** Connection state after handshake. *)
 type connection_state = Unresolved | Client
+
+let equal_connection_state a b =
+  match (a, b) with
+  | Unresolved, Unresolved | Client, Client -> true
+  | _ -> false
 
 type channel_inbox = {
   queue : inbox_item Queue.t;
@@ -72,10 +83,10 @@ type channel_entry =
 
 and connection = {
   name : string option;
-  read_fd : Unix.file_descr;
-  write_fd : Unix.file_descr;
+  read_fd : Unix.File_descr.t;
+  write_fd : Unix.File_descr.t;
   mutable next_channel_id : int;
-  channels : (int32, channel_entry) Hashtbl.t;
+  channels : (Int32.t, channel_entry) Hashtbl.t;
   channels_lock : Mutex.t;
   mutable running : bool;
   debug : bool;
@@ -90,7 +101,7 @@ and channel = {
   conn : connection;
   inbox : channel_inbox;
   requests : packet Queue.t;
-  responses : (int32, string) Hashtbl.t;
+  responses : (Int32.t, string) Hashtbl.t;
   role : string option;
   mutable next_message_id : int32;
   mutable closed : bool;
@@ -103,29 +114,28 @@ let channel_id ch = ch.channel_id
 (** [channel_name ch] returns a human-readable name for channel [ch]. *)
 let channel_name ch =
   match (ch.role, ch.conn.name) with
-  | None, None -> Printf.sprintf "Channel %ld" ch.channel_id
-  | None, Some n -> Printf.sprintf "%s channel [id=%ld]" n ch.channel_id
-  | Some r, None -> Printf.sprintf "channel [id=%ld] (%s)" ch.channel_id r
-  | Some r, Some n ->
-      Printf.sprintf "%s channel [id=%ld] (%s)" n ch.channel_id r
+  | None, None -> sprintf "Channel %ld" ch.channel_id
+  | None, Some n -> sprintf "%s channel [id=%ld]" n ch.channel_id
+  | Some r, None -> sprintf "channel [id=%ld] (%s)" ch.channel_id r
+  | Some r, Some n -> sprintf "%s channel [id=%ld] (%s)" n ch.channel_id r
 
 (** [channel_repr ch] returns a debug representation of channel [ch]. *)
 let channel_repr ch =
   match ch.role with
-  | None -> Printf.sprintf "Channel(%ld)" ch.channel_id
-  | Some r -> Printf.sprintf "Channel(%ld, role=%s)" ch.channel_id r
+  | None -> sprintf "Channel(%ld)" ch.channel_id
+  | Some r -> sprintf "Channel(%ld, role=%s)" ch.channel_id r
 
 (** [entry_name conn channel_id] returns the name of the channel entry for
     [channel_id] in [conn], or a default. *)
 let entry_name conn channel_id =
-  match Hashtbl.find_opt conn.channels channel_id with
+  match Hashtbl.find conn.channels channel_id with
   | Some (Live ch) -> channel_name ch
   | Some (Dead d) -> d.name
-  | None -> Printf.sprintf "channel %ld" channel_id
+  | None -> sprintf "channel %ld" channel_id
 
 (** [make_channel conn channel_id ~role] creates a new channel. *)
 let make_channel conn channel_id ~role =
-  assert (channel_id <> 0l || role = Some "Control");
+  assert (Int32.( <> ) channel_id 0l || Poly.( = ) role (Some "Control"));
   {
     channel_id;
     conn;
@@ -136,7 +146,7 @@ let make_channel conn channel_id ~role =
         cond = Condition.create ();
       };
     requests = Queue.create ();
-    responses = Hashtbl.create 8;
+    responses = Hashtbl.create (module Int32);
     role;
     next_message_id = 1l;
     closed = false;
@@ -146,24 +156,22 @@ let make_channel conn channel_id ~role =
     condition variable. Must be called without holding [ch.inbox.lock]. *)
 let push_inbox ch item =
   Mutex.lock ch.inbox.lock;
-  Queue.push item ch.inbox.queue;
+  Queue.enqueue ch.inbox.queue item;
   Condition.signal ch.inbox.cond;
   Mutex.unlock ch.inbox.lock
 
 (** [signal_all_channels conn] pushes {!Shutdown} into all live channels'
     inboxes. Must be called while holding [conn.channels_lock]. *)
 let signal_all_channels conn =
-  Hashtbl.iter
-    (fun _id entry ->
+  Hashtbl.iteri conn.channels ~f:(fun ~key:_ ~data:entry ->
       match entry with Live ch -> push_inbox ch Shutdown | Dead _ -> ())
-    conn.channels
 
 (** [send_packet conn packet] sends a packet on the connection, thread-safe. *)
 let send_packet conn packet =
   Mutex.lock conn.writer_lock;
-  Fun.protect
+  Exn.protect
     ~finally:(fun () -> Mutex.unlock conn.writer_lock)
-    (fun () -> write_packet conn.write_fd packet)
+    ~f:(fun () -> write_packet conn.write_fd packet)
 
 (** Background reader thread function. Reads packets from [conn.read_fd] and
     dispatches them to the appropriate channel's inbox. Exits when the stream
@@ -171,24 +179,24 @@ let send_packet conn packet =
 let reader_loop conn =
   let dispatch_packet (pkt : packet) =
     (* Handle close_channel_payload for ANY channel (even unregistered) *)
-    if pkt.payload = close_channel_payload then begin
-      assert (pkt.message_id = close_channel_message_id);
+    if String.equal pkt.payload close_channel_payload then begin
+      assert (Int32.equal pkt.message_id close_channel_message_id);
       if conn.debug then begin
         Mutex.lock conn.channels_lock;
         let prev_name =
-          match Hashtbl.find_opt conn.channels pkt.channel_id with
+          match Hashtbl.find conn.channels pkt.channel_id with
           | Some (Live ch) -> channel_name ch
           | Some (Dead d) -> d.name
           | None -> "Never opened!"
         in
-        Hashtbl.replace conn.channels pkt.channel_id
-          (Dead { channel_id = pkt.channel_id; name = prev_name });
+        Hashtbl.set conn.channels ~key:pkt.channel_id
+          ~data:(Dead { channel_id = pkt.channel_id; name = prev_name });
         Mutex.unlock conn.channels_lock
       end
     end
     else begin
       Mutex.lock conn.channels_lock;
-      let entry = Hashtbl.find_opt conn.channels pkt.channel_id in
+      let entry = Hashtbl.find conn.channels pkt.channel_id in
       match entry with
       | Some (Live ch) ->
           Mutex.unlock conn.channels_lock;
@@ -200,8 +208,7 @@ let reader_loop conn =
               match entry with Some (Dead _) -> "closed" | _ -> "non-existent"
             in
             let error_msg =
-              Printf.sprintf "Message %ld sent to %s %s" pkt.message_id
-                disposition
+              sprintf "Message %ld sent to %s %s" pkt.message_id disposition
                 (entry_name conn pkt.channel_id)
             in
             try
@@ -238,7 +245,7 @@ let close conn =
     conn.running <- false;
     (try Unix.close conn.read_fd with Unix.Unix_error _ -> ());
     (* Only close write_fd if it's different from read_fd *)
-    (if conn.write_fd <> conn.read_fd then
+    (if not (phys_equal conn.write_fd conn.read_fd) then
        try Unix.close conn.write_fd with Unix.Unix_error _ -> ());
     Mutex.lock conn.channels_lock;
     signal_all_channels conn;
@@ -256,7 +263,7 @@ let create_connection ~read_fd ~write_fd ?name ?(debug = false) () =
       read_fd;
       write_fd;
       next_channel_id = 1;
-      channels = Hashtbl.create 16;
+      channels = Hashtbl.create (module Int32);
       channels_lock = Mutex.create ();
       running = true;
       debug;
@@ -267,7 +274,7 @@ let create_connection ~read_fd ~write_fd ?name ?(debug = false) () =
   in
   let control = make_channel conn 0l ~role:(Some "Control") in
   Mutex.lock conn.channels_lock;
-  Hashtbl.replace conn.channels 0l (Live control);
+  Hashtbl.set conn.channels ~key:0l ~data:(Live control);
   Mutex.unlock conn.channels_lock;
   (* Spawn background reader thread *)
   ignore (Thread.create reader_loop conn);
@@ -281,7 +288,7 @@ let server_has_exited conn = conn.server_exited
 
 (** [control_channel conn] returns the control channel (channel 0). *)
 let control_channel conn =
-  match Hashtbl.find_opt conn.channels 0l with
+  match Hashtbl.find conn.channels 0l with
   | Some (Live ch) -> ch
   | _ -> failwith "Internal error: no control channel"
 
@@ -290,14 +297,14 @@ let control_channel conn =
     Client channels use odd IDs [(counter << 1) | 1], server channels use even
     IDs [(counter << 1)]. *)
 let new_channel conn ?role () =
-  if conn.connection_state = Unresolved then
+  if equal_connection_state conn.connection_state Unresolved then
     failwith "Cannot create a new channel before handshake has been performed."
   else begin
-    let channel_id = Int32.of_int ((conn.next_channel_id lsl 1) lor 1) in
+    let channel_id = Int32.of_int_exn ((conn.next_channel_id lsl 1) lor 1) in
     conn.next_channel_id <- conn.next_channel_id + 1;
     let ch = make_channel conn channel_id ~role in
     Mutex.lock conn.channels_lock;
-    Hashtbl.replace conn.channels channel_id (Live ch);
+    Hashtbl.set conn.channels ~key:channel_id ~data:(Live ch);
     Mutex.unlock conn.channels_lock;
     ch
   end
@@ -305,13 +312,13 @@ let new_channel conn ?role () =
 (** [connect_channel conn channel_id ?role ()] connects to a channel created by
     the peer. *)
 let connect_channel conn channel_id ?role () =
-  if conn.connection_state = Unresolved then
+  if equal_connection_state conn.connection_state Unresolved then
     failwith "Cannot create a new channel before handshake has been performed.";
   if Hashtbl.mem conn.channels channel_id then
-    failwith (Printf.sprintf "Channel already connected as %ld." channel_id);
+    failwith (sprintf "Channel already connected as %ld." channel_id);
   let ch = make_channel conn channel_id ~role in
   Mutex.lock conn.channels_lock;
-  Hashtbl.replace conn.channels channel_id (Live ch);
+  Hashtbl.set conn.channels ~key:channel_id ~data:(Live ch);
   Mutex.unlock conn.channels_lock;
   ch
 
@@ -325,13 +332,13 @@ let pop_inbox_item ch timeout =
   let deadline = Unix.gettimeofday () +. timeout in
   let rec wait () =
     if not (Queue.is_empty ch.inbox.queue) then begin
-      let item = Queue.pop ch.inbox.queue in
+      let item = Queue.dequeue_exn ch.inbox.queue in
       Mutex.unlock ch.inbox.lock;
       item
     end
     else if ch.closed then begin
       Mutex.unlock ch.inbox.lock;
-      raise (Failure (Printf.sprintf "%s is closed" (channel_name ch)))
+      raise (Failure (sprintf "%s is closed" (channel_name ch)))
     end
     else if ch.conn.server_exited then begin
       Mutex.unlock ch.inbox.lock;
@@ -339,16 +346,16 @@ let pop_inbox_item ch timeout =
     end
     else begin
       let remaining = deadline -. Unix.gettimeofday () in
-      if remaining <= 0.0 then begin
+      if Float.( <= ) remaining 0.0 then begin
         Mutex.unlock ch.inbox.lock;
         raise
           (Failure
-             (Printf.sprintf "Timed out after %.1fs waiting for a message on %s"
+             (sprintf "Timed out after %.1fs waiting for a message on %s"
                 timeout (channel_name ch)))
       end;
       (* Release lock, sleep briefly, re-acquire *)
       Mutex.unlock ch.inbox.lock;
-      Unix.sleepf (min 0.01 remaining);
+      Caml_unix.sleepf (Float.min 0.01 remaining);
       Mutex.lock ch.inbox.lock;
       wait ()
     end
@@ -366,17 +373,16 @@ let process_one_message ch ?(timeout = channel_timeout) () =
       if pkt.is_reply then begin
         if Hashtbl.mem ch.responses pkt.message_id then
           failwith
-            (Printf.sprintf "Got two responses for message ID %ld"
-               pkt.message_id)
-        else Hashtbl.replace ch.responses pkt.message_id pkt.payload
+            (sprintf "Got two responses for message ID %ld" pkt.message_id)
+        else Hashtbl.set ch.responses ~key:pkt.message_id ~data:pkt.payload
       end
-      else Queue.push pkt ch.requests
+      else Queue.enqueue ch.requests pkt
 
 (** [send_request_raw ch payload] sends raw bytes as a request and returns the
     message ID for matching the response. *)
 let send_request_raw ch payload =
   let message_id = ch.next_message_id in
-  ch.next_message_id <- Int32.add ch.next_message_id 1l;
+  ch.next_message_id <- Int32.( + ) ch.next_message_id 1l;
   send_packet ch.conn
     { payload; channel_id = ch.channel_id; is_reply = false; message_id };
   message_id
@@ -391,7 +397,7 @@ let receive_response_raw ch message_id ?(timeout = channel_timeout) () =
   while not (Hashtbl.mem ch.responses message_id) do
     process_one_message ch ~timeout ()
   done;
-  let result = Hashtbl.find ch.responses message_id in
+  let result = Hashtbl.find_exn ch.responses message_id in
   Hashtbl.remove ch.responses message_id;
   result
 
@@ -407,7 +413,7 @@ let receive_request_raw ch ?(timeout = channel_timeout) () =
   while Queue.is_empty ch.requests do
     process_one_message ch ~timeout ()
   done;
-  let pkt = Queue.pop ch.requests in
+  let pkt = Queue.dequeue_exn ch.requests in
   (pkt.message_id, pkt.payload)
 
 (** [receive_request ch ?timeout ()] receives and CBOR-decodes a request,
@@ -432,16 +438,16 @@ let close_channel ch =
   if ch.closed then ()
   else begin
     let is_registered =
-      match Hashtbl.find_opt ch.conn.channels ch.channel_id with
-      | Some (Live ch2) -> ch2 == ch
+      match Hashtbl.find ch.conn.channels ch.channel_id with
+      | Some (Live ch2) -> phys_equal ch2 ch
       | _ -> false
     in
     if not is_registered then ch.closed <- true
     else begin
       ch.closed <- true;
       if ch.conn.debug then
-        Hashtbl.replace ch.conn.channels ch.channel_id
-          (Dead { name = channel_name ch; channel_id = ch.channel_id });
+        Hashtbl.set ch.conn.channels ~key:ch.channel_id
+          ~data:(Dead { name = channel_name ch; channel_id = ch.channel_id });
       if is_live ch.conn then
         send_packet ch.conn
           {
@@ -486,12 +492,14 @@ let pending_get pr =
 (** [send_handshake conn] initiates the handshake as a client. Returns the
     server protocol version string (e.g. ["0.1"]). *)
 let send_handshake conn =
-  if conn.connection_state <> Unresolved then
+  if not (equal_connection_state conn.connection_state Unresolved) then
     failwith "Handshake already established";
   conn.connection_state <- Client;
   let ch = control_channel conn in
   let message_id = send_request_raw ch handshake_string in
   let response = receive_response_raw ch message_id () in
-  if String.length response < 6 || String.sub response 0 6 <> "Hegel/" then
-    failwith (Printf.sprintf "Bad handshake response: %S" response)
-  else String.sub response 6 (String.length response - 6)
+  if
+    String.length response < 6
+    || not (String.equal (String.sub response ~pos:0 ~len:6) "Hegel/")
+  then failwith (sprintf "Bad handshake response: %S" response)
+  else String.sub response ~pos:6 ~len:(String.length response - 6)

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -64,10 +64,7 @@ let result_or_error body =
 (** Connection state after handshake. *)
 type connection_state = Unresolved | Client
 
-let equal_connection_state a b =
-  match (a, b) with
-  | Unresolved, Unresolved | Client, Client -> true
-  | _ -> false
+let equal_connection_state a b = Poly.( = ) a b
 
 type channel_inbox = {
   queue : inbox_item Queue.t;

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -4,6 +4,11 @@
     packets from the input stream and dispatches them to per-channel inboxes.
     Channels wait on condition variables for new messages. *)
 
+open! Core
+module Unix = Core_unix
+module Mutex = Caml_threads.Mutex
+module Condition = Caml_threads.Condition
+
 (** Sentinel value placed in a channel's inbox when the connection shuts down.
 *)
 type inbox_item = Pkt of Protocol.packet | Shutdown
@@ -37,8 +42,8 @@ type channel_entry =
 
 and connection = {
   name : string option;
-  read_fd : Unix.file_descr;
-  write_fd : Unix.file_descr;
+  read_fd : Core_unix.File_descr.t;
+  write_fd : Core_unix.File_descr.t;
   mutable next_channel_id : int;
   channels : (int32, channel_entry) Hashtbl.t;
   channels_lock : Mutex.t;
@@ -63,8 +68,8 @@ and channel = {
 (** Logical channel for request/response messaging. *)
 
 val create_connection :
-  read_fd:Unix.file_descr ->
-  write_fd:Unix.file_descr ->
+  read_fd:Core_unix.File_descr.t ->
+  write_fd:Core_unix.File_descr.t ->
   ?name:string ->
   ?debug:bool ->
   unit ->

--- a/lib/derive.ml
+++ b/lib/derive.ml
@@ -7,6 +7,8 @@
     {!Hegel.Generators.draw} internally and return typed OCaml values. These
     helpers provide the plumbing for option and list types. *)
 
+open! Core
+
 (** [generate_option tc gen_fn] generates an [option] value.
 
     Uses {!Generators.booleans} to decide between [Some] and [None]. When [Some]
@@ -23,4 +25,4 @@ let generate_list tc gen_fn =
   let len =
     Generators.draw tc (Generators.integers ~min_value:0 ~max_value:20 ())
   in
-  List.init len (fun _ -> gen_fn tc)
+  List.init len ~f:(fun _ -> gen_fn tc)

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name hegel)
  (public_name hegel)
- (libraries cbor checkseum.c unix threads.posix)
+ (libraries core core_unix unix cbor checkseum.c threads.posix)
  (private_modules
   generators_core
   generators_primitives

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name hegel)
  (public_name hegel)
- (libraries core core_unix unix cbor checkseum.c threads.posix)
+ (libraries core core_unix cbor checkseum.c threads.posix)
  (private_modules
   generators_core
   generators_primitives

--- a/lib/generators_collections.ml
+++ b/lib/generators_collections.ml
@@ -1,3 +1,4 @@
+open! Core
 open Generators_core
 
 (** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
@@ -9,16 +10,14 @@ open Generators_core
 let hashmaps keys values ?(min_size = 0) ?max_size () =
   if min_size < 0 then
     raise
-      (Invalid_argument
-         (Printf.sprintf "min_size=%d must be non-negative" min_size));
+      (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
   (match max_size with
   | Some ms when ms < 0 ->
-      raise
-        (Invalid_argument (Printf.sprintf "max_size=%d must be non-negative" ms))
+      raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
   | Some ms when min_size > ms ->
       raise
         (Invalid_argument
-           (Printf.sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+           (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
   | _ -> ());
   let key_schema, key_transform =
     match keys with
@@ -31,13 +30,13 @@ let hashmaps keys values ?(min_size = 0) ?max_size () =
     | _ -> failwith "hashmaps: values generator must be a Basic generator"
   in
   let pairs =
-    List.filter_map Fun.id
+    List.filter_opt
       [
         Some (`Text "type", `Text "dict");
         Some (`Text "keys", key_schema);
         Some (`Text "values", val_schema);
         Some (`Text "min_size", `Int min_size);
-        Option.map (fun ms -> (`Text "max_size", `Int ms)) max_size;
+        Option.map max_size ~f:(fun ms -> (`Text "max_size", `Int ms));
       ]
   in
   (* The server returns dicts as [[k, v], ...] lists. We transform to typed
@@ -45,11 +44,9 @@ let hashmaps keys values ?(min_size = 0) ?max_size () =
   let transform raw =
     match raw with
     | `Array kv_pairs ->
-        List.map
-          (function
-            | `Array [ k; v ] -> (key_transform k, val_transform v)
-            | _ -> failwith "hashmaps: expected [k, v] pair from server")
-          kv_pairs
+        List.map kv_pairs ~f:(function
+          | `Array [ k; v ] -> (key_transform k, val_transform v)
+          | _ -> failwith "hashmaps: expected [k, v] pair from server")
     | _ -> failwith "hashmaps: expected array from server"
   in
   Basic { schema = `Map pairs; transform }
@@ -66,32 +63,30 @@ let hashmaps keys values ?(min_size = 0) ?max_size () =
 let lists elements ?(min_size = 0) ?max_size () =
   if min_size < 0 then
     raise
-      (Invalid_argument
-         (Printf.sprintf "min_size=%d must be non-negative" min_size));
+      (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
   (match max_size with
   | Some ms when ms < 0 ->
-      raise
-        (Invalid_argument (Printf.sprintf "max_size=%d must be non-negative" ms))
+      raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
   | Some ms when min_size > ms ->
       raise
         (Invalid_argument
-           (Printf.sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+           (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
   | _ -> ());
   match as_basic elements with
   | Some (elem_schema, elem_transform) ->
       let pairs =
-        List.filter_map Fun.id
+        List.filter_opt
           [
             Some (`Text "type", `Text "list");
             Some (`Text "elements", elem_schema);
             Some (`Text "min_size", `Int min_size);
-            Option.map (fun ms -> (`Text "max_size", `Int ms)) max_size;
+            Option.map max_size ~f:(fun ms -> (`Text "max_size", `Int ms));
           ]
       in
       let raw_schema = `Map pairs in
       let list_transform raw_list =
         match raw_list with
-        | `Array items -> List.map elem_transform items
+        | `Array items -> List.map items ~f:elem_transform
         | _ ->
             failwith "Internal error: server returned non-array for list schema"
       in

--- a/lib/generators_combinators.ml
+++ b/lib/generators_combinators.ml
@@ -1,3 +1,4 @@
+open! Core
 open Generators_core
 open Generators_primitives
 
@@ -25,7 +26,7 @@ let sampled_from options =
 let one_of (generators : 'a generator list) =
   if List.length generators = 0 then
     failwith "one_of requires at least one generator";
-  let basics = List.filter_map as_basic generators in
+  let basics = List.filter_map generators ~f:as_basic in
   if List.length basics <> List.length generators then begin
     (* Path 3: composite — generate index in ONE_OF span, then delegate *)
     let gens = Array.of_list generators in
@@ -56,16 +57,14 @@ let one_of (generators : 'a generator list) =
        the tagged-tuple path which is always correct. *)
     (* Path 2: tagged-tuple schema with dispatch transform *)
     let tagged_schemas =
-      List.mapi
-        (fun i (s, _) ->
+      List.mapi basics ~f:(fun i (s, _) ->
           `Map
             [
               (`Text "type", `Text "tuple");
               (`Text "elements", `Array [ `Map [ (`Text "const", `Int i) ]; s ]);
             ])
-        basics
     in
-    let transforms = Array.of_list (List.map snd basics) in
+    let transforms = Array.of_list (List.map basics ~f:snd) in
     let dispatch raw =
       match raw with
       | `Array [ tag; value ] ->
@@ -105,7 +104,7 @@ let rec ip_addresses ?version () =
           transform = Cbor_helpers.extract_string;
         }
   | None -> one_of [ ip_addresses ~version:4 (); ip_addresses ~version:6 () ]
-  | Some v -> failwith (Printf.sprintf "ip_addresses: invalid version %d" v)
+  | Some v -> failwith (sprintf "ip_addresses: invalid version %d" v)
 
 (** [tuples2 g1 g2] creates a generator for 2-element tuples.
 

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -1,3 +1,4 @@
+open! Core
 open Connection
 
 (** Constants for span labels used in generation tracking. *)
@@ -65,7 +66,7 @@ let max_filter_attempts = 3
     span is stopped with [discard:false] regardless of whether [f] raises. *)
 let group label data f =
   Client.start_span ~label data;
-  Fun.protect ~finally:(fun () -> Client.stop_span data) (fun () -> f ())
+  Exn.protect ~finally:(fun () -> Client.stop_span data) ~f:(fun () -> f ())
 
 (** [discardable_group label data f] runs [f ()] inside a span with [label]. If
     [f] raises, the span is stopped with [discard:true]; otherwise
@@ -118,7 +119,7 @@ let get_server_name coll data =
                     (`Text "min_size", `Int coll.min_size);
                     (`Text "max_size", max_size_val);
                   ]))
-        with Request_error e when e.error_type = "StopTest" ->
+        with Request_error e when String.equal e.error_type "StopTest" ->
           data.test_aborted <- true;
           raise Client.Data_exhausted
       in
@@ -143,7 +144,7 @@ let collection_more coll data =
                   (`Text "command", `Text "collection_more");
                   (`Text "collection", server_name);
                 ]))
-      with Request_error e when e.error_type = "StopTest" ->
+      with Request_error e when String.equal e.error_type "StopTest" ->
         data.test_aborted <- true;
         raise Client.Data_exhausted
     in

--- a/lib/generators_primitives.ml
+++ b/lib/generators_primitives.ml
@@ -1,3 +1,4 @@
+open! Core
 open Generators_core
 
 (** [integers ?min_value ?max_value ()] creates a generator for integers within
@@ -7,14 +8,14 @@ let integers ?min_value ?max_value () =
   | Some min, Some max when min > max ->
       raise
         (Invalid_argument
-           (Printf.sprintf "Cannot have max_value=%d < min_value=%d" max min))
+           (sprintf "Cannot have max_value=%d < min_value=%d" max min))
   | _ -> ());
   let pairs =
-    List.filter_map Fun.id
+    List.filter_opt
       [
         Some (`Text "type", `Text "integer");
-        Option.map (fun v -> (`Text "min_value", `Int v)) min_value;
-        Option.map (fun v -> (`Text "max_value", `Int v)) max_value;
+        Option.map min_value ~f:(fun v -> (`Text "min_value", `Int v));
+        Option.map max_value ~f:(fun v -> (`Text "max_value", `Int v));
       ]
   in
   Basic { schema = `Map pairs; transform = Cbor_helpers.extract_int }
@@ -51,12 +52,11 @@ let floats ?min_value ?max_value ?(exclude_min = false) ?(exclude_max = false)
     raise
       (Invalid_argument "Cannot have allow_nan=true with min_value or max_value");
   (match (min_value, max_value) with
-  | Some min, Some max when min > max ->
+  | Some min, Some max when Float.( > ) min max ->
       raise
         (Invalid_argument
-           (Printf.sprintf
-              "There are no floats between min_value=%g and max_value=%g" min
-              max))
+           (sprintf "There are no floats between min_value=%g and max_value=%g"
+              min max))
   | _ -> ());
   if eff_allow_infinity && has_min && has_max then
     raise
@@ -74,10 +74,10 @@ let floats ?min_value ?max_value ?(exclude_min = false) ?(exclude_max = false)
   in
   let pairs =
     pairs
-    @ List.filter_map Fun.id
+    @ List.filter_opt
         [
-          Option.map (fun v -> (`Text "min_value", `Float v)) min_value;
-          Option.map (fun v -> (`Text "max_value", `Float v)) max_value;
+          Option.map min_value ~f:(fun v -> (`Text "min_value", `Float v));
+          Option.map max_value ~f:(fun v -> (`Text "max_value", `Float v));
         ]
   in
   Basic { schema = `Map pairs; transform = Cbor_helpers.extract_float }
@@ -88,23 +88,21 @@ let floats ?min_value ?max_value ?(exclude_min = false) ?(exclude_max = false)
 let text ?(min_size = 0) ?max_size () =
   if min_size < 0 then
     raise
-      (Invalid_argument
-         (Printf.sprintf "min_size=%d must be non-negative" min_size));
+      (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
   (match max_size with
   | Some ms when ms < 0 ->
-      raise
-        (Invalid_argument (Printf.sprintf "max_size=%d must be non-negative" ms))
+      raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
   | Some ms when min_size > ms ->
       raise
         (Invalid_argument
-           (Printf.sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+           (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
   | _ -> ());
   let pairs =
-    List.filter_map Fun.id
+    List.filter_opt
       [
         Some (`Text "type", `Text "string");
         Some (`Text "min_size", `Int min_size);
-        Option.map (fun ms -> (`Text "max_size", `Int ms)) max_size;
+        Option.map max_size ~f:(fun ms -> (`Text "max_size", `Int ms));
       ]
   in
   Basic { schema = `Map pairs; transform = Cbor_helpers.extract_string }
@@ -114,23 +112,21 @@ let text ?(min_size = 0) ?max_size () =
 let binary ?(min_size = 0) ?max_size () =
   if min_size < 0 then
     raise
-      (Invalid_argument
-         (Printf.sprintf "min_size=%d must be non-negative" min_size));
+      (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
   (match max_size with
   | Some ms when ms < 0 ->
-      raise
-        (Invalid_argument (Printf.sprintf "max_size=%d must be non-negative" ms))
+      raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
   | Some ms when min_size > ms ->
       raise
         (Invalid_argument
-           (Printf.sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+           (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
   | _ -> ());
   let pairs =
-    List.filter_map Fun.id
+    List.filter_opt
       [
         Some (`Text "type", `Text "binary");
         Some (`Text "min_size", `Int min_size);
-        Option.map (fun ms -> (`Text "max_size", `Int ms)) max_size;
+        Option.map max_size ~f:(fun ms -> (`Text "max_size", `Int ms));
       ]
   in
   Basic { schema = `Map pairs; transform = Cbor_helpers.extract_bytes }
@@ -185,14 +181,13 @@ let domains ?max_length () =
   (match max_length with
   | Some ml when ml < 4 || ml > 255 ->
       raise
-        (Invalid_argument
-           (Printf.sprintf "max_length=%d must be between 4 and 255" ml))
+        (Invalid_argument (sprintf "max_length=%d must be between 4 and 255" ml))
   | _ -> ());
   let pairs =
-    List.filter_map Fun.id
+    List.filter_opt
       [
         Some (`Text "type", `Text "domain");
-        Option.map (fun ml -> (`Text "max_length", `Int ml)) max_length;
+        Option.map max_length ~f:(fun ml -> (`Text "max_length", `Int ml));
       ]
   in
   Basic { schema = `Map pairs; transform = Cbor_helpers.extract_string }

--- a/lib/protocol.ml
+++ b/lib/protocol.ml
@@ -11,6 +11,9 @@
     - Message ID (high bit = reply flag)
     - Payload length *)
 
+open! Core
+module Unix = Core_unix
+
 (** Magic number identifying Hegel packets ("HEGL" in hex). *)
 let magic = 0x4845474Cl
 
@@ -25,7 +28,7 @@ let terminator = 0x0A
 let reply_bit = Int32.shift_left 1l 31
 
 (** Special message ID used when closing a channel. *)
-let close_channel_message_id = Int32.sub (Int32.shift_left 1l 31) 1l
+let close_channel_message_id = Int32.(shift_left 1l 31 - 1l)
 
 (** Special payload byte sent when closing a channel. Chosen to be invalid CBOR
     per RFC 8949 (reserved tag byte 0xFE). *)
@@ -42,9 +45,10 @@ type packet = {
 (** [equal_packet a b] returns [true] if packets [a] and [b] have identical
     fields. *)
 let equal_packet a b =
-  a.channel_id = b.channel_id
-  && a.message_id = b.message_id
-  && a.is_reply = b.is_reply && a.payload = b.payload
+  Int32.equal a.channel_id b.channel_id
+  && Int32.equal a.message_id b.message_id
+  && Bool.equal a.is_reply b.is_reply
+  && String.equal a.payload b.payload
 
 (** [pp_packet fmt p] pretty-prints packet [p] to formatter [fmt]. *)
 let pp_packet fmt p =
@@ -74,23 +78,22 @@ let compute_crc32_parts a b =
     32-bit integer at [offset] in [buf]. *)
 let pack_uint32_be buf offset value =
   Bytes.set buf offset
-    (Char.chr (Int32.to_int (Int32.shift_right_logical value 24) land 0xFF));
+    (Char.of_int_exn (Int32.to_int_exn Int32.(value lsr 24) land 0xFF));
   Bytes.set buf (offset + 1)
-    (Char.chr (Int32.to_int (Int32.shift_right_logical value 16) land 0xFF));
+    (Char.of_int_exn (Int32.to_int_exn Int32.(value lsr 16) land 0xFF));
   Bytes.set buf (offset + 2)
-    (Char.chr (Int32.to_int (Int32.shift_right_logical value 8) land 0xFF));
-  Bytes.set buf (offset + 3) (Char.chr (Int32.to_int value land 0xFF))
+    (Char.of_int_exn (Int32.to_int_exn Int32.(value lsr 8) land 0xFF));
+  Bytes.set buf (offset + 3)
+    (Char.of_int_exn (Int32.to_int_exn value land 0xFF))
 
 (** [unpack_uint32_be data offset] reads a big-endian unsigned 32-bit integer
     from [data] at [offset]. *)
 let unpack_uint32_be data offset =
-  let b0 = Int32.of_int (Char.code (Bytes.get data offset)) in
-  let b1 = Int32.of_int (Char.code (Bytes.get data (offset + 1))) in
-  let b2 = Int32.of_int (Char.code (Bytes.get data (offset + 2))) in
-  let b3 = Int32.of_int (Char.code (Bytes.get data (offset + 3))) in
-  Int32.logor
-    (Int32.logor (Int32.shift_left b0 24) (Int32.shift_left b1 16))
-    (Int32.logor (Int32.shift_left b2 8) b3)
+  let b0 = Int32.of_int_exn (Char.to_int (Bytes.get data offset)) in
+  let b1 = Int32.of_int_exn (Char.to_int (Bytes.get data (offset + 1))) in
+  let b2 = Int32.of_int_exn (Char.to_int (Bytes.get data (offset + 2))) in
+  let b3 = Int32.of_int_exn (Char.to_int (Bytes.get data (offset + 3))) in
+  Int32.((b0 lsl 24) lor (b1 lsl 16) lor (b2 lsl 8) lor b3)
 
 exception Partial_packet of string
 (** Exception raised when the connection is closed partway through reading a
@@ -104,12 +107,12 @@ exception Connection_closed of string
     [sock]. Raises {!Partial_packet} if the connection closes with no data read,
     or {!Connection_closed} if it closes after partial data. *)
 let recv_exact sock n =
-  if n = 0 then Bytes.empty
+  if n = 0 then Bytes.create 0
   else begin
     let buf = Bytes.create n in
     let rec read_all pos =
       if pos < n then begin
-        let chunk = Unix.read sock buf pos (n - pos) in
+        let chunk = Unix.read sock ~buf ~pos ~len:(n - pos) in
         if chunk = 0 then begin
           if pos > 0 then
             raise (Connection_closed "Connection closed while reading data")
@@ -137,21 +140,21 @@ let read_packet sock =
   let channel_id = unpack_uint32_be header_buf 8 in
   let raw_message_id = unpack_uint32_be header_buf 12 in
   let length = unpack_uint32_be header_buf 16 in
-  let is_reply = Int32.logand raw_message_id reply_bit <> 0l in
+  let is_reply = Int32.( <> ) Int32.(raw_message_id land reply_bit) 0l in
   let message_id =
-    if is_reply then Int32.logxor raw_message_id reply_bit else raw_message_id
+    if is_reply then Int32.(raw_message_id lxor reply_bit) else raw_message_id
   in
-  if pkt_magic <> magic then
+  if Int32.( <> ) pkt_magic magic then
     failwith
-      (Printf.sprintf "Invalid magic number: expected 0x%08lX, got 0x%08lX"
-         magic pkt_magic);
-  let payload_buf = recv_exact sock (Int32.to_int length) in
+      (sprintf "Invalid magic number: expected 0x%08lX, got 0x%08lX" magic
+         pkt_magic);
+  let payload_buf = recv_exact sock (Int32.to_int_exn length) in
   let term_buf = recv_exact sock 1 in
-  let term_byte = Char.code (Bytes.get term_buf 0) in
+  let term_byte = Char.to_int (Bytes.get term_buf 0) in
   if term_byte <> terminator then
     failwith
-      (Printf.sprintf "Invalid terminator: expected 0x%02X, got 0x%02X"
-         terminator term_byte);
+      (sprintf "Invalid terminator: expected 0x%02X, got 0x%02X" terminator
+         term_byte);
   (* Verify checksum: CRC32 over header with checksum field zeroed + payload *)
   let header_for_check = Bytes.copy header_buf in
   pack_uint32_be header_for_check 4 0l;
@@ -160,17 +163,17 @@ let read_packet sock =
       (Bytes.to_string header_for_check)
       (Bytes.to_string payload_buf)
   in
-  if computed_crc <> checksum then
+  if Int32.( <> ) computed_crc checksum then
     failwith
-      (Printf.sprintf "Checksum mismatch: expected 0x%08lX, got 0x%08lX"
-         checksum computed_crc);
+      (sprintf "Checksum mismatch: expected 0x%08lX, got 0x%08lX" checksum
+         computed_crc);
   { channel_id; message_id; is_reply; payload = Bytes.to_string payload_buf }
 
 (** [write_packet sock packet] serializes and writes [packet] to Unix file
     descriptor [sock]. *)
 let write_packet sock packet =
   let wire_message_id =
-    if packet.is_reply then Int32.logor packet.message_id reply_bit
+    if packet.is_reply then Int32.(packet.message_id lor reply_bit)
     else packet.message_id
   in
   let payload_len = String.length packet.payload in
@@ -180,7 +183,7 @@ let write_packet sock packet =
   pack_uint32_be header_buf 4 0l;
   pack_uint32_be header_buf 8 packet.channel_id;
   pack_uint32_be header_buf 12 wire_message_id;
-  pack_uint32_be header_buf 16 (Int32.of_int payload_len);
+  pack_uint32_be header_buf 16 (Int32.of_int_exn payload_len);
   let checksum =
     compute_crc32_parts (Bytes.to_string header_buf) packet.payload
   in
@@ -188,12 +191,13 @@ let write_packet sock packet =
   (* Assemble into a single buffer: header + payload + terminator *)
   let total_len = header_size + payload_len + 1 in
   let buf = Bytes.create total_len in
-  Bytes.blit header_buf 0 buf 0 header_size;
-  Bytes.blit_string packet.payload 0 buf header_size payload_len;
-  Bytes.set buf (header_size + payload_len) (Char.chr terminator);
+  Bytes.blit ~src:header_buf ~src_pos:0 ~dst:buf ~dst_pos:0 ~len:header_size;
+  Bytes.From_string.blit ~src:packet.payload ~src_pos:0 ~dst:buf
+    ~dst_pos:header_size ~len:payload_len;
+  Bytes.set buf (header_size + payload_len) (Char.of_int_exn terminator);
   let rec write_all pos =
     if pos < total_len then
-      let written = Unix.write sock buf pos (total_len - pos) in
+      let written = Unix.write sock ~buf ~pos ~len:(total_len - pos) in
       write_all (pos + written)
   in
   write_all 0

--- a/lib/protocol.mli
+++ b/lib/protocol.mli
@@ -3,6 +3,8 @@
     This module defines the binary packet format used for communication between
     the Hegel client and the Hegel server. *)
 
+module Unix = Core_unix
+
 val magic : int32
 (** Magic number identifying Hegel packets ("HEGL" in hex). *)
 
@@ -60,15 +62,15 @@ val unpack_uint32_be : bytes -> int -> int32
 (** [unpack_uint32_be data offset] reads a big-endian unsigned 32-bit integer
     from [data] at [offset]. *)
 
-val recv_exact : Unix.file_descr -> int -> bytes
+val recv_exact : Core_unix.File_descr.t -> int -> bytes
 (** [recv_exact sock n] reads exactly [n] bytes from Unix file descriptor
     [sock]. Raises {!Partial_packet} if the connection closes with no data read,
     or {!Connection_closed} if it closes after partial data. *)
 
-val read_packet : Unix.file_descr -> packet
+val read_packet : Core_unix.File_descr.t -> packet
 (** [read_packet sock] reads and parses a single packet from Unix file
     descriptor [sock]. *)
 
-val write_packet : Unix.file_descr -> packet -> unit
+val write_packet : Core_unix.File_descr.t -> packet -> unit
 (** [write_packet sock packet] serializes and writes [packet] to Unix file
     descriptor [sock]. *)

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -6,6 +6,10 @@
     The main entry point is {!run_hegel_test}, which the user calls without
     needing to manage connections or sessions directly. *)
 
+open! Core
+module Unix = Core_unix
+module Mutex = Caml_threads.Mutex
+module Thread = Caml_threads.Thread
 open Connection
 
 (** Version of hegel-core to install. *)
@@ -34,40 +38,43 @@ let uv_not_found_message =
    instead.\n\n\
    See https://hegel.dev/reference/installation for more details."
 
-(** [run_command cmd args] runs a command and returns its exit status. Output is
-    redirected to the install log file. *)
+(** [run_command_to_log cmd args log_path] runs a command and returns its exit
+    status. Output is redirected to the install log file. *)
 let run_command_to_log cmd args log_path =
   let log_fd =
-    Unix.openfile log_path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+    Unix.openfile log_path
+      ~mode:[ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ]
+      ~perm:0o644
   in
-  Fun.protect
+  Exn.protect
     ~finally:(fun () -> Unix.close log_fd)
-    (fun () ->
+    ~f:(fun () ->
       let pid =
-        Unix.create_process cmd
+        Caml_unix.create_process cmd
           (Array.of_list (cmd :: args))
-          Unix.stdin log_fd log_fd
+          Caml_unix.stdin log_fd log_fd
       in
-      let _, status = Unix.waitpid [] pid in
+      let _, status = Caml_unix.waitpid [] pid in
       status)
 
 (** [ensure_hegel_installed ()] checks for a cached hegel installation and
     installs via uv if needed. Returns the path to the hegel binary. *)
 let ensure_hegel_installed () =
-  let venv_dir = Printf.sprintf "%s/venv" hegel_server_dir in
-  let version_file = Printf.sprintf "%s/hegel-version" venv_dir in
-  let hegel_bin = Printf.sprintf "%s/bin/hegel" venv_dir in
-  let install_log = Printf.sprintf "%s/install.log" hegel_server_dir in
+  let venv_dir = sprintf "%s/venv" hegel_server_dir in
+  let version_file = sprintf "%s/hegel-version" venv_dir in
+  let hegel_bin = sprintf "%s/bin/hegel" venv_dir in
+  let install_log = sprintf "%s/install.log" hegel_server_dir in
   (* Check cached version *)
   try
-    let cached =
-      String.trim (In_channel.with_open_text version_file In_channel.input_all)
-    in
-    if cached = hegel_server_version && Sys.file_exists hegel_bin then hegel_bin
+    let cached = String.strip (In_channel.read_all version_file) in
+    if
+      String.equal cached hegel_server_version
+      && Stdlib.Sys.file_exists hegel_bin
+    then hegel_bin
     else raise Exit
   with _ ->
     (* Need to install *)
-    (try Unix.mkdir hegel_server_dir 0o755 with Unix.Unix_error _ -> ());
+    (try Unix.mkdir hegel_server_dir ~perm:0o755 with Unix.Unix_error _ -> ());
     (* Create venv *)
     let status =
       try run_command_to_log "uv" [ "venv"; "--clear"; venv_dir ] install_log
@@ -75,15 +82,12 @@ let ensure_hegel_installed () =
         failwith uv_not_found_message
     in
     (match status with
-    | Unix.WEXITED 0 -> ()
+    | Caml_unix.WEXITED 0 -> ()
     | _ ->
-        let log =
-          try In_channel.with_open_text install_log In_channel.input_all
-          with _ -> ""
-        in
-        failwith (Printf.sprintf "uv venv failed. Install log:\n%s" log));
+        let log = try In_channel.read_all install_log with _ -> "" in
+        failwith (sprintf "uv venv failed. Install log:\n%s" log));
     (* Install hegel-core *)
-    let python_path = Printf.sprintf "%s/bin/python" venv_dir in
+    let python_path = sprintf "%s/bin/python" venv_dir in
     let status =
       run_command_to_log "uv"
         [
@@ -91,47 +95,42 @@ let ensure_hegel_installed () =
           "install";
           "--python";
           python_path;
-          Printf.sprintf "hegel-core==%s" hegel_server_version;
+          sprintf "hegel-core==%s" hegel_server_version;
         ]
         install_log
     in
     (match status with
-    | Unix.WEXITED 0 -> ()
+    | Caml_unix.WEXITED 0 -> ()
     | _ ->
-        let log =
-          try In_channel.with_open_text install_log In_channel.input_all
-          with _ -> ""
-        in
+        let log = try In_channel.read_all install_log with _ -> "" in
         failwith
-          (Printf.sprintf
+          (sprintf
              "Failed to install hegel-core (version: %s). Set %s to a hegel \
               binary path to skip installation.\n\
               Install log:\n\
               %s"
              hegel_server_version hegel_server_command_env log));
-    if not (Sys.file_exists hegel_bin) then
-      failwith
-        (Printf.sprintf "hegel not found at %s after installation" hegel_bin);
+    if not (Stdlib.Sys.file_exists hegel_bin) then
+      failwith (sprintf "hegel not found at %s after installation" hegel_bin);
     (* Write version file *)
-    Out_channel.with_open_text version_file (fun oc ->
-        output_string oc hegel_server_version);
+    Out_channel.write_all version_file ~data:hegel_server_version;
     hegel_bin
 
 (** [find_hegel ()] locates the hegel binary. Checks, in order:
     - [HEGEL_SERVER_COMMAND] environment variable
     - Auto-install via uv to [.hegel/venv/] *)
 let find_hegel () =
-  match Sys.getenv_opt hegel_server_command_env with
-  | Some path when path <> "" -> path
+  match Sys.getenv hegel_server_command_env with
+  | Some path when not (String.is_empty path) -> path
   | _ -> ensure_hegel_installed ()
 
 (** [server_log_fd ()] returns a file descriptor for the server log file. *)
 let server_log_fd () =
-  (try Unix.mkdir hegel_server_dir 0o755 with Unix.Unix_error _ -> ());
+  (try Unix.mkdir hegel_server_dir ~perm:0o755 with Unix.Unix_error _ -> ());
   Unix.openfile
-    (Printf.sprintf "%s/server.log" hegel_server_dir)
-    [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ]
-    0o644
+    (sprintf "%s/server.log" hegel_server_dir)
+    ~mode:[ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ]
+    ~perm:0o644
 
 type hegel_session = {
   mutable process : int option;
@@ -163,8 +162,8 @@ let cleanup session =
   | None -> ());
   match session.process with
   | Some pid ->
-      (try Unix.kill pid Sys.sigterm with _ -> ());
-      (try ignore (Unix.waitpid [] pid) with _ -> ());
+      (try Caml_unix.kill pid Stdlib.Sys.sigterm with _ -> ());
+      (try ignore (Caml_unix.waitpid [] pid) with _ -> ());
       session.process <- None
   | None -> ()
 
@@ -174,9 +173,9 @@ let start session =
   if has_working_client session then ()
   else begin
     Mutex.lock session.lock;
-    Fun.protect
+    Exn.protect
       ~finally:(fun () -> Mutex.unlock session.lock)
-      (fun () ->
+      ~f:(fun () ->
         if not (has_working_client session) then begin
           (* Clean up any old session *)
           cleanup session;
@@ -187,7 +186,7 @@ let start session =
           let log_fd = server_log_fd () in
           (* Start hegel subprocess with --stdio *)
           let pid =
-            Unix.create_process hegel_cmd
+            Caml_unix.create_process hegel_cmd
               [| hegel_cmd; "--stdio"; "--verbosity"; "normal" |]
               child_stdin_read child_stdout_write log_fd
           in
@@ -207,12 +206,12 @@ let start session =
           ignore
             (Thread.create
                (fun () ->
-                 ignore (Unix.waitpid [] pid);
+                 ignore (Caml_unix.waitpid [] pid);
                  match session.connection with
                  | Some conn -> conn.server_exited <- true
                  | None -> ())
                ());
-          at_exit (fun () -> cleanup session)
+          Stdlib.at_exit (fun () -> cleanup session)
         end)
   end
 
@@ -225,4 +224,4 @@ let restart_session () = cleanup global_session
     provided. *)
 let run_hegel_test ?(settings = Client.default_settings ()) test_fn =
   start global_session;
-  Client.run_test (Option.get global_session.client) ~settings test_fn
+  Client.run_test (Option.value_exn global_session.client) ~settings test_fn

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -6,6 +6,8 @@
     The main entry point is {!run_hegel_test}, which the user calls without
     needing to manage connections or sessions directly. *)
 
+module Mutex = Caml_threads.Mutex
+
 val hegel_server_version : string
 (** Version of hegel-core to install. *)
 
@@ -18,7 +20,8 @@ val hegel_server_dir : string
 val uv_not_found_message : string
 (** Message shown when uv is not found. *)
 
-val run_command_to_log : string -> string list -> string -> Unix.process_status
+val run_command_to_log :
+  string -> string list -> string -> Caml_unix.process_status
 (** [run_command_to_log cmd args log_path] runs [cmd] with [args], redirecting
     stdout and stderr to [log_path]. Returns the process exit status. *)
 

--- a/test/dune
+++ b/test/dune
@@ -14,7 +14,7 @@
   test_showcase
   test_conformance_helpers
   test_derive)
- (libraries hegel alcotest unix threads.posix)
+ (libraries hegel alcotest core core_unix threads.posix)
  (foreign_stubs
   (language c)
   (names unsetenv_stubs)))
@@ -22,6 +22,6 @@
 (test
  (name test_ppx_derive)
  (modules test_ppx_derive)
- (libraries hegel alcotest unix threads.posix)
+ (libraries hegel alcotest core core_unix threads.posix)
  (preprocess
   (pps ppx_hegel_generator)))

--- a/test/test_cbor_helpers.ml
+++ b/test/test_cbor_helpers.ml
@@ -1,3 +1,4 @@
+open! Core
 open Hegel
 open Cbor_helpers
 
@@ -56,16 +57,16 @@ let test_roundtrip_list () =
   let decoded = decode (encode v) in
   let lst = extract_list decoded in
   Alcotest.(check int) "list length" 3 (List.length lst);
-  Alcotest.(check int) "list[0]" 1 (extract_int (List.nth lst 0));
-  Alcotest.(check string) "list[1]" "two" (extract_string (List.nth lst 1));
-  Alcotest.(check bool) "list[2]" true (extract_bool (List.nth lst 2))
+  Alcotest.(check int) "list[0]" 1 (extract_int (List.nth_exn lst 0));
+  Alcotest.(check string) "list[1]" "two" (extract_string (List.nth_exn lst 1));
+  Alcotest.(check bool) "list[2]" true (extract_bool (List.nth_exn lst 2))
 
 let test_roundtrip_dict () =
   let v = `Map [ (`Text "key", `Int 99) ] in
   let decoded = decode (encode v) in
   let m = extract_dict decoded in
   Alcotest.(check int) "dict length" 1 (List.length m);
-  let k, value = List.hd m in
+  let k, value = List.hd_exn m in
   Alcotest.(check string) "dict key" "key" (extract_string k);
   Alcotest.(check int) "dict value" 99 (extract_int value)
 
@@ -82,8 +83,8 @@ let test_nested_list_of_dicts () =
   let decoded = decode (encode v) in
   let lst = extract_list decoded in
   Alcotest.(check int) "list length" 2 (List.length lst);
-  let d0 = extract_dict (List.nth lst 0) in
-  let d1 = extract_dict (List.nth lst 1) in
+  let d0 = extract_dict (List.nth_exn lst 0) in
+  let d1 = extract_dict (List.nth_exn lst 1) in
   Alcotest.(check int) "d0 keys" 2 (List.length d0);
   Alcotest.(check int) "d1 keys" 2 (List.length d1)
 
@@ -98,10 +99,12 @@ let test_nested_dict_with_list_values () =
   let decoded = decode (encode v) in
   let m = extract_dict decoded in
   Alcotest.(check int) "map keys" 2 (List.length m);
-  let scores_kv = List.find (fun (k, _) -> extract_string k = "scores") m in
+  let scores_kv =
+    List.find_exn m ~f:(fun (k, _) -> String.equal (extract_string k) "scores")
+  in
   let scores = extract_list (snd scores_kv) in
   Alcotest.(check int) "scores length" 3 (List.length scores);
-  Alcotest.(check int) "score 0" 90 (extract_int (List.nth scores 0))
+  Alcotest.(check int) "score 0" 90 (extract_int (List.nth_exn scores 0))
 
 (* --- Extractor error tests --- *)
 

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -1,3 +1,6 @@
+open! Core
+module Mutex = Caml_threads.Mutex
+module Thread = Caml_threads.Thread
 open Hegel
 open Connection
 open Client
@@ -8,7 +11,9 @@ let find_cmd = Test_helpers.find_cmd
 (* ---- Unit tests for helpers that don't need a server ---- *)
 
 let test_assume_true () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let tc =
     Client.
@@ -16,10 +21,12 @@ let test_assume_true () =
   in
   assume tc true;
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 let test_assume_false_raises () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let tc =
     Client.
@@ -29,10 +36,12 @@ let test_assume_false_raises () =
   (try assume tc false with Assume_rejected -> raised := true);
   Alcotest.(check bool) "raised Assume_rejected" true !raised;
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 let test_note_when_not_final () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let tc =
     Client.
@@ -40,10 +49,12 @@ let test_note_when_not_final () =
   in
   note tc "should not print";
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 let test_note_when_final () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let tc =
     Client.
@@ -51,25 +62,27 @@ let test_note_when_final () =
   in
   note tc "test message from note";
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 let test_extract_origin_no_backtrace () =
   let origin = extract_origin (Failure "test") in
   Alcotest.(check bool) "has Failure" true (contains_substring origin "Failure")
 
 let test_extract_origin_with_backtrace () =
-  Printexc.record_backtrace true;
+  Stdlib.Printexc.record_backtrace true;
   let origin =
     try raise (Failure "test error") with exn -> extract_origin exn
   in
-  Printexc.record_backtrace false;
+  Stdlib.Printexc.record_backtrace false;
   Alcotest.(check bool) "has Failure" true (contains_substring origin "Failure");
   Alcotest.(check bool)
     "has file:line" true
     (contains_substring origin "test_client.ml")
 
 let test_start_span_when_aborted () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let data =
     Client.
@@ -78,7 +91,7 @@ let test_start_span_when_aborted () =
   start_span data;
   stop_span data;
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 let test_nested_test_raises () =
   let raised = ref false in
@@ -100,12 +113,12 @@ let test_nested_test_raises () =
     session so the new env var takes effect on the subprocess. *)
 let with_test_mode mode f =
   Session.restart_session ();
-  Unix.putenv "HEGEL_PROTOCOL_TEST_MODE" mode;
-  Fun.protect
+  Core_unix.putenv ~key:"HEGEL_PROTOCOL_TEST_MODE" ~data:mode;
+  Exn.protect
     ~finally:(fun () ->
-      Unix.putenv "HEGEL_PROTOCOL_TEST_MODE" "";
+      Core_unix.putenv ~key:"HEGEL_PROTOCOL_TEST_MODE" ~data:"";
       Session.restart_session ())
-    f
+    ~f
 
 let test_simple_passing_test () =
   Session.run_hegel_test ~settings:(Client.settings ~test_cases:5 ()) (fun tc ->
@@ -256,7 +269,7 @@ let test_start_stop_span_live () =
 (** Test: version mismatch in create_client (version too high). *)
 let test_version_mismatch () =
   let server_socket, client_socket =
-    Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
   in
   let peer_conn = Test_helpers.make_connection server_socket ~name:"Peer" () in
   let client_conn =
@@ -282,7 +295,7 @@ let test_version_mismatch () =
 (** Test: version mismatch in create_client (version too low). *)
 let test_version_mismatch_low () =
   let server_socket, client_socket =
-    Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
   in
   let peer_conn = Test_helpers.make_connection server_socket ~name:"Peer" () in
   let client_conn =
@@ -321,7 +334,7 @@ let test_multiple_interesting () =
        (fun tc ->
          let v = Hegel.draw tc (Hegel.Generators.booleans ()) in
          if v then failwith "error from Failure branch" else raise Exit)
-   with e -> raised_msg := Printexc.to_string e);
+   with e -> raised_msg := Exn.to_string e);
   Alcotest.(check bool)
     "has Multiple failures" true
     (contains_substring !raised_msg "Multiple failures")
@@ -330,7 +343,9 @@ let test_multiple_interesting () =
     return [(client, client_conn, peer_conn)]. The caller provides a peer
     function that will be run in a thread. *)
 let with_fake_server peer_fn client_fn =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let client_conn = Test_helpers.make_connection s1 ~name:"Client" () in
   let peer_conn = Test_helpers.make_connection s2 ~name:"Peer" () in
   let t_hs = Thread.create Test_helpers.handshake_via_channel peer_conn in
@@ -349,8 +364,9 @@ let accept_run_test peer_conn =
   let msg_id, msg = receive_request ctrl () in
   let pairs = Cbor_helpers.extract_dict msg in
   let test_ch_id =
-    Int32.of_int
-      (Cbor_helpers.extract_int (List.assoc (`Text "channel_id") pairs))
+    Int32.of_int_exn
+      (Cbor_helpers.extract_int
+         (List.Assoc.find_exn pairs ~equal:Poly.( = ) (`Text "channel_id")))
   in
   send_response_value ctrl msg_id `Null;
   let test_ch = connect_channel peer_conn test_ch_id ~role:"Test" () in
@@ -522,7 +538,9 @@ let test_run_test_passed_false () =
     server_exited to true, then try to receive. Should raise with
     server_crashed_message. *)
 let test_server_exited_in_pop_inbox () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   conn.server_exited <- true;
   let ch = control_channel conn in
@@ -535,7 +553,7 @@ let test_server_exited_in_pop_inbox () =
        (contains_substring msg "hegel server process has exited"));
   Alcotest.(check bool) "raised" true !raised;
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 (** Test: run_hegel_test with explicit settings parameter (covers the Some s
     branch in session.ml line 257). *)
@@ -552,15 +570,13 @@ let test_run_hegel_test_with_settings () =
 
 (** Test: find_hegel uses HEGEL_SERVER_COMMAND env var. *)
 let test_find_hegel_via_env () =
-  let orig_cmd =
-    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
-  in
-  Unix.putenv "HEGEL_SERVER_COMMAND" "/tmp/fake-hegel";
+  let orig_cmd = Sys.getenv "HEGEL_SERVER_COMMAND" in
+  Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:"/tmp/fake-hegel";
   let path = Session.find_hegel () in
   Alcotest.(check string) "path" "/tmp/fake-hegel" path;
   match orig_cmd with
-  | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
-  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" ""
+  | Some v -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:v
+  | None -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:""
 
 (** Test: session start failure (bad server command). Covers the error path when
     the hegel subprocess exits immediately without completing the handshake. *)
@@ -568,17 +584,15 @@ let test_session_start_failure () =
   let session : Session.hegel_session =
     { process = None; connection = None; client = None; lock = Mutex.create () }
   in
-  let orig_cmd =
-    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
-  in
-  Unix.putenv "HEGEL_SERVER_COMMAND" "/bin/false";
+  let orig_cmd = Sys.getenv "HEGEL_SERVER_COMMAND" in
+  Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:"/bin/false";
   let raised = ref false in
   (try Session.start session with _ -> raised := true);
   Alcotest.(check bool) "raised" true !raised;
   Session.cleanup session;
   match orig_cmd with
-  | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
-  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" ""
+  | Some v -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:v
+  | None -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:""
 
 (** Test: monitor thread detects server crash (session.ml line 231). Start a
     real session, kill the server process, verify server_exited. *)
@@ -590,9 +604,9 @@ let test_monitor_thread_detects_crash () =
   (* Kill the server process *)
   (match session.process with
   | Some pid -> (
-      Unix.kill pid Sys.sigkill;
+      Caml_unix.kill pid Stdlib.Sys.sigkill;
       (* Wait for the monitor thread to detect the crash *)
-      Unix.sleepf 0.5;
+      Caml_unix.sleepf 0.5;
       match session.connection with
       | Some conn ->
           Alcotest.(check bool)
@@ -609,11 +623,13 @@ let test_monitor_thread_detects_crash () =
     outer try/with, we'd need a non-Unix exception - but we can at least
     exercise the code path by closing the fds first and marking running=true. *)
 let test_cleanup_with_close_error () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   (* Close both fds underneath the connection *)
-  Unix.close s1;
-  Unix.close s2;
+  Core_unix.close s1;
+  Core_unix.close s2;
   (* Ensure conn.running is true so close actually tries to close fds *)
   conn.running <- true;
   let session : Session.hegel_session =
@@ -625,7 +641,7 @@ let test_cleanup_with_close_error () =
     }
   in
   Session.cleanup session;
-  Alcotest.(check bool) "cleaned up" true (session.connection = None)
+  Alcotest.(check bool) "cleaned up" true (Option.is_none session.connection)
 
 (** Test: run_hegel_test when session is None (unreachable in normal usage, but
     covers the branch). *)
@@ -640,7 +656,9 @@ let test_session_not_started () =
 
 (** Test: cleanup a session with actual resources. *)
 let test_session_cleanup_with_resources () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let session : Session.hegel_session =
     {
@@ -651,17 +669,19 @@ let test_session_cleanup_with_resources () =
     }
   in
   Session.cleanup session;
-  Alcotest.(check bool) "conn cleaned" true (session.connection = None);
-  Unix.close s2
+  Alcotest.(check bool) "conn cleaned" true (Option.is_none session.connection);
+  Core_unix.close s2
 
 (** Test: cleanup with a connection whose socket is already closed (covers error
     catch in close). *)
 let test_session_cleanup_closed_conn () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   (* Close the raw socket fd underneath, so conn.close will error *)
-  Unix.close s1;
-  Unix.close s2;
+  Core_unix.close s1;
+  Core_unix.close s2;
   let session : Session.hegel_session =
     {
       process = None;
@@ -671,14 +691,14 @@ let test_session_cleanup_closed_conn () =
     }
   in
   Session.cleanup session;
-  Alcotest.(check bool) "cleaned" true (session.connection = None)
+  Alcotest.(check bool) "cleaned" true (Option.is_none session.connection)
 
 (** Test: cleanup a session with a process (uses /bin/sleep for a real PID). *)
 let test_session_cleanup_with_process () =
   let sleep_cmd = find_cmd "sleep" in
   let pid =
-    Unix.create_process sleep_cmd [| sleep_cmd; "60" |] Unix.stdin Unix.stderr
-      Unix.stderr
+    Caml_unix.create_process sleep_cmd [| sleep_cmd; "60" |] Caml_unix.stdin
+      Caml_unix.stderr Caml_unix.stderr
   in
   let session : Session.hegel_session =
     {
@@ -689,18 +709,18 @@ let test_session_cleanup_with_process () =
     }
   in
   Session.cleanup session;
-  Alcotest.(check bool) "process cleaned" true (session.process = None)
+  Alcotest.(check bool) "process cleaned" true (Option.is_none session.process)
 
 (** Test: cleanup with already-dead process (covers kill error catch). *)
 let test_session_cleanup_dead_process () =
   (* Start a process that exits immediately *)
   let true_cmd = find_cmd "true" in
   let pid =
-    Unix.create_process true_cmd [| true_cmd |] Unix.stdin Unix.stderr
-      Unix.stderr
+    Caml_unix.create_process true_cmd [| true_cmd |] Caml_unix.stdin
+      Caml_unix.stderr Caml_unix.stderr
   in
   (* Wait for it to finish *)
-  ignore (Unix.waitpid [] pid);
+  ignore (Caml_unix.waitpid [] pid);
   let session : Session.hegel_session =
     {
       process = Some pid;
@@ -710,11 +730,13 @@ let test_session_cleanup_dead_process () =
     }
   in
   Session.cleanup session;
-  Alcotest.(check bool) "cleaned" true (session.process = None)
+  Alcotest.(check bool) "cleaned" true (Option.is_none session.process)
 
 (** Test: has_working_client with a live connection. *)
 let test_has_working_client_live () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Test" () in
   let session : Session.hegel_session =
     {
@@ -734,7 +756,7 @@ let test_has_working_client_live () =
     "has working client" true
     (Session.has_working_client session);
   close conn;
-  Unix.close s2
+  Core_unix.close s2
 
 (** Test: run_hegel_test with default parameters. *)
 let test_run_hegel_test_defaults () =
@@ -782,30 +804,28 @@ let all_ci_var_names =
     environment. *)
 let with_clean_ci_env f =
   let saved =
-    List.map (fun name -> (name, Sys.getenv_opt name)) all_ci_var_names
+    List.map all_ci_var_names ~f:(fun name -> (name, Sys.getenv name))
   in
-  List.iter (fun name -> Test_helpers.unsetenv name) all_ci_var_names;
-  Fun.protect
+  List.iter all_ci_var_names ~f:(fun name -> Test_helpers.unsetenv name);
+  Exn.protect
     ~finally:(fun () ->
-      List.iter
-        (fun (name, v) ->
+      List.iter saved ~f:(fun (name, v) ->
           match v with
-          | Some orig -> Unix.putenv name orig
-          | None -> Test_helpers.unsetenv name)
-        saved)
-    f
+          | Some orig -> Core_unix.putenv ~key:name ~data:orig
+          | None -> Test_helpers.unsetenv name))
+    ~f
 
 let test_is_in_ci_some_none_branch () =
   (* Test the (Some _, None) branch: set a var that expects any value *)
   with_clean_ci_env (fun () ->
-      Unix.putenv "HEROKU_TEST_RUN_ID" "anything";
+      Core_unix.putenv ~key:"HEROKU_TEST_RUN_ID" ~data:"anything";
       Alcotest.(check bool)
         "is_in_ci with HEROKU_TEST_RUN_ID" true (Client.is_in_ci ()))
 
 let test_is_in_ci_some_v_some_exp_branch () =
   (* Test the (Some v, Some exp) branch: set a var with matching expected value *)
   with_clean_ci_env (fun () ->
-      Unix.putenv "TF_BUILD" "true";
+      Core_unix.putenv ~key:"TF_BUILD" ~data:"true";
       Alcotest.(check bool)
         "is_in_ci with TF_BUILD=true" true (Client.is_in_ci ()))
 
@@ -815,7 +835,7 @@ let test_with_verbosity () =
   let s = Client.default_settings () |> Client.with_verbosity Client.Debug in
   Alcotest.(check bool)
     "verbosity is Debug" true
-    (s.Client.verbosity = Client.Debug)
+    (Poly.( = ) s.Client.verbosity Client.Debug)
 
 let test_with_derandomize () =
   let s = Client.default_settings () |> Client.with_derandomize true in
@@ -827,7 +847,7 @@ let test_with_database () =
   in
   Alcotest.(check bool)
     "database is Path" true
-    (s.Client.database = Client.Path "/tmp/db")
+    (Poly.( = ) s.Client.database (Client.Path "/tmp/db"))
 
 let test_with_suppress_health_check () =
   let s =
@@ -840,27 +860,31 @@ let test_with_suppress_health_check () =
     (List.length s.Client.suppress_health_check);
   Alcotest.(check bool)
     "first is Too_slow" true
-    (List.nth s.Client.suppress_health_check 0 = Client.Too_slow);
+    (Poly.( = ) (List.nth_exn s.Client.suppress_health_check 0) Client.Too_slow);
   Alcotest.(check bool)
     "second is Filter_too_much" true
-    (List.nth s.Client.suppress_health_check 1 = Client.Filter_too_much)
+    (Poly.( = )
+       (List.nth_exn s.Client.suppress_health_check 1)
+       Client.Filter_too_much)
 
 (** Test: default_settings in CI sets derandomize and disables database. *)
 let test_default_settings_in_ci () =
   with_clean_ci_env (fun () ->
-      Unix.putenv "CI" "true";
+      Core_unix.putenv ~key:"CI" ~data:"true";
       let s = Client.default_settings () in
       Alcotest.(check bool) "derandomize in CI" true s.derandomize;
       Alcotest.(check bool)
         "database disabled in CI" true
-        (s.database = Client.Disabled))
+        (Poly.( = ) s.database Client.Disabled))
 
 (** Test: default_settings outside CI sets database to Unset. *)
 let test_default_settings_not_in_ci () =
   with_clean_ci_env (fun () ->
       let s = Client.default_settings () in
       Alcotest.(check bool) "derandomize not in CI" false s.derandomize;
-      Alcotest.(check bool) "database is Unset" true (s.database = Client.Unset))
+      Alcotest.(check bool)
+        "database is Unset" true
+        (Poly.( = ) s.database Client.Unset))
 
 (** Test: settings convenience constructor. *)
 let test_settings_convenience () =
@@ -868,17 +892,17 @@ let test_settings_convenience () =
   Alcotest.(check int) "default test_cases" 100 s0.Client.test_cases;
   let s = Client.settings ~test_cases:50 () in
   Alcotest.(check int) "test_cases" 50 s.Client.test_cases;
-  Alcotest.(check bool) "seed is None" true (s.Client.seed = None);
+  Alcotest.(check bool) "seed is None" true (Option.is_none s.Client.seed);
   let s2 = Client.settings ~test_cases:10 ~seed:42 () in
   Alcotest.(check int) "test_cases" 10 s2.Client.test_cases;
-  Alcotest.(check int) "seed" 42 (Option.get s2.Client.seed)
+  Alcotest.(check int) "seed" 42 (Option.value_exn s2.Client.seed)
 
 (** Test: with_seed builder. *)
 let test_with_seed () =
   let s = Client.default_settings () |> Client.with_seed (Some 99) in
-  Alcotest.(check int) "seed" 99 (Option.get s.Client.seed);
+  Alcotest.(check int) "seed" 99 (Option.value_exn s.Client.seed);
   let s2 = Client.with_seed None s in
-  Alcotest.(check bool) "seed cleared" true (s2.Client.seed = None)
+  Alcotest.(check bool) "seed cleared" true (Option.is_none s2.Client.seed)
 
 (** Test: run_test with database_key. *)
 let test_run_test_with_database_key () =
@@ -898,35 +922,34 @@ let test_run_test_with_database_key () =
     matching version file and binary, verifying the cache hit path (lines 62-67
     in session.ml). *)
 let test_ensure_hegel_installed_cached () =
-  let orig_cwd = Sys.getcwd () in
-  let tmp_dir = Filename.temp_dir "hegel_test_cache" "" in
-  Fun.protect
+  let orig_cwd = Stdlib.Sys.getcwd () in
+  let tmp_dir = Stdlib.Filename.temp_dir "hegel_test_cache" "" in
+  Exn.protect
     ~finally:(fun () ->
-      Sys.chdir orig_cwd;
+      Stdlib.Sys.chdir orig_cwd;
       let rec rm_rf path =
-        let stat = Unix.lstat path in
-        if stat.st_kind = Unix.S_DIR then begin
-          Array.iter
-            (fun entry -> rm_rf (Filename.concat path entry))
-            (Sys.readdir path);
-          Unix.rmdir path
+        let stat = Core_unix.lstat path in
+        if Poly.( = ) stat.st_kind Core_unix.S_DIR then begin
+          Array.iter (Stdlib.Sys.readdir path) ~f:(fun entry ->
+              rm_rf (Filename.concat path entry));
+          Core_unix.rmdir path
         end
-        else Sys.remove path
+        else Stdlib.Sys.remove path
       in
       rm_rf tmp_dir)
-    (fun () ->
-      Sys.chdir tmp_dir;
+    ~f:(fun () ->
+      Stdlib.Sys.chdir tmp_dir;
       (* Create .hegel/venv/bin/ directories *)
-      Unix.mkdir ".hegel" 0o755;
-      Unix.mkdir ".hegel/venv" 0o755;
-      Unix.mkdir ".hegel/venv/bin" 0o755;
+      Core_unix.mkdir_p ".hegel";
+      Core_unix.mkdir ~perm:0o755 ".hegel/venv";
+      Core_unix.mkdir ~perm:0o755 ".hegel/venv/bin";
       (* Write the version file with the current version *)
-      Out_channel.with_open_text ".hegel/venv/hegel-version" (fun oc ->
-          output_string oc Session.hegel_server_version);
+      Out_channel.with_file ".hegel/venv/hegel-version" ~f:(fun oc ->
+          Out_channel.output_string oc Session.hegel_server_version);
       (* Create a fake hegel binary *)
-      Out_channel.with_open_text ".hegel/venv/bin/hegel" (fun oc ->
-          output_string oc "#!/bin/sh\nexit 0\n");
-      Unix.chmod ".hegel/venv/bin/hegel" 0o755;
+      Out_channel.with_file ".hegel/venv/bin/hegel" ~f:(fun oc ->
+          Out_channel.output_string oc "#!/bin/sh\nexit 0\n");
+      Core_unix.chmod ".hegel/venv/bin/hegel" ~perm:0o755;
       (* Call ensure_hegel_installed - should find the cached version *)
       let path = Session.ensure_hegel_installed () in
       Alcotest.(check string) "cached path" ".hegel/venv/bin/hegel" path)
@@ -939,17 +962,15 @@ let test_server_crash_detection () =
   let session : Session.hegel_session =
     { process = None; connection = None; client = None; lock = Mutex.create () }
   in
-  let orig_cmd =
-    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
-  in
-  Unix.putenv "HEGEL_SERVER_COMMAND" false_cmd;
-  Fun.protect
+  let orig_cmd = Sys.getenv "HEGEL_SERVER_COMMAND" in
+  Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:false_cmd;
+  Exn.protect
     ~finally:(fun () ->
       (match orig_cmd with
-      | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
-      | None -> Unix.putenv "HEGEL_SERVER_COMMAND" "");
+      | Some v -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:v
+      | None -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:"");
       Session.cleanup session)
-    (fun () ->
+    ~f:(fun () ->
       (* start will fail because /bin/false exits immediately *)
       let raised = ref false in
       (try Session.start session with _ -> raised := true);
@@ -959,7 +980,7 @@ let test_server_crash_detection () =
       match session.connection with
       | Some conn ->
           (* Give the monitor thread a moment to detect the exit *)
-          Unix.sleepf 0.1;
+          Caml_unix.sleepf 0.1;
           Alcotest.(check bool)
             "server_exited set" true
             (Connection.server_has_exited conn)
@@ -974,7 +995,7 @@ let test_is_in_ci_value_mismatch () =
   with_clean_ci_env (fun () ->
       (* Set TF_BUILD to a non-matching value -- all other CI vars are
          already unset by with_clean_ci_env *)
-      Unix.putenv "TF_BUILD" "false";
+      Core_unix.putenv ~key:"TF_BUILD" ~data:"false";
       Alcotest.(check bool)
         "is_in_ci with TF_BUILD=false" false (Client.is_in_ci ()))
 
@@ -985,7 +1006,9 @@ let test_is_in_ci_value_mismatch () =
     Data_was_exhausted path, the event loop checks server_has_exited. *)
 let test_server_crash_in_event_loop () =
   let raised_msg = ref "" in
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let client_conn = Test_helpers.make_connection s1 ~name:"Client" () in
   let peer_conn = Test_helpers.make_connection s2 ~name:"Peer" () in
   let t_hs = Thread.create Test_helpers.handshake_via_channel peer_conn in
@@ -1003,14 +1026,14 @@ let test_server_crash_in_event_loop () =
                 (`Map
                    [
                      (`Text "event", `Text "test_case");
-                     (`Text "channel_id", `Int (Int32.to_int data_ch_id));
+                     (`Text "channel_id", `Int (Int32.to_int_exn data_ch_id));
                    ])));
         (* After the client acknowledges the test_case event, set
            server_exited. The test_fn raises Data_exhausted so
            run_test_case skips mark_complete — no request/response race
            with pop_inbox_item's server_exited check. *)
         client_conn.server_exited <- true;
-        Unix.sleepf 0.5)
+        Caml_unix.sleepf 0.5)
       ()
   in
   (try
@@ -1019,7 +1042,7 @@ let test_server_crash_in_event_loop () =
        (fun _tc ->
          (* Sleep briefly to release the runtime lock, giving the peer
             thread time to set server_exited before we return. *)
-         Unix.sleepf 0.05;
+         Caml_unix.sleepf 0.05;
          raise Data_exhausted)
    with Failure msg -> raised_msg := msg);
   Thread.join t_peer;
@@ -1039,15 +1062,17 @@ let test_send_error_reply_fails_silently () =
   let client_read_fd, peer_write_fd = Unix.pipe () in
   let peer_read_fd, client_write_fd = Unix.pipe () in
   (* Close the client's write fd so error replies will fail *)
-  Unix.close client_write_fd;
+  Core_unix.close client_write_fd;
   (* Create the client connection with the broken write fd.
      We need a valid write fd for the connection constructor, so use /dev/null *)
-  let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644 in
+  let devnull =
+    Core_unix.openfile "/dev/null" ~mode:[ Core_unix.O_WRONLY ] ~perm:0o644
+  in
   let conn =
     Connection.create_connection ~read_fd:client_read_fd ~write_fd:devnull ()
   in
   (* Close the devnull fd so writes will fail *)
-  Unix.close devnull;
+  Core_unix.close devnull;
   (* From the peer side, send a non-reply packet to channel 99 (non-existent).
      The background reader will try to send an error reply, which will fail
      because devnull is closed. *)
@@ -1061,73 +1086,74 @@ let test_send_error_reply_fails_silently () =
   in
   Protocol.write_packet peer_write_fd pkt;
   (* Give the reader thread time to process the packet and attempt the error reply *)
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   (* Clean up *)
   close conn;
-  Unix.close peer_write_fd;
-  try Unix.close peer_read_fd with Unix.Unix_error _ -> ()
+  Core_unix.close peer_write_fd;
+  try Core_unix.close peer_read_fd with Core_unix.Unix_error _ -> ()
 
 (** Test: run_command_to_log runs a command and redirects output to a log file.
 *)
 let test_run_command_to_log () =
-  let log_path = Filename.temp_file "hegel_test_cmd" ".log" in
-  Fun.protect
-    ~finally:(fun () -> try Sys.remove log_path with _ -> ())
-    (fun () ->
+  let log_path = Stdlib.Filename.temp_file "hegel_test_cmd" ".log" in
+  Exn.protect
+    ~finally:(fun () -> try Stdlib.Sys.remove log_path with _ -> ())
+    ~f:(fun () ->
       let echo_cmd = find_cmd "echo" in
       let status =
         Session.run_command_to_log echo_cmd [ "hello world" ] log_path
       in
-      Alcotest.(check bool) "exit 0" true (status = Unix.WEXITED 0);
-      let contents = In_channel.with_open_text log_path In_channel.input_all in
+      Alcotest.(check bool)
+        "exit 0" true
+        (Poly.( = ) status (Caml_unix.WEXITED 0));
+      let contents = In_channel.read_all log_path in
       Alcotest.(check bool)
         "has output" true
         (contains_substring contents "hello world"))
 
 (** Test: run_command_to_log with a failing command. *)
 let test_run_command_to_log_fail () =
-  let log_path = Filename.temp_file "hegel_test_cmd" ".log" in
-  Fun.protect
-    ~finally:(fun () -> try Sys.remove log_path with _ -> ())
-    (fun () ->
+  let log_path = Stdlib.Filename.temp_file "hegel_test_cmd" ".log" in
+  Exn.protect
+    ~finally:(fun () -> try Stdlib.Sys.remove log_path with _ -> ())
+    ~f:(fun () ->
       let false_cmd = find_cmd "false" in
       let status = Session.run_command_to_log false_cmd [] log_path in
       Alcotest.(check bool)
         "non-zero exit" true
-        (match status with Unix.WEXITED 0 -> false | _ -> true))
+        (match status with Caml_unix.WEXITED 0 -> false | _ -> true))
 
 (** Test: ensure_hegel_installed version mismatch triggers reinstall. Create a
     cached venv with wrong version; since uv is available it will try to
     reinstall. We expect it to either succeed (if network is available) or fail
     with an install error. Either way the version mismatch path is exercised. *)
 let test_ensure_hegel_installed_version_mismatch () =
-  let orig_cwd = Sys.getcwd () in
-  let tmp_dir = Filename.temp_dir "hegel_test_mismatch" "" in
-  Fun.protect
+  let orig_cwd = Stdlib.Sys.getcwd () in
+  let tmp_dir = Stdlib.Filename.temp_dir "hegel_test_mismatch" "" in
+  Exn.protect
     ~finally:(fun () ->
-      Sys.chdir orig_cwd;
+      Stdlib.Sys.chdir orig_cwd;
       let rec rm_rf path =
-        let stat = Unix.lstat path in
-        if stat.st_kind = Unix.S_DIR then begin
-          Array.iter
-            (fun entry -> rm_rf (Filename.concat path entry))
-            (Sys.readdir path);
-          Unix.rmdir path
+        let stat = Core_unix.lstat path in
+        if Poly.( = ) stat.st_kind Core_unix.S_DIR then begin
+          Array.iter (Stdlib.Sys.readdir path) ~f:(fun entry ->
+              rm_rf (Filename.concat path entry));
+          Core_unix.rmdir path
         end
-        else Sys.remove path
+        else Stdlib.Sys.remove path
       in
       rm_rf tmp_dir)
-    (fun () ->
-      Sys.chdir tmp_dir;
+    ~f:(fun () ->
+      Stdlib.Sys.chdir tmp_dir;
       (* Create .hegel/venv/bin/ directories with wrong version *)
-      Unix.mkdir ".hegel" 0o755;
-      Unix.mkdir ".hegel/venv" 0o755;
-      Unix.mkdir ".hegel/venv/bin" 0o755;
-      Out_channel.with_open_text ".hegel/venv/hegel-version" (fun oc ->
-          output_string oc "0.0.0-wrong");
-      Out_channel.with_open_text ".hegel/venv/bin/hegel" (fun oc ->
-          output_string oc "#!/bin/sh\nexit 0\n");
-      Unix.chmod ".hegel/venv/bin/hegel" 0o755;
+      Core_unix.mkdir_p ".hegel";
+      Core_unix.mkdir ~perm:0o755 ".hegel/venv";
+      Core_unix.mkdir ~perm:0o755 ".hegel/venv/bin";
+      Out_channel.with_file ".hegel/venv/hegel-version" ~f:(fun oc ->
+          Out_channel.output_string oc "0.0.0-wrong");
+      Out_channel.with_file ".hegel/venv/bin/hegel" ~f:(fun oc ->
+          Out_channel.output_string oc "#!/bin/sh\nexit 0\n");
+      Core_unix.chmod ".hegel/venv/bin/hegel" ~perm:0o755;
       (* Call ensure_hegel_installed - version won't match, so it will try
          to reinstall via uv. This will fail (wrong package version or
          network issues) but exercises the version mismatch path. *)
@@ -1146,30 +1172,29 @@ let test_ensure_hegel_installed_version_mismatch () =
     set PATH to empty so uv can't be found, and ensure no cached version exists.
     Should raise with uv_not_found_message. *)
 let test_ensure_hegel_installed_uv_not_found () =
-  let orig_cwd = Sys.getcwd () in
-  let tmp_dir = Filename.temp_dir "hegel_test_no_uv" "" in
-  let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
-  Fun.protect
+  let orig_cwd = Stdlib.Sys.getcwd () in
+  let tmp_dir = Stdlib.Filename.temp_dir "hegel_test_no_uv" "" in
+  let orig_path = Sys.getenv "PATH" in
+  Exn.protect
     ~finally:(fun () ->
-      Sys.chdir orig_cwd;
+      Stdlib.Sys.chdir orig_cwd;
       (match orig_path with
-      | Some p -> Unix.putenv "PATH" p
-      | None -> Unix.putenv "PATH" "");
+      | Some p -> Core_unix.putenv ~key:"PATH" ~data:p
+      | None -> Core_unix.putenv ~key:"PATH" ~data:"");
       let rec rm_rf path =
-        let stat = Unix.lstat path in
-        if stat.st_kind = Unix.S_DIR then begin
-          Array.iter
-            (fun entry -> rm_rf (Filename.concat path entry))
-            (Sys.readdir path);
-          Unix.rmdir path
+        let stat = Core_unix.lstat path in
+        if Poly.( = ) stat.st_kind Core_unix.S_DIR then begin
+          Array.iter (Stdlib.Sys.readdir path) ~f:(fun entry ->
+              rm_rf (Filename.concat path entry));
+          Core_unix.rmdir path
         end
-        else Sys.remove path
+        else Stdlib.Sys.remove path
       in
       rm_rf tmp_dir)
-    (fun () ->
-      Sys.chdir tmp_dir;
+    ~f:(fun () ->
+      Stdlib.Sys.chdir tmp_dir;
       (* Set PATH to empty so uv won't be found *)
-      Unix.putenv "PATH" "";
+      Core_unix.putenv ~key:"PATH" ~data:"";
       let raised_msg = ref "" in
       (try ignore (Session.ensure_hegel_installed ())
        with Failure msg -> raised_msg := msg);
@@ -1187,7 +1212,7 @@ let create_fake_uv dir ~venv_exit ~pip_exit ~work_dir ?(delete_log = false) () =
   let rm_log =
     if delete_log then Printf.sprintf "rm -f \"%s\"\n" install_log else ""
   in
-  Out_channel.with_open_text uv_path (fun oc ->
+  Out_channel.with_file uv_path ~f:(fun oc ->
       Printf.fprintf oc
         "#!/bin/sh\n\
          case \"$1\" in\n\
@@ -1207,38 +1232,38 @@ let create_fake_uv dir ~venv_exit ~pip_exit ~work_dir ?(delete_log = false) () =
         rm_log venv_exit
         (Filename.dirname hegel_bin)
         hegel_bin hegel_bin rm_log pip_exit);
-  Unix.chmod uv_path 0o755
+  Core_unix.chmod uv_path ~perm:0o755
 
 (** Helper: run ensure_hegel_installed in a temp dir with a fake uv. *)
 let with_fake_uv_env ~venv_exit ~pip_exit ?(delete_log = false) f =
-  let orig_cwd = Sys.getcwd () in
-  let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
-  let tmp_dir = Filename.temp_dir "hegel_test_fakeuv" "" in
+  let orig_cwd = Stdlib.Sys.getcwd () in
+  let orig_path = Sys.getenv "PATH" in
+  let tmp_dir = Stdlib.Filename.temp_dir "hegel_test_fakeuv" "" in
   let fake_bin_dir = Filename.concat tmp_dir "bin" in
   let work_dir = Filename.concat tmp_dir "work" in
-  Unix.mkdir fake_bin_dir 0o755;
-  Unix.mkdir work_dir 0o755;
+  Core_unix.mkdir ~perm:0o755 fake_bin_dir;
+  Core_unix.mkdir ~perm:0o755 work_dir;
   create_fake_uv fake_bin_dir ~venv_exit ~pip_exit ~work_dir ~delete_log ();
-  Fun.protect
+  Exn.protect
     ~finally:(fun () ->
-      Sys.chdir orig_cwd;
+      Stdlib.Sys.chdir orig_cwd;
       (match orig_path with
-      | Some p -> Unix.putenv "PATH" p
-      | None -> Unix.putenv "PATH" "");
+      | Some p -> Core_unix.putenv ~key:"PATH" ~data:p
+      | None -> Core_unix.putenv ~key:"PATH" ~data:"");
       let rec rm_rf path =
-        let stat = Unix.lstat path in
-        if stat.st_kind = Unix.S_DIR then begin
-          Array.iter
-            (fun entry -> rm_rf (Filename.concat path entry))
-            (Sys.readdir path);
-          Unix.rmdir path
+        let stat = Core_unix.lstat path in
+        if Poly.( = ) stat.st_kind Core_unix.S_DIR then begin
+          Array.iter (Stdlib.Sys.readdir path) ~f:(fun entry ->
+              rm_rf (Filename.concat path entry));
+          Core_unix.rmdir path
         end
-        else Sys.remove path
+        else Stdlib.Sys.remove path
       in
       try rm_rf tmp_dir with _ -> ())
-    (fun () ->
-      Sys.chdir work_dir;
-      Unix.putenv "PATH" (Printf.sprintf "%s:/bin:/usr/bin" fake_bin_dir);
+    ~f:(fun () ->
+      Stdlib.Sys.chdir work_dir;
+      Core_unix.putenv ~key:"PATH"
+        ~data:(Printf.sprintf "%s:/bin:/usr/bin" fake_bin_dir);
       f ())
 
 (** Test: ensure_hegel_installed success path with fake uv. *)
@@ -1289,15 +1314,15 @@ let test_ensure_installed_pip_fails_no_log () =
 
 (** Test: ensure_hegel_installed when hegel binary not found after install. *)
 let test_ensure_installed_binary_missing () =
-  let orig_cwd = Sys.getcwd () in
-  let orig_path = try Some (Sys.getenv "PATH") with Not_found -> None in
-  let tmp_dir = Filename.temp_dir "hegel_test_nobin" "" in
+  let orig_cwd = Stdlib.Sys.getcwd () in
+  let orig_path = Sys.getenv "PATH" in
+  let tmp_dir = Stdlib.Filename.temp_dir "hegel_test_nobin" "" in
   let fake_bin_dir = Filename.concat tmp_dir "bin" in
-  Unix.mkdir fake_bin_dir 0o755;
+  Core_unix.mkdir ~perm:0o755 fake_bin_dir;
   (* Create a fake uv that succeeds but does NOT create the hegel binary *)
   let uv_path = Filename.concat fake_bin_dir "uv" in
-  Out_channel.with_open_text uv_path (fun oc ->
-      output_string oc
+  Out_channel.with_file uv_path ~f:(fun oc ->
+      Out_channel.output_string oc
         "#!/bin/sh\n\
          if [ \"$1\" = \"venv\" ]; then\n\
         \  mkdir -p \"$3/bin\"\n\
@@ -1308,29 +1333,29 @@ let test_ensure_installed_binary_missing () =
         \  exit 0\n\
          fi\n\
          exit 1\n");
-  Unix.chmod uv_path 0o755;
-  Fun.protect
+  Core_unix.chmod uv_path ~perm:0o755;
+  Exn.protect
     ~finally:(fun () ->
-      Sys.chdir orig_cwd;
+      Stdlib.Sys.chdir orig_cwd;
       (match orig_path with
-      | Some p -> Unix.putenv "PATH" p
-      | None -> Unix.putenv "PATH" "");
+      | Some p -> Core_unix.putenv ~key:"PATH" ~data:p
+      | None -> Core_unix.putenv ~key:"PATH" ~data:"");
       let rec rm_rf path =
-        let stat = Unix.lstat path in
-        if stat.st_kind = Unix.S_DIR then begin
-          Array.iter
-            (fun entry -> rm_rf (Filename.concat path entry))
-            (Sys.readdir path);
-          Unix.rmdir path
+        let stat = Core_unix.lstat path in
+        if Poly.( = ) stat.st_kind Core_unix.S_DIR then begin
+          Array.iter (Stdlib.Sys.readdir path) ~f:(fun entry ->
+              rm_rf (Filename.concat path entry));
+          Core_unix.rmdir path
         end
-        else Sys.remove path
+        else Stdlib.Sys.remove path
       in
       try rm_rf tmp_dir with _ -> ())
-    (fun () ->
+    ~f:(fun () ->
       let work_dir = Filename.concat tmp_dir "work" in
-      Unix.mkdir work_dir 0o755;
-      Sys.chdir work_dir;
-      Unix.putenv "PATH" (Printf.sprintf "%s:/bin:/usr/bin" fake_bin_dir);
+      Core_unix.mkdir ~perm:0o755 work_dir;
+      Stdlib.Sys.chdir work_dir;
+      Core_unix.putenv ~key:"PATH"
+        ~data:(Printf.sprintf "%s:/bin:/usr/bin" fake_bin_dir);
       let raised_msg = ref "" in
       (try ignore (Session.ensure_hegel_installed ())
        with Failure msg -> raised_msg := msg);
@@ -1341,58 +1366,51 @@ let test_ensure_installed_binary_missing () =
 (** Test: find_hegel fallthrough to ensure_hegel_installed. *)
 let test_find_hegel_fallthrough_to_install () =
   with_fake_uv_env ~venv_exit:0 ~pip_exit:0 (fun () ->
-      let orig_cmd =
-        try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
-      in
+      let orig_cmd = Sys.getenv "HEGEL_SERVER_COMMAND" in
       Test_helpers.unsetenv "HEGEL_SERVER_COMMAND";
-      Fun.protect
+      Exn.protect
         ~finally:(fun () ->
           match orig_cmd with
-          | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
+          | Some v -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:v
           | None -> Test_helpers.unsetenv "HEGEL_SERVER_COMMAND")
-        (fun () ->
+        ~f:(fun () ->
           let path = Session.find_hegel () in
           Alcotest.(check bool) "found hegel" true (String.length path > 0)))
 
 let test_find_hegel_auto_install () =
-  let orig_cmd =
-    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
-  in
-  Unix.putenv "HEGEL_SERVER_COMMAND" "";
+  let orig_cmd = Sys.getenv "HEGEL_SERVER_COMMAND" in
+  Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:"";
   let path = Session.find_hegel () in
   Alcotest.(check bool) "found hegel" true (String.length path > 0);
   match orig_cmd with
-  | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
-  | None -> Unix.putenv "HEGEL_SERVER_COMMAND" ""
+  | Some v -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:v
+  | None -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:""
 
 (** Test: session start creates .hegel dir for server log when it doesn't exist.
     Covers the mkdir success path in server_log_fd (session.ml). *)
 let test_session_start_creates_hegel_dir () =
-  let orig_cwd = Sys.getcwd () in
-  let orig_cmd =
-    try Some (Sys.getenv "HEGEL_SERVER_COMMAND") with Not_found -> None
-  in
-  let tmp_dir = Filename.temp_dir "hegel_test_logdir" "" in
-  Fun.protect
+  let orig_cwd = Stdlib.Sys.getcwd () in
+  let orig_cmd = Sys.getenv "HEGEL_SERVER_COMMAND" in
+  let tmp_dir = Stdlib.Filename.temp_dir "hegel_test_logdir" "" in
+  Exn.protect
     ~finally:(fun () ->
-      Sys.chdir orig_cwd;
+      Stdlib.Sys.chdir orig_cwd;
       (match orig_cmd with
-      | Some v -> Unix.putenv "HEGEL_SERVER_COMMAND" v
-      | None -> Unix.putenv "HEGEL_SERVER_COMMAND" "");
+      | Some v -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:v
+      | None -> Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:"");
       let rec rm_rf path =
-        let stat = Unix.lstat path in
-        if stat.st_kind = Unix.S_DIR then begin
-          Array.iter
-            (fun entry -> rm_rf (Filename.concat path entry))
-            (Sys.readdir path);
-          Unix.rmdir path
+        let stat = Core_unix.lstat path in
+        if Poly.( = ) stat.st_kind Core_unix.S_DIR then begin
+          Array.iter (Stdlib.Sys.readdir path) ~f:(fun entry ->
+              rm_rf (Filename.concat path entry));
+          Core_unix.rmdir path
         end
-        else Sys.remove path
+        else Stdlib.Sys.remove path
       in
       try rm_rf tmp_dir with _ -> ())
-    (fun () ->
-      Sys.chdir tmp_dir;
-      Unix.putenv "HEGEL_SERVER_COMMAND" "/bin/false";
+    ~f:(fun () ->
+      Stdlib.Sys.chdir tmp_dir;
+      Core_unix.putenv ~key:"HEGEL_SERVER_COMMAND" ~data:"/bin/false";
       let session : Session.hegel_session =
         {
           process = None;
@@ -1405,7 +1423,7 @@ let test_session_start_creates_hegel_dir () =
       Session.cleanup session;
       Alcotest.(check bool)
         ".hegel dir created" true
-        (Sys.file_exists ".hegel" && Sys.is_directory ".hegel"))
+        (Stdlib.Sys.file_exists ".hegel" && Stdlib.Sys.is_directory ".hegel"))
 
 (* ---- Session lifecycle ---- *)
 

--- a/test/test_connection.ml
+++ b/test/test_connection.ml
@@ -1,3 +1,7 @@
+open! Core
+module Unix = Core_unix
+module Thread = Caml_threads.Thread
+module Mutex = Caml_threads.Mutex
 open Hegel
 open Protocol
 open Connection
@@ -121,9 +125,9 @@ let test_channel_ids_are_odd_for_client () =
   Alcotest.(check int32) "ch2 id" 5l ch2.channel_id;
   Alcotest.(check int32) "ch3 id" 7l ch3.channel_id;
   (* All odd *)
-  Alcotest.(check bool) "ch1 odd" true (Int32.rem ch1.channel_id 2l = 1l);
-  Alcotest.(check bool) "ch2 odd" true (Int32.rem ch2.channel_id 2l = 1l);
-  Alcotest.(check bool) "ch3 odd" true (Int32.rem ch3.channel_id 2l = 1l);
+  Alcotest.(check bool) "ch1 odd" true Int32.(equal (rem ch1.channel_id 2l) 1l);
+  Alcotest.(check bool) "ch2 odd" true Int32.(equal (rem ch2.channel_id 2l) 1l);
+  Alcotest.(check bool) "ch3 odd" true Int32.(equal (rem ch3.channel_id 2l) 1l);
   close client_conn;
   close peer_conn
 
@@ -287,11 +291,15 @@ let test_request_response () =
              let msg_id, message = receive_request ch () in
              let x =
                Cbor_helpers.extract_int
-                 (List.assoc (`Text "x") (Cbor_helpers.extract_dict message))
+                 (List.Assoc.find_exn
+                    (Cbor_helpers.extract_dict message)
+                    ~equal:Poly.( = ) (`Text "x"))
              in
              let y =
                Cbor_helpers.extract_int
-                 (List.assoc (`Text "y") (Cbor_helpers.extract_dict message))
+                 (List.Assoc.find_exn
+                    (Cbor_helpers.extract_dict message)
+                    ~equal:Poly.( = ) (`Text "y"))
              in
              send_response_value ch msg_id
                (`Map [ (`Text "sum", `Int (x + y)) ])
@@ -308,7 +316,9 @@ let test_request_response () =
   in
   let sum =
     Cbor_helpers.extract_int
-      (List.assoc (`Text "sum") (Cbor_helpers.extract_dict result))
+      (List.Assoc.find_exn
+         (Cbor_helpers.extract_dict result)
+         ~equal:Poly.( = ) (`Text "sum"))
   in
   Alcotest.(check int) "sum" 5 sum;
   close client_conn;
@@ -361,7 +371,9 @@ let test_pending_request_caching () =
             let msg_id, message = receive_request ch () in
             let v =
               Cbor_helpers.extract_int
-                (List.assoc (`Text "value") (Cbor_helpers.extract_dict message))
+                (List.Assoc.find_exn
+                   (Cbor_helpers.extract_dict message)
+                   ~equal:Poly.( = ) (`Text "value"))
             in
             send_response_value ch msg_id (`Int (v * 2))
           done
@@ -421,17 +433,16 @@ let test_duplicate_response_error () =
   let conn = make_connection s1 ~name:"Test" () in
   let ch = control_channel conn in
   (* Put a response in the responses dict directly *)
-  Hashtbl.replace ch.responses 42l "first";
+  Hashtbl.set ch.responses ~key:42l ~data:"first";
   (* Now try to process another reply with same ID *)
-  Queue.push
+  Queue.enqueue ch.inbox.queue
     (Pkt
        {
          channel_id = 0l;
          message_id = 42l;
          is_reply = true;
          payload = "second";
-       })
-    ch.inbox.queue;
+       });
   let raised = ref false in
   (try process_one_message ch ~timeout:0.1 ()
    with Failure msg ->
@@ -448,7 +459,7 @@ let test_shutdown_in_inbox () =
   let s1, _s2 = make_socket_pair () in
   let conn = make_connection s1 ~name:"Test" () in
   let ch = control_channel conn in
-  Queue.push Shutdown ch.inbox.queue;
+  Queue.enqueue ch.inbox.queue Shutdown;
   let raised = ref false in
   (try ignore (receive_request ch ~timeout:0.1 ())
    with Failure msg ->
@@ -491,10 +502,10 @@ let test_message_to_dead_channel () =
   let ch_peer = connect_channel peer_conn ch_client.channel_id () in
   close_channel ch_client;
   (* Give time for close to be received *)
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   (* Now send a request to the dead channel from peer *)
   ignore (send_request ch_peer (`Map [ (`Text "test", `Text "data") ]));
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   close peer_conn;
   close client_conn
 
@@ -522,10 +533,10 @@ let test_close_channel_creates_dead_channel () =
   ignore result;
   Thread.join t;
   (* The channel should be dead on peer side *)
-  let dead = Hashtbl.find peer_conn.channels client_ch.channel_id in
-  (match dead with
-  | Dead _ -> Alcotest.(check bool) "is dead" true true
-  | Live _ -> Alcotest.fail "expected dead channel");
+  (match Hashtbl.find peer_conn.channels client_ch.channel_id with
+  | Some (Dead _) -> Alcotest.(check bool) "is dead" true true
+  | Some (Live _) -> Alcotest.fail "expected dead channel"
+  | None -> Alcotest.fail "expected channel entry");
   close client_conn;
   close peer_conn
 
@@ -541,10 +552,14 @@ let test_close_channel_creates_dead_channel_with_connect () =
         let msg_id, msg = receive_request ch () in
         let channel_id =
           Cbor_helpers.extract_int
-            (List.assoc (`Text "channel") (Cbor_helpers.extract_dict msg))
+            (List.Assoc.find_exn
+               (Cbor_helpers.extract_dict msg)
+               ~equal:Poly.( = ) (`Text "channel"))
         in
         ignore
-          (connect_channel peer_conn (Int32.of_int channel_id) ~role:"Hello" ());
+          (connect_channel peer_conn
+             (Int32.of_int_exn channel_id)
+             ~role:"Hello" ());
         send_response_value ch msg_id (`Text "Ok");
         let msg_id2, _ = receive_request ch () in
         send_response_value ch msg_id2 (`Text "Ok"))
@@ -556,21 +571,22 @@ let test_close_channel_creates_dead_channel_with_connect () =
     pending_get
       (request
          (control_channel client_conn)
-         (`Map [ (`Text "channel", `Int (Int32.to_int client_ch.channel_id)) ]))
+         (`Map
+            [ (`Text "channel", `Int (Int32.to_int_exn client_ch.channel_id)) ]))
   in
   ignore r1;
   close_channel client_ch;
   let r2 = pending_get (request (control_channel client_conn) (`Map [])) in
   ignore r2;
   Thread.join t;
-  let dead = Hashtbl.find peer_conn.channels client_ch.channel_id in
-  (match dead with
-  | Dead d ->
+  (match Hashtbl.find peer_conn.channels client_ch.channel_id with
+  | Some (Dead d) ->
       Alcotest.(check bool) "is dead" true true;
       Alcotest.(check bool)
         "name has Hello" true
         (contains_substring d.name "Hello")
-  | Live _ -> Alcotest.fail "expected dead channel");
+  | Some (Live _) -> Alcotest.fail "expected dead channel"
+  | None -> Alcotest.fail "expected channel entry");
   close client_conn;
   close peer_conn
 
@@ -588,7 +604,7 @@ let test_reader_loop_clean_exit () =
   (* Send a packet from client *)
   ignore (send_request ch_client (`Map [ (`Text "test", `Text "data") ]));
   (* Background reader handles message dispatch automatically *)
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   close client_conn;
   close peer_conn
 
@@ -598,9 +614,8 @@ let test_process_reply_packet () =
   let s1, _s2 = make_socket_pair () in
   let conn = make_connection s1 ~name:"Test" () in
   let ch = control_channel conn in
-  Queue.push
-    (Pkt { channel_id = 0l; message_id = 7l; is_reply = true; payload = "ok" })
-    ch.inbox.queue;
+  Queue.enqueue ch.inbox.queue
+    (Pkt { channel_id = 0l; message_id = 7l; is_reply = true; payload = "ok" });
   process_one_message ch ~timeout:0.1 ();
   let resp = receive_response_raw ch 7l ~timeout:0.1 () in
   Alcotest.(check string) "response" "ok" resp;
@@ -610,9 +625,8 @@ let test_process_request_packet () =
   let s1, _s2 = make_socket_pair () in
   let conn = make_connection s1 ~name:"Test" () in
   let ch = control_channel conn in
-  Queue.push
-    (Pkt { channel_id = 0l; message_id = 3l; is_reply = false; payload = "req" })
-    ch.inbox.queue;
+  Queue.enqueue ch.inbox.queue
+    (Pkt { channel_id = 0l; message_id = 3l; is_reply = false; payload = "req" });
   let msg_id, payload = receive_request_raw ch ~timeout:0.1 () in
   Alcotest.(check int32) "msg_id" 3l msg_id;
   Alcotest.(check string) "payload" "req" payload;
@@ -625,7 +639,7 @@ let test_debug_mode_recv () =
   let conn = make_connection s1 ~name:"DebugTest" ~debug:true () in
   write_packet s2
     { channel_id = 0l; message_id = 1l; is_reply = false; payload = "hello" };
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   close conn
 
 let test_debug_close_channel_recv () =
@@ -640,9 +654,9 @@ let test_debug_close_channel_recv () =
       payload = close_channel_payload;
     };
   (* Background reader processes the packet automatically *)
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   (* Check it created a dead channel *)
-  (match Hashtbl.find_opt conn.channels 999l with
+  (match Hashtbl.find conn.channels 999l with
   | Some (Dead d) ->
       Alcotest.(check bool) "dead channel" true true;
       Alcotest.(check string) "name" "Never opened!" d.name
@@ -744,8 +758,8 @@ let test_debug_close_already_dead_channel () =
   let s1, s2 = make_socket_pair () in
   let conn = make_connection s1 ~name:"Server" ~debug:true () in
   (* Manually insert a Dead entry for channel 50 *)
-  Hashtbl.replace conn.channels 50l
-    (Dead { channel_id = 50l; name = "OldDead" });
+  Hashtbl.set conn.channels ~key:50l
+    ~data:(Dead { channel_id = 50l; name = "OldDead" });
   (* Send a close packet for channel 50 from the other end *)
   write_packet s2
     {
@@ -755,8 +769,8 @@ let test_debug_close_already_dead_channel () =
       payload = close_channel_payload;
     };
   (* Background reader processes the packets automatically *)
-  Unix.sleepf 0.1;
-  (match Hashtbl.find_opt conn.channels 50l with
+  Caml_unix.sleepf 0.1;
+  (match Hashtbl.find conn.channels 50l with
   | Some (Dead d) ->
       Alcotest.(check string) "dead name preserved" "OldDead" d.name
   | _ -> Alcotest.fail "expected Dead entry with preserved name");
@@ -778,9 +792,9 @@ let test_debug_close_existing_live_channel () =
   close_channel ch_client;
   (* Background reader processes the close packet in debug mode *)
   let ch_id = ch_client.channel_id in
-  Unix.sleepf 0.1;
+  Caml_unix.sleepf 0.1;
   (* Check the dead entry has the Live channel's name *)
-  (match Hashtbl.find_opt peer_conn.channels ch_id with
+  (match Hashtbl.find peer_conn.channels ch_id with
   | Some (Dead d) ->
       Alcotest.(check bool)
         "dead name has LiveChSrv" true
@@ -799,8 +813,8 @@ let test_message_to_dead_channel_in_reader () =
   let ch_client = new_channel client_conn ~role:"WillDie" () in
   let ch_id = ch_client.channel_id in
   (* Manually insert a Dead entry on peer side *)
-  Hashtbl.replace peer_conn.channels ch_id
-    (Dead { channel_id = ch_id; name = "DeadCh" });
+  Hashtbl.set peer_conn.channels ~key:ch_id
+    ~data:(Dead { channel_id = ch_id; name = "DeadCh" });
   (* Send a non-reply packet to the dead channel from client side *)
   send_packet client_conn
     {
@@ -900,13 +914,12 @@ let test_process_one_message_default_timeout () =
   let s1, _s2 = make_socket_pair () in
   let conn = make_connection s1 ~name:"Test" () in
   let ch = control_channel conn in
-  Queue.push
+  Queue.enqueue ch.inbox.queue
     (Pkt
-       { channel_id = 0l; message_id = 1l; is_reply = false; payload = "test" })
-    ch.inbox.queue;
+       { channel_id = 0l; message_id = 1l; is_reply = false; payload = "test" });
   (* Call process_one_message without ~timeout to hit the default *)
   process_one_message ch ();
-  let pkt = Queue.pop ch.requests in
+  let pkt = Queue.dequeue_exn ch.requests in
   Alcotest.(check string) "payload" "test" pkt.payload;
   close conn
 
@@ -914,7 +927,8 @@ let test_process_one_message_default_timeout () =
 let test_control_channel_failure () =
   let s1, s2 = make_socket_pair () in
   let conn = make_connection s1 ~name:"Test" () in
-  Hashtbl.replace conn.channels 0l (Dead { channel_id = 0l; name = "Control" });
+  Hashtbl.set conn.channels ~key:0l
+    ~data:(Dead { channel_id = 0l; name = "Control" });
   let raised = ref false in
   (try ignore (control_channel conn) with Failure _ -> raised := true);
   Alcotest.(check bool) "raised" true !raised;

--- a/test/test_generators_core.ml
+++ b/test/test_generators_core.ml
@@ -116,7 +116,9 @@ let test_max_filter_attempts () =
   Alcotest.(check int) "max attempts" 3 max_filter_attempts
 
 let dummy_data () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Dummy" () in
   let data =
     Client.
@@ -171,7 +173,9 @@ let test_discardable_group_exception () =
 
 (** Test: collection_more raises Data_exhausted on StopTest (socketpair). *)
 let test_collection_more_stoptest () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Client" () in
   let peer_conn = Test_helpers.make_connection s2 ~name:"Peer" () in
   let t_hs = Thread.create Test_helpers.handshake_via_channel peer_conn in
@@ -205,7 +209,9 @@ let test_collection_more_stoptest () =
 
 (** Test: collection_reject sends command when not finished (socketpair). *)
 let test_collection_reject_live () =
-  let s1, s2 = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let s1, s2 =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   let conn = Test_helpers.make_connection s1 ~name:"Client" () in
   let peer_conn = Test_helpers.make_connection s2 ~name:"Peer" () in
   let t_hs = Thread.create Test_helpers.handshake_via_channel peer_conn in

--- a/test/test_helpers.ml
+++ b/test/test_helpers.ml
@@ -4,6 +4,10 @@ external unsetenv : string -> unit = "caml_unsetenv"
 (** [unsetenv name] removes the environment variable [name] from the process
     environment. Uses the POSIX [unsetenv(3)] function via a C stub. *)
 
+open! Core
+module Unix = Core_unix
+module Mutex = Caml_threads.Mutex
+module Thread = Caml_threads.Thread
 open Hegel
 
 (** [contains_substring s sub] returns [true] if [sub] appears anywhere in [s].
@@ -14,14 +18,15 @@ let contains_substring s sub =
   else
     let rec check i =
       if i > slen - sublen then false
-      else if String.sub s i sublen = sub then true
+      else if String.equal (String.sub s ~pos:i ~len:sublen) sub then true
       else check (i + 1)
     in
     check 0
 
 (** [make_socket_pair ()] creates a connected socketpair. Returns [(fd1, fd2)].
 *)
-let make_socket_pair () = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0
+let make_socket_pair () =
+  Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
 
 (** [make_connection fd ?name ?debug ()] creates a connection using the same fd
     for both reading and writing (for use with socketpairs). *)
@@ -62,16 +67,15 @@ let handshake_pair peer_conn client_conn =
 
 (** Helper: check where a given command is *)
 let find_cmd cmd =
-  let inp_channel = Unix.open_process_in ("which " ^ cmd) in
-  let output = String.trim (In_channel.input_all inp_channel) in
-  let exit_code = Unix.close_process_in inp_channel in
+  let inp_channel = Core_unix.open_process_in ("which " ^ cmd) in
+  let output = String.strip (In_channel.input_all inp_channel) in
+  let exit_code = Core_unix.close_process_in inp_channel in
   match exit_code with
-  | WEXITED 0 -> output
-  | exit_code ->
+  | Ok () -> output
+  | Error err ->
       raise
         (Failure
-           (Printf.sprintf "Command failed with status: %s"
-              (match exit_code with
-              | WEXITED code -> string_of_int code
-              | WSIGNALED sign -> "signaled: " ^ string_of_int sign
-              | WSTOPPED sign -> "stopped: " ^ string_of_int sign)))
+           (sprintf "Command failed with status: %s"
+              (match err with
+              | `Exit_non_zero code -> Int.to_string code
+              | `Signal signal -> "signaled: " ^ Signal.to_string signal)))

--- a/test/test_protocol.ml
+++ b/test/test_protocol.ml
@@ -1,3 +1,6 @@
+open! Core
+module Unix = Core_unix
+module Thread = Caml_threads.Thread
 open Hegel
 open Protocol
 
@@ -5,18 +8,20 @@ let contains_substring = Test_helpers.contains_substring
 
 (** Helper: create a socketpair for testing. Returns (reader, writer). *)
 let with_socket_pair f =
-  let reader, writer = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
-  Fun.protect
+  let reader, writer =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
+  Exn.protect
+    ~f:(fun () -> f reader writer)
     ~finally:(fun () ->
-      Unix.close reader;
-      Unix.close writer)
-    (fun () -> f reader writer)
+      Core_unix.close reader;
+      Core_unix.close writer)
 
 (** Helper: build raw packet bytes for testing read_packet edge cases. Mirrors
     the Python _make_packet helper. *)
 let make_raw_packet ?(pkt_magic = magic) ?checksum ?(channel_id = 0l)
     ?(message_id = 1l) ?(payload = "payload") ?(term = terminator) () =
-  let length = Int32.of_int (String.length payload) in
+  let length = Int32.of_int_exn (String.length payload) in
   (* Build header with zeroed checksum for CRC computation *)
   let header_for_check = Bytes.create header_size in
   pack_uint32_be header_for_check 0 pkt_magic;
@@ -36,14 +41,14 @@ let make_raw_packet ?(pkt_magic = magic) ?checksum ?(channel_id = 0l)
   pack_uint32_be header 8 channel_id;
   pack_uint32_be header 12 message_id;
   pack_uint32_be header 16 length;
-  Bytes.to_string header ^ payload ^ String.make 1 (Char.chr term)
+  Bytes.to_string header ^ payload ^ String.make 1 (Char.of_int_exn term)
 
 let sendall fd data =
   let bytes = Bytes.of_string data in
   let len = Bytes.length bytes in
   let rec write_all pos =
     if pos < len then
-      let written = Unix.write fd bytes pos (len - pos) in
+      let written = Core_unix.write fd ~buf:bytes ~pos ~len:(len - pos) in
       write_all (pos + written)
   in
   write_all 0
@@ -60,7 +65,7 @@ let test_terminator () = Alcotest.(check int) "TERMINATOR" 0x0A terminator
 let test_close_channel_message_id () =
   Alcotest.(check int32)
     "CLOSE_CHANNEL_MESSAGE_ID"
-    (Int32.sub (Int32.shift_left 1l 31) 1l)
+    Int32.(shift_left 1l 31 - 1l)
     close_channel_message_id
 
 let test_close_channel_payload () =
@@ -236,26 +241,30 @@ let test_recv_exact_zero () =
       Alcotest.(check int) "empty bytes" 0 (Bytes.length result))
 
 let test_recv_exact_partial_close () =
-  let reader, writer = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  let reader, writer =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
   sendall writer "abc";
-  Unix.close writer;
+  Core_unix.close writer;
   let exn_raised = ref false in
   (try
      let _ = recv_exact reader 10 in
      ()
    with Connection_closed _ -> exn_raised := true);
-  Unix.close reader;
+  Core_unix.close reader;
   Alcotest.(check bool) "Connection_closed raised" true !exn_raised
 
 let test_recv_exact_no_data_close () =
-  let reader, writer = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
-  Unix.close writer;
+  let reader, writer =
+    Core_unix.socketpair ~domain:PF_UNIX ~kind:SOCK_STREAM ~protocol:0 ()
+  in
+  Core_unix.close writer;
   let exn_raised = ref false in
   (try
      let _ = recv_exact reader 10 in
      ()
    with Partial_packet _ -> exn_raised := true);
-  Unix.close reader;
+  Core_unix.close reader;
   Alcotest.(check bool) "Partial_packet raised" true !exn_raised
 
 (* --- pp_packet and equal_packet tests --- *)
@@ -293,13 +302,11 @@ let test_equal_packet_different () =
 
 let test_pack_unpack_uint32 () =
   let values = [ 0l; 1l; 0x7FFFFFFFl; 0x80000000l; 0xFFFFFFFFl ] in
-  List.iter
-    (fun v ->
+  List.iter values ~f:(fun v ->
       let buf = Bytes.create 4 in
       pack_uint32_be buf 0 v;
       let result = unpack_uint32_be buf 0 in
-      Alcotest.(check int32) (Printf.sprintf "pack/unpack 0x%lX" v) v result)
-    values
+      Alcotest.(check int32) (sprintf "pack/unpack 0x%lX" v) v result)
 
 let tests =
   [


### PR DESCRIPTION
Something I hadn't appreciated is that OCaml is one of those languages that loves standard libraries so much that it has two of them. There's the standard standard library (from Inria) and the Jane Street standard library (from, well, Jane Street).

I think our side in this particular split is clear, but previously hegel-ocaml implemented the wrong one. If there's a demand for an Inria-compatible hegel-ocaml too we (Claude) could do that relatively easily I think, but this is a better starting point.