### PR TITLE
Regenerate hegel.opam to match current dune output

### DIFF
--- a/hegel.opam
+++ b/hegel.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/hegeldev/hegel-ocaml"
 bug-reports: "https://github.com/hegeldev/hegel-ocaml/issues"
 depends: [
   "ocaml" {>= "5.2"}
-  "dune" {>= "3.16" & >= "3.16"}
+  "dune" {>= "3.16"}
   "core" {>= "0.17"}
   "core_unix" {>= "0.17"}
   "alcotest" {with-test & >= "1.7"}


### PR DESCRIPTION
<!-- Human description goes here -->

Fixes the lint failure on main from run [25504554520](https://github.com/hegeldev/hegel-ocaml/actions/runs/25504554520).

<details>
<summary>AI-generated implementation notes</summary>

## Why main is failing

The `lint` job's "Check opam files are up to date" step runs:

```sh
opam exec -- dune build hegel.opam && git diff --exit-code '*.opam'
```

On the merge commit for #45 the lint cache wasn't found (the previous `opam-Linux-lint-*` caches had aged out), so opam pulled a fresh dune (3.23). Dune 3.23 normalizes the `(lang dune 3.16)` + `(depends (dune (>= 3.16)))` pair into a single constraint:

```diff
-  "dune" {>= "3.16" & >= "3.16"}
+  "dune" {>= "3.16"}
```

The committed `hegel.opam` had the duplicated form (generated by an older dune), so `git diff --exit-code` failed.

This was a latent bug independent of #45 — it would have surfaced on the next main run that hit a cold lint cache regardless. #45's merge happened to be that run.

## Fix

Regenerate `hegel.opam` (just hand-applied the same one-line diff that dune emits, since this environment doesn't have opam/dune installed). The file now matches what `dune build hegel.opam` produces with dune 3.23, so the lint check will pass.
</details>