### PR TITLE
claude: whitelist .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,11 @@
 .hypothesis/
 __pycache__/
 *.pyc
-.claude/plan.md
-.claude/local/
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
 CLAUDE.local.md
 _build/
 _coverage/


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Switch the `.claude/` section of `.gitignore` from a blacklist (`.claude/plan.md`, `.claude/local/`) to a whitelist. Local files (skills, agents, settings, plans) inside `.claude/` are now untracked by default; only `.claude/CLAUDE.md` remains tracked. Top-level `CLAUDE.local.md` continues to be gitignored at the top level.

Verified with `git ls-files .claude/` (still lists `.claude/CLAUDE.md`) and `git status --short` (previously-untracked `.claude/agents/` and `.claude/skills/` are now correctly ignored).

</details>
