### PR TITLE
claude: run format-nix as part of format recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ format:
     eval $(opam env)
     dune fmt || true
     # also run format-nix if we have nix installed
-    which nix && just format-nix || true
+    @which nix && just format-nix || true
 
 format-nix:
     nix run nixpkgs#nixfmt -- nix/flake.nix

--- a/justfile
+++ b/justfile
@@ -19,6 +19,8 @@ format:
     set -euo pipefail
     eval $(opam env)
     dune fmt || true
+    # also run format-nix if we have nix installed
+    which nix && just format-nix || true
 
 format-nix:
     nix run nixpkgs#nixfmt -- nix/flake.nix


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Addresses https://github.com/hegeldev/hegel-ocaml/pull/30#discussion_r3093227670.

Adds a trailing `which nix && just format-nix || true` line to the `format` recipe so that running `just format` also formats `nix/flake.nix` when nix is available locally — mirroring the pattern in hegel-rust's justfile. On machines without nix installed, the `which` check fails and `|| true` keeps the recipe succeeding.

Adapted slightly from the rust version: the OCaml `format` recipe is a shebang (`#!/usr/bin/env bash`) recipe rather than a regular just recipe, so the `@` echo-suppression prefix doesn't apply and isn't needed.

</details>
