### PR TITLE
Add CLAUDE.local.md and .claude/local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 __pycache__/
 *.pyc
 .claude/plan.md
+.claude/local/
+CLAUDE.local.md
 _build/
 _coverage/
 *.cmi


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Add gitignore entries for `CLAUDE.local.md` (top-level local instructions file) and `.claude/local/` (directory for local skills and personal Claude config), placed alongside the existing `.claude/plan.md` entry. This is part of a cross-repo standardization of Claude-related gitignore patterns.

</details>