### PR TITLE
Bump pinned hegel-core to 0.8.0; fix test helpers and oxcaml caching

### DIFF
--- a/.github/workflows/ci-oxcaml.yml
+++ b/.github/workflows/ci-oxcaml.yml
@@ -40,24 +40,32 @@ jobs:
           chmod +x /usr/local/bin/opam
           opam --version
 
-      - name: Cache opam switch
+      - name: Cache opam
+        id: cache-opam
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.opam
           key: opam-oxcaml-${{ runner.os }}-with-test-${{ hashFiles('*.opam') }}
           restore-keys: |
             opam-oxcaml-${{ runner.os }}-with-test-
-          save-always: true
 
       - name: Set up OxCaml
+        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
-          opam init --bare --disable-sandboxing --yes
+          # Cache may be partially restored via restore-keys (a different key
+          # prefix matched); guard each step so it's idempotent.
+          if [ ! -d "$HOME/.opam" ]; then
+            opam init --bare --disable-sandboxing --yes
+          fi
           if ! opam switch list --short 2>/dev/null | grep -q '^oxcaml$'; then
             opam switch create oxcaml \
               --packages "ocaml-variants.5.2.0+ox" \
               --repos "oxcaml=git+https://github.com/oxcaml/opam-repository.git,default" \
               --yes
           fi
+
+      - name: Set opam environment
+        run: |
           echo "$HOME/.opam/oxcaml/bin" >> $GITHUB_PATH
           echo "OPAMSWITCH=oxcaml" >> $GITHUB_ENV
 
@@ -97,24 +105,32 @@ jobs:
           chmod +x /usr/local/bin/opam
           opam --version
 
-      - name: Cache opam switch
+      - name: Cache opam
+        id: cache-opam
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.opam
-          key: opam-oxcaml-${{ runner.os }}-${{ hashFiles('*.opam') }}
+          key: opam-oxcaml-${{ runner.os }}-with-test-${{ hashFiles('*.opam') }}
           restore-keys: |
-            opam-oxcaml-${{ runner.os }}-
-          save-always: true
+            opam-oxcaml-${{ runner.os }}-with-test-
 
       - name: Set up OxCaml
+        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
-          opam init --bare --disable-sandboxing --yes
+          # Cache may be partially restored via restore-keys (a different key
+          # prefix matched); guard each step so it's idempotent.
+          if [ ! -d "$HOME/.opam" ]; then
+            opam init --bare --disable-sandboxing --yes
+          fi
           if ! opam switch list --short 2>/dev/null | grep -q '^oxcaml$'; then
             opam switch create oxcaml \
               --packages "ocaml-variants.5.2.0+ox" \
               --repos "oxcaml=git+https://github.com/oxcaml/opam-repository.git,default" \
               --yes
           fi
+
+      - name: Set opam environment
+        run: |
           echo "$HOME/.opam/oxcaml/bin" >> $GITHUB_PATH
           echo "OPAMSWITCH=oxcaml" >> $GITHUB_ENV
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,3 @@
 RELEASE_TYPE: patch
 
