### PR TITLE
Reexport `settings` at Hegel module level

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Reexports `settings` in the top level `Hegel` module. 

--- a/conformance/test_binary.ml
+++ b/conformance/test_binary.ml
@@ -9,8 +9,7 @@ let () =
   let min_size = Json_params.get_int params "min_size" 0 in
   let max_size = Json_params.get_int_opt params "max_size" in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       let b = Hegel.draw tc (binary ~min_size ?max_size ()) in
       let length = String.length b in
       write_metrics [ ("length", string_of_int length) ])

--- a/conformance/test_booleans.ml
+++ b/conformance/test_booleans.ml
@@ -5,7 +5,6 @@ open Hegel.Generators
 
 let () =
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       let b = Hegel.draw tc (booleans ()) in
       write_metrics [ ("value", if b then "true" else "false") ])

--- a/conformance/test_floats.ml
+++ b/conformance/test_floats.ml
@@ -19,8 +19,7 @@ let () =
   let allow_nan = Json_params.get_bool_opt params "allow_nan" in
   let allow_infinity = Json_params.get_bool_opt params "allow_infinity" in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       let f =
         Hegel.draw tc
           (floats ?min_value ?max_value ~exclude_min ~exclude_max ?allow_nan

--- a/conformance/test_hashmaps.ml
+++ b/conformance/test_hashmaps.ml
@@ -17,8 +17,7 @@ let () =
   let mode = Json_params.get_mode params in
   let test_cases = get_test_cases () in
   if key_type = "string" then
-    Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-      (fun tc ->
+    Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
         with_metrics (fun () ->
             let key_gen = text ~min_size:1 ~max_size:10 () in
             let key_gen =
@@ -52,8 +51,7 @@ let () =
               ("max_value", Json_params.int_opt_to_json max_val_result);
             ]))
   else
