### PR TITLE
claude: Simplify auto-bump RELEASE.md output

### DIFF
--- a/.github/scripts/bump_hegel_core.py
+++ b/.github/scripts/bump_hegel_core.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import subprocess
@@ -17,33 +16,6 @@ def get_current_version() -> str:
     m = re.search(r'^let hegel_server_version = "([^"]+)"', text, re.MULTILINE)
     assert m is not None
     return m.group(1)
-
-
-def get_releases_in_range(from_version: str, to_version: str) -> list[dict[str, str]]:
-    """Fetch hegel-core releases between from_version (exclusive) and to_version (inclusive)."""
-    result = subprocess.run(
-        ["gh", "api", f"repos/{CORE_REPO}/releases", "--paginate", "--jq", ".[]"],
-        capture_output=True,
-        text=True,
-        check=True,
-        cwd=ROOT,
-    )
-    # --jq ".[]" with --paginate outputs one JSON object per line
-    releases = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
-
-    from_parts = [int(x) for x in from_version.split(".")]
-    to_parts = [int(x) for x in to_version.split(".")]
-
-    in_range = []
-    for release in releases:
-        tag = release["tag_name"].lstrip("v")
-        parts = [int(x) for x in tag.split(".")]
-        if parts > from_parts and parts <= to_parts:
-            in_range.append({"version": tag, "body": release["body"].strip()})
-
-    # Sort oldest first
-    in_range.sort(key=lambda r: [int(x) for x in r["version"].split(".")])
-    return in_range
 
 
 def bump(version: str, protocol_version: str) -> None:
@@ -101,24 +73,14 @@ def bump(version: str, protocol_version: str) -> None:
         cwd=ROOT,
     )
 
-    releases = get_releases_in_range(current_version, version)
+    current_url = f"https://github.com/{CORE_REPO}/releases/tag/v{current_version}"
     release_url = f"https://github.com/{CORE_REPO}/releases/tag/v{version}"
-
-    changelog_sections = []
-    for r in releases:
-        url = f"https://github.com/{CORE_REPO}/releases/tag/v{r['version']}"
-        quoted = "\n".join(f"> {line}" if line else ">" for line in r["body"].splitlines())
-        changelog_sections.append(f"{quoted}\n>\n> — [v{r['version']}]({url})")
-
-    changes_text = "\n\n".join(changelog_sections)
-    noun = "change" if len(releases) == 1 else "changes"
 
     release_md = ROOT / "RELEASE.md"
     release_md.write_text(
         f"RELEASE_TYPE: patch\n\n"
-        f"Bump our pinned hegel-core to [{version}]({release_url}), "
-        f"incorporating the following {noun}:\n\n"
-        f"{changes_text}\n"
+        f"This patch bumps our pinned hegel-core from "
+        f"[{current_version}]({current_url}) to [{version}]({release_url}).\n"
     )
 
     app_id = os.environ["HEGEL_RELEASE_APP_ID"]


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

- Drops the inline blockquoted changelog from the auto-generated RELEASE.md;
  replaces it with a single line linking the from/to versions.
- Removes the now-unused `get_releases_in_range` function and its
  `gh api repos/.../releases --paginate` call.

Same change shipping in parallel across hegel-typescript, hegel-go,
hegel-rust, hegel-cpp, hegel-ocaml.

This is a `.github/scripts/` change only — no library source files are modified, so no library `RELEASE.md` is required for this PR itself.

</details>