-Bump our pinned hegel-core to [0.8.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.8.0), incorporating the following changes:
-
-> This patch adds support for the `uuid` schema type, exposing Hypothesis's
-> `uuids` strategy. UUIDs are returned to the client as strings in the
-> canonical hyphenated form. An optional `version` field selects a specific
-> UUID version (1-5).
->
-> — [v0.7.1](https://github.com/hegeldev/hegel-core/releases/tag/v0.7.1)
-
-> This patch bumps `PROTOCOL_VERSION` to `0.14`. The previous release (0.7.1) added the `uuid` schema type without bumping the protocol, so client libraries had no way to negotiate "this server understands `uuid`" at handshake. Bumping now lets clients that emit `{"type": "uuid"}` schemas require protocol `0.14` and fail cleanly against older servers instead of getting an `Unsupported schema` error at draw time.
->
-> — [v0.8.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.8.0)
+Bump our pinned hegel-core to [0.8.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.8.0). 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+RELEASE_TYPE: patch
+
+Bump our pinned hegel-core to [0.8.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.8.0), incorporating the following changes:
+
+> This patch adds support for the `uuid` schema type, exposing Hypothesis's
+> `uuids` strategy. UUIDs are returned to the client as strings in the
+> canonical hyphenated form. An optional `version` field selects a specific
+> UUID version (1-5).
+>
+> — [v0.7.1](https://github.com/hegeldev/hegel-core/releases/tag/v0.7.1)
+
+> This patch bumps `PROTOCOL_VERSION` to `0.14`. The previous release (0.7.1) added the `uuid` schema type without bumping the protocol, so client libraries had no way to negotiate "this server understands `uuid`" at handshake. Bumping now lets clients that emit `{"type": "uuid"}` schemas require protocol `0.14` and fail cleanly against older servers instead of getting an `Unsupported schema` error at draw time.
+>
+> — [v0.8.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.8.0)

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -214,9 +214,9 @@ let stop_span ?(discard = false) tc =
                ])))
 
 (** Supported protocol version range. *)
-let supported_protocol_lo = "0.13"
+let supported_protocol_lo = "0.14"
 
-let supported_protocol_hi = "0.13"
+let supported_protocol_hi = "0.14"
 
 (** Compare two "major.minor" version strings numerically. Returns a negative
     number if a < b, 0 if a = b, positive if a > b. *)

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -17,7 +17,7 @@ module Thread = Caml_threads.Thread
 open Connection
 
 (** Version of hegel-core to install. *)
-let hegel_server_version = "0.7.0"
+let hegel_server_version = "0.8.0"
 
 (** Environment variable to override the hegel server command. *)
 let hegel_server_command_env = "HEGEL_SERVER_COMMAND"

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1777651935,
-        "narHash": "sha256-cptWYJ5fsm7/E0Y1VAJc//xhe4wDS26v86U3uRkNY2U=",
-        "ref": "refs/tags/v0.7.0",
-        "rev": "7673b1cec8efee0252d78664f2be1ca97a7cce06",
-        "revCount": 670,
+        "lastModified": 1778144688,
+        "narHash": "sha256-L995WpgKUiZkXHwmFODrM4lryP/ymPXegS7O+4cfqpA=",
+        "ref": "refs/tags/v0.8.0",
+        "rev": "9e3237c4c2db8bfbd0362418837be8bfd59cec5e",
+        "revCount": 679,
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       },
       "original": {
         "dir": "nix",
-        "ref": "refs/tags/v0.7.0",
+        "ref": "refs/tags/v0.8.0",
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     # note: this version is automatically bumped when we update hegel-core, do not update manually
-    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.7.0"; # git+https instead of github so that we can use the ref parameter
+    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.8.0"; # git+https instead of github so that we can use the ref parameter
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 

--- a/test/test_connection.ml
+++ b/test/test_connection.ml
@@ -35,7 +35,7 @@ let test_send_handshake_returns_version () =
   let t = Thread.create Test_helpers.handshake_via_stream peer_conn in
   let version = send_handshake client_conn in
   Thread.join t;
-  Alcotest.(check string) "version" "0.13" version;
+  Alcotest.(check string) "version" Client.supported_protocol_hi version;
   close client_conn;
   close peer_conn
 

--- a/test/test_helpers.ml
+++ b/test/test_helpers.ml
@@ -33,12 +33,17 @@ let make_socket_pair () =
 let make_connection fd ?name ?debug () =
   Connection.create_connection ~read_fd:fd ~write_fd:fd ?name ?debug ()
 
+(** A handshake payload that the real client will accept — built from the
+    client's own supported-protocol constant so it stays valid across protocol
+    bumps. *)
+let supported_handshake_payload = "Hegel/" ^ Client.supported_protocol_hi
+
 (** [raw_handshake_responder fd] reads one raw handshake packet from [fd] and
-    responds with ["Hegel/0.13"]. Used by tests that need the client's
-    {!Connection.send_handshake} to succeed. This function reads and writes on a
-    raw fd without a connection object, so it must be used BEFORE any connection
-    is created on the same fd, or on a separate fd that has no background
-    reader. *)
+    responds with a payload the client will accept. Used by tests that need the
+    client's {!Connection.send_handshake} to succeed. This function reads and
+    writes on a raw fd without a connection object, so it must be used BEFORE
+    any connection is created on the same fd, or on a separate fd that has no
+    background reader. *)
 let raw_handshake_responder fd =
   let pkt = Protocol.read_packet fd in
   Protocol.write_packet fd