-    Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-      (fun tc ->
+    Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
         with_metrics (fun () ->
             let key_gen = integers ~min_value:min_key ~max_value:max_key () in
             let key_gen =

--- a/conformance/test_integers.ml
+++ b/conformance/test_integers.ml
@@ -9,7 +9,6 @@ let () =
   let min_value = Json_params.get_int_opt params "min_value" in
   let max_value = Json_params.get_int_opt params "max_value" in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       let n = Hegel.draw tc (integers ?min_value ?max_value ()) in
       write_metrics [ ("value", string_of_int n) ])

--- a/conformance/test_lists.ml
+++ b/conformance/test_lists.ml
@@ -17,8 +17,7 @@ let () =
   let unique = Json_params.get_bool params "unique" false in
   let mode = Json_params.get_mode params in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       with_metrics (fun () ->
           let test_mode =
             try Sys.getenv "HEGEL_PROTOCOL_TEST_MODE" with Not_found -> ""

--- a/conformance/test_one_of.ml
+++ b/conformance/test_one_of.ml
@@ -39,8 +39,7 @@ let () =
   in
   let branches = List.map make_branch ranges in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       with_metrics (fun () ->
           let n = Hegel.draw tc (one_of branches) in
           [ ("value", string_of_int n) ]))

--- a/conformance/test_origin_deduplication.ml
+++ b/conformance/test_origin_deduplication.ml
@@ -24,8 +24,7 @@ let () =
   let mode = Json_params.get_mode params in
   let test_cases = get_test_cases () in
   try
-    Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-      (fun tc ->
+    Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
         with_metrics (fun () ->
             let x = Hegel.draw tc (integers ~min_value:0 ~max_value:100 ()) in
             (match mode with

--- a/conformance/test_sampled_from.ml
+++ b/conformance/test_sampled_from.ml
@@ -8,7 +8,6 @@ let () =
   let params = Json_params.parse params_str in
   let options = Json_params.get_int_array params "options" in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       let n = Hegel.draw tc (sampled_from options) in
       write_metrics [ ("value", string_of_int n) ])

--- a/conformance/test_text.ml
+++ b/conformance/test_text.ml
@@ -64,8 +64,7 @@ let () =
     Json_params.get_string_opt params "exclude_characters"
   in
   let test_cases = get_test_cases () in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases ()) (fun tc ->
       let s =
         Hegel.draw tc
           (text ~min_size ?max_size ?codec ?min_codepoint ?max_codepoint

--- a/examples/basic_properties.ml
+++ b/examples/basic_properties.ml
@@ -6,8 +6,7 @@ open Hegel.Generators
 
 (** Property: integer arithmetic identities. *)
 let test_integer_arithmetic () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let a = Hegel.draw tc (integers ~min_value:(-1000) ~max_value:1000 ()) in
       let b = Hegel.draw tc (integers ~min_value:(-1000) ~max_value:1000 ()) in
       (* Addition is commutative *)
@@ -19,8 +18,7 @@ let test_integer_arithmetic () =
 
 (** Property: boolean identities. *)
 let test_boolean_laws () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:50 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:50 ()) (fun tc ->
       let p = Hegel.draw tc (booleans ()) in
       let q = Hegel.draw tc (booleans ()) in
       (* De Morgan's law *)
@@ -32,8 +30,7 @@ let test_boolean_laws () =
 
 (** Property: division identity (with assume to avoid division by zero). *)
 let test_division () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let n = Hegel.draw tc (integers ~min_value:(-1000) ~max_value:1000 ()) in
       let d = Hegel.draw tc (integers ~min_value:(-1000) ~max_value:1000 ()) in
       Hegel.assume tc (d <> 0);
@@ -43,23 +40,20 @@ let test_division () =
 
 (** Property: text strings have non-negative length. *)
 let test_text_length () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let s = Hegel.draw tc (text ~min_size:0 ~max_size:50 ()) in
       assert (String.length s >= 0))
 
 (** Property: binary blobs have non-negative byte length. *)
 let test_binary_length () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let b = Hegel.draw tc (binary ~min_size:0 ~max_size:50 ()) in
       assert (String.length b >= 0))
 
 (** Property: finite floats are their own doubles divided by two. Uses
     allow_nan:false and allow_infinity:false to restrict to finite values. *)
 let test_float_finite () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let x =
         Hegel.draw tc
           (floats ~min_value:(-1e6) ~max_value:1e6 ~allow_nan:false

--- a/examples/collections.ml
+++ b/examples/collections.ml
@@ -7,8 +7,7 @@ open Hegel.Generators
 (** Property: every element in a list of non-negative integers is non-negative.
     Uses [filter] to restrict the element generator. *)
 let test_filtered_list () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let non_neg =
         filter (fun v -> v >= 0) (integers ~min_value:(-100) ~max_value:100 ())
       in
@@ -18,8 +17,7 @@ let test_filtered_list () =
 (** Property: a list generated with [min_size] has at least that many elements.
 *)
 let test_list_min_size () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let lst =
         Hegel.draw tc (lists (integers ()) ~min_size:3 ~max_size:10 ())
       in
@@ -28,8 +26,7 @@ let test_list_min_size () =
 (** Property: [map] transforms every element. Here we map integers to their
     absolute values and check all are >= 0. *)
 let test_map_combinator () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let abs_gen =
         map (fun v -> abs v) (integers ~min_value:(-100) ~max_value:100 ())
       in
@@ -40,8 +37,7 @@ let test_map_combinator () =
     integer [n] in [1..5], then generates a list of exactly [n] integers using
     [flat_map]. *)
 let test_flat_map_combinator () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:50 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:50 ()) (fun tc ->
       let pair_gen =
         flat_map
           (fun n ->
@@ -57,8 +53,7 @@ let test_flat_map_combinator () =
 
 (** Property: [sampled_from] always returns one of the specified values. *)
 let test_sampled_from () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let options = [ 10; 20; 30; 40 ] in
       let v = Hegel.draw tc (sampled_from options) in
       assert (v = 10 || v = 20 || v = 30 || v = 40))
@@ -66,8 +61,7 @@ let test_sampled_from () =
 (** Property: hashmaps generated with a min_size have at least that many
     entries. *)
 let test_hashmap_size () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:50 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:50 ()) (fun tc ->
       let pairs =
         Hegel.draw tc
           (hashmaps

--- a/examples/derived_types.ml
+++ b/examples/derived_types.ml
@@ -21,8 +21,7 @@ type entity = { name : string; tag : int option; active : bool }
 
 (** Property: the distance from any point to the origin is non-negative. *)
 let test_point_distance_nonnegative () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let p = point_generator tc in
       let dist_sq = (p.x * p.x) + (p.y * p.y) in
       assert (dist_sq >= 0))
@@ -30,8 +29,7 @@ let test_point_distance_nonnegative () =
 (** Property: color_generator covers all three constructors. *)
 let test_color_all_variants () =
   let saw = Hashtbl.create 3 in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:50 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:50 ()) (fun tc ->
       let c = color_generator tc in
       match c with
       | Red -> Hashtbl.replace saw "red" true
@@ -45,8 +43,7 @@ let test_shape_all_variants () =
   let saw_rect = ref false in
   let saw_labeled = ref false in
   let saw_dot = ref false in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let s = shape_generator tc in
       match s with
       | Circle r ->
@@ -68,8 +65,7 @@ let test_shape_all_variants () =
 let test_entity_valid () =
   let saw_tagged = ref false in
   let saw_untagged = ref false in
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:50 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:50 ()) (fun tc ->
       let e = entity_generator tc in
       ignore (String.length e.name);
       ignore e.active;

--- a/examples/real_world.ml
+++ b/examples/real_world.ml
@@ -30,8 +30,7 @@ let multiset_equal a b = List.sort compare a = List.sort compare b
 
 (** Property: merging two sorted lists gives a sorted list. *)
 let test_merge_sorted_is_sorted () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:200 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:200 ()) (fun tc ->
       let int_gen = integers ~min_value:(-1000) ~max_value:1000 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:20 () in
       let a = sorted (Hegel.draw tc list_gen) in
@@ -42,8 +41,7 @@ let test_merge_sorted_is_sorted () =
 (** Property: merging two sorted lists preserves all elements (multiset equality
     between [a @ b] and the merged result). *)
 let test_merge_preserves_elements () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:200 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:200 ()) (fun tc ->
       let int_gen = integers ~min_value:(-100) ~max_value:100 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:15 () in
       let a = sorted (Hegel.draw tc list_gen) in
@@ -54,8 +52,7 @@ let test_merge_preserves_elements () =
 (** Property: merging a list with itself preserves sorted order and doubles
     every element's count. *)
 let test_merge_with_self () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let int_gen = integers ~min_value:(-500) ~max_value:500 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:10 () in
       let a = sorted (Hegel.draw tc list_gen) in
@@ -65,8 +62,7 @@ let test_merge_with_self () =
 
 (** Property: merge is commutative up to element equality (same multiset). *)
 let test_merge_commutative () =
-  Hegel.run_hegel_test ~settings:(Hegel.Client.settings ~test_cases:100 ())
-    (fun tc ->
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:100 ()) (fun tc ->
       let int_gen = integers ~min_value:(-200) ~max_value:200 () in
       let list_gen = lists int_gen ~min_size:0 ~max_size:10 () in
       let a = sorted (Hegel.draw tc list_gen) in

--- a/lib/hegel.ml
+++ b/lib/hegel.ml
@@ -52,5 +52,4 @@ let default_settings = Client.default_settings
 
 (** [settings ?test_cases ?seed ()] creates settings with the given overrides
     applied to {!default_settings}. Convenience constructor for common cases. *)
-
 let settings = Client.settings

--- a/lib/hegel.ml
+++ b/lib/hegel.ml
@@ -49,3 +49,8 @@ let run_hegel_test = Session.run_hegel_test
 (** [default_settings ()] creates default test settings with CI auto-detection.
 *)
 let default_settings = Client.default_settings
+
+(** [settings ?test_cases ?seed ()] creates settings with the given overrides
+    applied to {!default_settings}. Convenience constructor for common cases. *)
+
+let settings = Client.settings

--- a/lib/hegel.mli
+++ b/lib/hegel.mli
@@ -50,3 +50,7 @@ val run_hegel_test :
 val default_settings : unit -> Client.settings
 (** [default_settings ()] creates default test settings with CI auto-detection.
 *)
+
+val settings : ?test_cases:int -> ?seed:int -> unit -> Client.settings
+(** [settings ?test_cases ?seed ()] creates settings with the given overrides
+    applied to {!default_settings}. Convenience constructor for common cases. *)


### PR DESCRIPTION
`default_settings` is already reexported, so doing the same for `settings`