### PR TITLE
Fix intermittent test hangs by joining reader thread on close

### DIFF
--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -241,15 +241,27 @@ let close conn =
        On Linux, close() alone does not wake up a blocked read() in another
        thread. shutdown() ensures the reader gets EOF immediately.
        Fails harmlessly with ENOTSOCK on pipes. *)
-    (try Unix.shutdown conn.read_fd ~mode:Unix.SHUTDOWN_ALL
-     with Unix.Unix_error _ -> ());
+    let shutdown_ok =
+      try
+        Unix.shutdown conn.read_fd ~mode:Unix.SHUTDOWN_ALL;
+        true
+      with Unix.Unix_error _ -> false
+    in
     (try Unix.close conn.read_fd with Unix.Unix_error _ -> ());
     (* Only close write_fd if it's different from read_fd *)
     (if not (phys_equal conn.write_fd conn.read_fd) then
        try Unix.close conn.write_fd with Unix.Unix_error _ -> ());
     Mutex.lock conn.streams_lock;
     signal_all_streams conn;
-    Mutex.unlock conn.streams_lock
+    Mutex.unlock conn.streams_lock;
+    (* Join the reader thread to ensure it has fully exited before returning.
+       Only safe when shutdown succeeded (sockets), since shutdown guarantees
+       the blocked read returns immediately. On pipes, shutdown fails with
+       ENOTSOCK and close alone may not unblock the reader thread. *)
+    if shutdown_ok then
+      match conn.reader_thread with
+      | Some t -> Thread.join t
+      | None -> ()
   end
 
 (** [create_connection ~read_fd ~write_fd ?name ?debug ()] creates a new

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -15,6 +15,12 @@ module Condition = Caml_threads.Condition
 module Thread = Caml_threads.Thread
 open Protocol
 
+(* Ignore SIGPIPE so that writes to broken sockets raise EPIPE instead of
+   killing the process. This is standard practice for network programs and is
+   required because background reader threads may attempt error-reply writes
+   to sockets whose remote end has already been closed. *)
+let () = Stdlib.Sys.set_signal Stdlib.Sys.sigpipe Stdlib.Sys.Signal_ignore
+
 (** Handshake string sent by the client to initiate the protocol. *)
 let handshake_string = "hegel_handshake_start"
 

--- a/test/test_connection.ml
+++ b/test/test_connection.ml
@@ -903,6 +903,41 @@ let test_control_stream_failure () =
   close conn;
   Unix.close s2
 
+(** Regression test: rapidly creating and closing connections must not hang.
+    Before the fix, close did not join the reader thread, leaving zombie threads
+    that could starve new connections' readers under unlucky scheduling. This
+    test runs 20 create/handshake/close cycles — without the fix it would hang
+    within a few iterations. *)
+let test_rapid_close_does_not_hang () =
+  for _ = 1 to 20 do
+    let s1, s2 = make_socket_pair () in
+    let peer_conn = make_connection s1 ~name:"Peer" () in
+    let client_conn = make_connection s2 ~name:"Client" () in
+    handshake_pair peer_conn client_conn;
+    close peer_conn;
+    close client_conn
+  done
+
+(** Regression test: writing to a socket whose remote end is closed must raise
+    an OCaml exception (EPIPE), not kill the process with SIGPIPE. This relies
+    on SIGPIPE being ignored at module init time. *)
+let test_write_to_broken_socket_raises () =
+  let s1, s2 = make_socket_pair () in
+  (* Close the read end so writes to s2 will get EPIPE *)
+  Unix.close s1;
+  let raised = ref false in
+  (try
+     Protocol.write_packet s2
+       {
+         Protocol.stream_id = 0l;
+         message_id = 1l;
+         is_reply = false;
+         payload = "hello";
+       }
+   with Unix.Unix_error (Unix.EPIPE, _, _) -> raised := true);
+  Alcotest.(check bool) "raised EPIPE" true !raised;
+  Unix.close s2
+
 let tests =
   [
     (* Connection lifecycle *)
@@ -1016,4 +1051,10 @@ let tests =
     (* control_stream failure *)
     Alcotest.test_case "control_stream failure" `Quick
       test_control_stream_failure;
+    (* Regression: rapid create/handshake/close must not hang *)
+    Alcotest.test_case "rapid close does not hang" `Quick
+      test_rapid_close_does_not_hang;
+    (* Regression: write to broken socket raises, not SIGPIPE *)
+    Alcotest.test_case "write to broken socket raises EPIPE" `Quick
+      test_write_to_broken_socket_raises;
   ]


### PR DESCRIPTION
Two fixes for intermittent test failures.

Claude says:

1. **Hang fix**: `Connection.close` now joins the background reader thread (when the fd is a socket) to prevent zombie threads from starving new connections' readers via runtime lock contention
2. **SIGPIPE fix**: Ignore `SIGPIPE` at module init so writes to broken sockets raise `EPIPE` instead of killing the process — standard practice for network programs

I've read through the code and it doesn't seem crazy, but I'd be lying if I said I fully understood it.