@@ -46,7 +51,7 @@ let raw_handshake_responder fd =
       stream_id = pkt.stream_id;
       message_id = pkt.message_id;
       is_reply = true;
-      payload = "Hegel/0.13";
+      payload = supported_handshake_payload;
     }
 
 (** [handshake_via_stream peer_conn] handles a handshake on the peer side using
@@ -54,7 +59,7 @@ let raw_handshake_responder fd =
 let handshake_via_stream peer_conn =
   let ch = Connection.control_stream peer_conn in
   let msg_id, _payload = Connection.receive_request_raw ch () in
-  Connection.send_response_raw ch msg_id "Hegel/0.13";
+  Connection.send_response_raw ch msg_id supported_handshake_payload;
   peer_conn.Connection.connection_state <- Connection.Client
 
 (** [handshake_pair peer_conn client_conn] performs a handshake between peer and


### PR DESCRIPTION
<!-- Human description goes here -->

This supersedes PR #44 — it includes the hegel-core 0.8.0 bump plus the test/CI fixes needed to make CI pass.

<details>
<summary>AI-generated implementation notes</summary>

## Contents

- **`af231e9` (cherry-picked from PR #44)**: Bumps the pinned `hegel-core` to 0.8.0 (`lib/session.ml`), lifts `supported_protocol_lo`/`_hi` from `0.13` → `0.14` (`lib/client.ml`), updates `nix/flake.{nix,lock}`, and adds `RELEASE.md`.
- **`9c2b840`**: Decouples the test helpers from the hardcoded protocol version and improves oxcaml CI caching.

## Why PR #44 was failing

The bump-hegel-core script lifts `supported_protocol_lo`/`_hi` in `lib/client.ml` to `0.14` but `test/test_helpers.ml` and `test/test_connection.ml` still hardcoded `"Hegel/0.13"` / `"0.13"`, so 9 client tests in `test` and `test (oxcaml)` failed with:

```
[failure] hegel-ocaml supports protocol versions 0.14 through 0.14, but the
connected server is using protocol version 0.13.
```

## Test-helper fix

- `test/test_helpers.ml`: introduce `supported_handshake_payload = "Hegel/" ^ Client.supported_protocol_hi`, used by both `raw_handshake_responder` and `handshake_via_stream`.
- `test/test_connection.ml`: assert the round-tripped version equals `Client.supported_protocol_hi`.

After this change, the bump-hegel-core script does not need to touch test files — protocol bumps flow through the constant.

## OxCaml CI caching

`.github/workflows/ci-oxcaml.yml`:

- The `test (oxcaml)` and `conformance (oxcaml)` jobs used **different** cache keys (`opam-oxcaml-<os>-with-test-<hash>` vs `opam-oxcaml-<os>-<hash>`). The conformance job only matched the test job's cache via restore-keys fallback, so it never got an exact-key hit and re-saved the ~2 GB cache on every run. Both jobs now use the same `with-test-` key.
- Removed deprecated `save-always: true` (GitHub Actions emits a warning).
- Added `if: steps.cache-opam.outputs.cache-hit != 'true'` to the `Set up OxCaml` step (matches `ci.yml`), and split the env-export into its own always-run step.

## Verification

I created a temporary draft PR (#46, since closed) that contained PR #44's bump + the test-helper fix on top, identical to this PR. All 8 CI checks — including the previously-failing `test` and `test (oxcaml)` — passed.
</details>