### PR TITLE
Handle StopTest in collection_reject, revert unique workaround

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Handle `StopTest` in `collection_reject` so that unique non-basic lists terminate cleanly when the server's rejection limit is reached, instead of raising an unhandled protocol error.

--- a/conformance/test_lists.ml
+++ b/conformance/test_lists.ml
@@ -28,11 +28,8 @@ let () =
         || test_mode = "stop_test_on_new_collection"
       in
       let base_elem = integers ?min_value ?max_value () in
-      (* Don't use non-basic path with unique — client-side uniqueness
-         enforcement via collection_reject is too slow for large min_size. *)
       let elem_gen =
-        if needs_non_basic && not unique then
-          Json_params.make_non_basic base_elem
+        if needs_non_basic then Json_params.make_non_basic base_elem
         else base_elem
       in
       let list_gen = lists elem_gen ~min_size ?max_size ~unique () in

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -95,7 +95,8 @@ val collection_more : collection -> Client.test_case -> bool
     generated, [false] when the collection is complete. *)
 
 val collection_reject : collection -> Client.test_case -> unit
-(** [collection_reject coll data] rejects the last element of the collection. *)
+(** [collection_reject coll data] rejects the last element of the collection.
+    Raises {!Client.Data_exhausted} on StopTest. *)
 
 val do_draw : 'a generator -> Client.test_case -> 'a
 (** [do_draw gen tc] produces a typed value from generator [gen] using the given

--- a/lib/generators_collections.ml
+++ b/lib/generators_collections.ml
@@ -110,7 +110,9 @@ let lists elements ?(min_size = 0) ?max_size ?(unique = false) () =
         CompositeList { elements; min_size; max_size }
       else
         (* Non-basic with uniqueness: use Composite with collection protocol
-           and duplicate rejection. *)
+           and duplicate rejection.  The server's own rejection limit
+           (via [many.reject]) will send StopTest when too many duplicates
+           occur, which [collection_reject] converts to [Data_exhausted]. *)
         Composite
           {
             label = Labels.list;

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -153,19 +153,24 @@ let collection_more coll data =
     more
 
 (** [collection_reject coll data] rejects the last element of the collection.
-    No-op if the collection is already finished. *)
+    No-op if the collection is already finished. Raises {!Client.Data_exhausted}
+    on StopTest. *)
 let collection_reject coll data =
   if not coll.finished then begin
     let collection_id = get_collection_id coll data in
     let stream = data.Client.stream in
-    ignore
-      (pending_get
-         (request stream
-            (`Map
-               [
-                 (`Text "command", `Text "collection_reject");
-                 (`Text "collection_id", collection_id);
-               ])))
+    try
+      ignore
+        (pending_get
+           (request stream
+              (`Map
+                 [
+                   (`Text "command", `Text "collection_reject");
+                   (`Text "collection_id", collection_id);
+                 ])))
+    with Request_error e when String.equal e.error_type "StopTest" ->
+      data.test_aborted <- true;
+      raise Client.Data_exhausted
   end
 
 (** [do_draw gen data] produces a typed value from generator [gen] using the

--- a/test/test_generators_collections.ml
+++ b/test/test_generators_collections.ml
@@ -220,6 +220,22 @@ let test_lists_non_basic_unique_e2e () =
       let uniq = List.sort_uniq compare items |> List.length in
       Alcotest.(check int) "all unique" n uniq)
 
+(** Test: lists(non-basic, unique=true) with impossible constraints terminates
+    via the server's rejection limit instead of hanging. Uses
+    min_value=max_value=0 so every second element is a guaranteed duplicate,
+    which causes the server to send StopTest after its rejection threshold. *)
+let test_lists_non_basic_unique_exhaustion_e2e () =
+  Session.run_hegel_test ~settings:(Client.settings ~test_cases:10 ())
+    (fun tc ->
+      let elem =
+        filter (fun _ -> true) (integers ~min_value:0 ~max_value:0 ())
+      in
+      (* Asking for ≥2 unique elements from {0} — impossible. The server's
+         many.reject() limit will fire and send StopTest, which
+         collection_reject converts to Data_exhausted. *)
+      let gen = lists elem ~min_size:2 ~unique:true () in
+      ignore (Hegel.draw tc gen))
+
 (** Test: hashmaps(non-basic keys) E2E — generates pairs. *)
 let test_hashmaps_non_basic_keys_e2e () =
   Session.run_hegel_test ~settings:(Client.settings ~test_cases:10 ())
@@ -280,6 +296,8 @@ let tests =
     Alcotest.test_case "lists unique e2e" `Quick test_lists_unique_e2e;
     Alcotest.test_case "lists non-basic unique e2e" `Quick
       test_lists_non_basic_unique_e2e;
+    Alcotest.test_case "lists non-basic unique exhaustion e2e" `Quick
+      test_lists_non_basic_unique_exhaustion_e2e;
     Alcotest.test_case "hashmaps non-basic keys e2e" `Quick
       test_hashmaps_non_basic_keys_e2e;
     Alcotest.test_case "hashmaps non-basic values e2e" `Quick


### PR DESCRIPTION
The problem here was that we weren't correctly handling errors when calling `reject()`, which can raise falsified assumption from the python side.