### PR TITLE
Vendor crc32 functions from checkseum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .venv/
 .hegel/
 .hypothesis/
+.vscode/
 __pycache__/
 *.pyc
 # whitelist .claude files, rather than blacklist. Some local claude files

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal checksum refactor.

--- a/dune-project
+++ b/dune-project
@@ -29,8 +29,6 @@
     (>= 1.7)))
   (ocplib-endian
    (>= 1.2))
-  (checkseum
-   (>= 0.5))
   (ppx_js_style
    (>= v0.17))
   (bisect_ppx
@@ -40,7 +38,7 @@
   (ocamlformat
    (and
     :with-test
-    (= 0.28.1)))
+    (= 0.29.0)))
   (yojson
    (>= 1.7))
   (odoc :with-doc)))

--- a/hegel.opam
+++ b/hegel.opam
@@ -14,10 +14,9 @@ depends: [
   "core_unix" {>= "0.17"}
   "alcotest" {with-test & >= "1.7"}
   "ocplib-endian" {>= "1.2"}
-  "checkseum" {>= "0.5"}
   "ppx_js_style" {>= "v0.17"}
   "bisect_ppx" {with-test & >= "2.8"}
-  "ocamlformat" {with-test & = "0.28.1"}
+  "ocamlformat" {with-test & = "0.29.0"}
   "yojson" {>= "1.7"}
   "odoc" {with-doc}
 ]

--- a/lib/crc32/LICENSE
+++ b/lib/crc32/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Romain Calascibetta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/crc32/crc32.ml
+++ b/lib/crc32/crc32.ml
@@ -1,0 +1,298 @@
+(* Adapted from https://github.com/mirage/checkseum/blob/main/src-ocaml/gin_crc32.ml:
+    Original work: Copyright (c) 2011, Jonathan Derque - MIT licensed
+                  Copyright (c) 2018, Romain Calascibetta - MIT licensed
+    The original used [Optint.t] for portability to 32-bit OCaml. We drop that
+    since [int] on 64-bit fits a uint32. *)
+
+let crc_table =
+  [| 0x00000000
+   ; 0x77073096
+   ; 0xee0e612c
+   ; 0x990951ba
+   ; 0x076dc419
+   ; 0x706af48f
+   ; 0xe963a535
+   ; 0x9e6495a3
+   ; 0x0edb8832
+   ; 0x79dcb8a4
+   ; 0xe0d5e91e
+   ; 0x97d2d988
+   ; 0x09b64c2b
+   ; 0x7eb17cbd
+   ; 0xe7b82d07
+   ; 0x90bf1d91
+   ; 0x1db71064
+   ; 0x6ab020f2
+   ; 0xf3b97148
+   ; 0x84be41de
+   ; 0x1adad47d
+   ; 0x6ddde4eb
+   ; 0xf4d4b551
+   ; 0x83d385c7
+   ; 0x136c9856
+   ; 0x646ba8c0
+   ; 0xfd62f97a
+   ; 0x8a65c9ec
+   ; 0x14015c4f
+   ; 0x63066cd9
+   ; 0xfa0f3d63
+   ; 0x8d080df5
+   ; 0x3b6e20c8
+   ; 0x4c69105e
+   ; 0xd56041e4
+   ; 0xa2677172
+   ; 0x3c03e4d1
+   ; 0x4b04d447
+   ; 0xd20d85fd
+   ; 0xa50ab56b
+   ; 0x35b5a8fa
+   ; 0x42b2986c
+   ; 0xdbbbc9d6
+   ; 0xacbcf940
+   ; 0x32d86ce3
+   ; 0x45df5c75
+   ; 0xdcd60dcf
+   ; 0xabd13d59
+   ; 0x26d930ac
+   ; 0x51de003a
+   ; 0xc8d75180
+   ; 0xbfd06116
+   ; 0x21b4f4b5
+   ; 0x56b3c423
+   ; 0xcfba9599
+   ; 0xb8bda50f
+   ; 0x2802b89e
+   ; 0x5f058808
+   ; 0xc60cd9b2
+   ; 0xb10be924
+   ; 0x2f6f7c87
+   ; 0x58684c11
+   ; 0xc1611dab
+   ; 0xb6662d3d
+   ; 0x76dc4190
+   ; 0x01db7106
+   ; 0x98d220bc
+   ; 0xefd5102a
+   ; 0x71b18589
+   ; 0x06b6b51f
+   ; 0x9fbfe4a5
+   ; 0xe8b8d433
+   ; 0x7807c9a2
+   ; 0x0f00f934
+   ; 0x9609a88e
+   ; 0xe10e9818
+   ; 0x7f6a0dbb
+   ; 0x086d3d2d
+   ; 0x91646c97
+   ; 0xe6635c01
+   ; 0x6b6b51f4
+   ; 0x1c6c6162
+   ; 0x856530d8
+   ; 0xf262004e
+   ; 0x6c0695ed
+   ; 0x1b01a57b
+   ; 0x8208f4c1
+   ; 0xf50fc457
+   ; 0x65b0d9c6
+   ; 0x12b7e950
+   ; 0x8bbeb8ea
+   ; 0xfcb9887c
+   ; 0x62dd1ddf
+   ; 0x15da2d49
+   ; 0x8cd37cf3
+   ; 0xfbd44c65
+   ; 0x4db26158
+   ; 0x3ab551ce
+   ; 0xa3bc0074
+   ; 0xd4bb30e2
+   ; 0x4adfa541
+   ; 0x3dd895d7
+   ; 0xa4d1c46d
+   ; 0xd3d6f4fb
+   ; 0x4369e96a
+   ; 0x346ed9fc
+   ; 0xad678846
+   ; 0xda60b8d0
+   ; 0x44042d73
+   ; 0x33031de5
+   ; 0xaa0a4c5f
+   ; 0xdd0d7cc9
+   ; 0x5005713c
+   ; 0x270241aa
+   ; 0xbe0b1010
+   ; 0xc90c2086
+   ; 0x5768b525
+   ; 0x206f85b3
+   ; 0xb966d409
+   ; 0xce61e49f
+   ; 0x5edef90e
+   ; 0x29d9c998
+   ; 0xb0d09822
+   ; 0xc7d7a8b4
+   ; 0x59b33d17
+   ; 0x2eb40d81
+   ; 0xb7bd5c3b
+   ; 0xc0ba6cad
+   ; 0xedb88320
+   ; 0x9abfb3b6
+   ; 0x03b6e20c
+   ; 0x74b1d29a
+   ; 0xead54739
+   ; 0x9dd277af
+   ; 0x04db2615
+   ; 0x73dc1683
+   ; 0xe3630b12
+   ; 0x94643b84
+   ; 0x0d6d6a3e
+   ; 0x7a6a5aa8
+   ; 0xe40ecf0b
+   ; 0x9309ff9d
+   ; 0x0a00ae27
+   ; 0x7d079eb1
+   ; 0xf00f9344
+   ; 0x8708a3d2
+   ; 0x1e01f268
+   ; 0x6906c2fe
+   ; 0xf762575d
+   ; 0x806567cb
+   ; 0x196c3671
+   ; 0x6e6b06e7
+   ; 0xfed41b76
+   ; 0x89d32be0
+   ; 0x10da7a5a
+   ; 0x67dd4acc
+   ; 0xf9b9df6f
+   ; 0x8ebeeff9
+   ; 0x17b7be43
+   ; 0x60b08ed5
+   ; 0xd6d6a3e8
+   ; 0xa1d1937e
+   ; 0x38d8c2c4
+   ; 0x4fdff252
+   ; 0xd1bb67f1
+   ; 0xa6bc5767
+   ; 0x3fb506dd
+   ; 0x48b2364b
+   ; 0xd80d2bda
+   ; 0xaf0a1b4c
+   ; 0x36034af6
+   ; 0x41047a60
+   ; 0xdf60efc3
+   ; 0xa867df55
+   ; 0x316e8eef
+   ; 0x4669be79
+   ; 0xcb61b38c
+   ; 0xbc66831a
+   ; 0x256fd2a0
+   ; 0x5268e236
+   ; 0xcc0c7795
+   ; 0xbb0b4703
+   ; 0x220216b9
+   ; 0x5505262f
+   ; 0xc5ba3bbe
+   ; 0xb2bd0b28
+   ; 0x2bb45a92
+   ; 0x5cb36a04
+   ; 0xc2d7ffa7
+   ; 0xb5d0cf31
+   ; 0x2cd99e8b
+   ; 0x5bdeae1d
+   ; 0x9b64c2b0
+   ; 0xec63f226
+   ; 0x756aa39c
+   ; 0x026d930a
+   ; 0x9c0906a9
+   ; 0xeb0e363f
+   ; 0x72076785
+   ; 0x05005713
+   ; 0x95bf4a82
+   ; 0xe2b87a14
+   ; 0x7bb12bae
+   ; 0x0cb61b38
+   ; 0x92d28e9b
+   ; 0xe5d5be0d
+   ; 0x7cdcefb7
+   ; 0x0bdbdf21
+   ; 0x86d3d2d4
+   ; 0xf1d4e242
+   ; 0x68ddb3f8
+   ; 0x1fda836e
+   ; 0x81be16cd
+   ; 0xf6b9265b
+   ; 0x6fb077e1
+   ; 0x18b74777
+   ; 0x88085ae6
+   ; 0xff0f6a70
+   ; 0x66063bca
+   ; 0x11010b5c
+   ; 0x8f659eff
+   ; 0xf862ae69
+   ; 0x616bffd3
+   ; 0x166ccf45
+   ; 0xa00ae278
+   ; 0xd70dd2ee
+   ; 0x4e048354
+   ; 0x3903b3c2
+   ; 0xa7672661
+   ; 0xd06016f7
+   ; 0x4969474d
+   ; 0x3e6e77db
+   ; 0xaed16a4a
+   ; 0xd9d65adc
+   ; 0x40df0b66
+   ; 0x37d83bf0
+   ; 0xa9bcae53
+   ; 0xdebb9ec5
+   ; 0x47b2cf7f
+   ; 0x30b5ffe9
+   ; 0xbdbdf21c
+   ; 0xcabac28a
+   ; 0x53b39330
+   ; 0x24b4a3a6
+   ; 0xbad03605
+   ; 0xcdd70693
+   ; 0x54de5729
+   ; 0x23d967bf
+   ; 0xb3667a2e
+   ; 0xc4614ab8
+   ; 0x5d681b02
+   ; 0x2a6f2b94
+   ; 0xb40bbe37
+   ; 0xc30c8ea1
+   ; 0x5a05df1b
+   ; 0x2d02ef8d
+  |]
+;;
+
+let buf_fold_left get f acc buf offset length =
+  let acc_r = ref acc in
+  for i = offset to offset + length - 1 do
+    acc_r := f !acc_r (get buf i)
+  done;
+  !acc_r
+;;
+
+let update_crc acc c =
+  let index = acc land 0xff lxor (int_of_char c land 0xff) in
+  crc_table.(index) lxor (acc lsr 8)
+;;
+
+(* Int32.to_int sign extends, so if the top bit is set the int is treated as signed
+   ANDing with 0xFFFFFFFF gives the original unsigned value.
+  *)
+let crc32 =
+  fun ~get buf off len crc ->
+  let acc =
+    buf_fold_left
+      get
+      update_crc
+      (Int32.to_int crc land 0xFFFFFFFF lxor 0xFFFFFFFF)
+      buf
+      off
+      len
+  in
+  Int32.of_int (acc lxor 0xFFFFFFFF)
+;;
+
+let default = 0l
+let digest_string a o l v = crc32 ~get:String.get a o l v

--- a/lib/crc32/crc32.mli
+++ b/lib/crc32/crc32.mli
@@ -1,0 +1,3 @@
+(* CRC32 functions *)
+val default : int32
+val digest_string : string -> int -> int -> int32 -> int32

--- a/lib/crc32/dune
+++ b/lib/crc32/dune
@@ -1,0 +1,4 @@
+(library
+ (name crc32)
+ (package hegel)
+ (wrapped false))

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name hegel)
  (public_name hegel)
- (libraries core core_unix cbor checkseum.c threads.posix)
+ (libraries core core_unix cbor crc32 threads.posix)
  (private_modules
   generators_core
   generators_primitives

--- a/lib/protocol.ml
+++ b/lib/protocol.ml
@@ -64,19 +64,13 @@ let pp_packet fmt p =
 
 (** [compute_crc32 data] computes the CRC32 checksum of [data] and returns it as
     an [int32]. *)
-let compute_crc32 data =
-  let crc =
-    Checkseum.Crc32.digest_string data 0 (String.length data) Checkseum.Crc32.default
-  in
-  Optint.to_int32 crc
-;;
+let compute_crc32 data = Crc32.digest_string data 0 (String.length data) Crc32.default
 
 (** [compute_crc32_parts a b] computes the CRC32 checksum over the concatenation
     of strings [a] and [b] without allocating the concatenated string. *)
 let compute_crc32_parts a b =
-  let crc = Checkseum.Crc32.digest_string a 0 (String.length a) Checkseum.Crc32.default in
-  let crc = Checkseum.Crc32.digest_string b 0 (String.length b) crc in
-  Optint.to_int32 crc
+  let crc = Crc32.digest_string a 0 (String.length a) Crc32.default in
+  Crc32.digest_string b 0 (String.length b) crc
 ;;
 
 (** [pack_uint32_be buf offset value] writes [value] as a big-endian unsigned

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,7 @@
   test_hegel
   test_helpers
   test_protocol
+  test_crc32
   test_cbor_helpers
   test_connection
   test_client
@@ -14,7 +15,7 @@
   test_conformance_helpers
   test_derive
   test_stateful)
- (libraries hegel alcotest core core_unix threads.posix)
+ (libraries hegel alcotest core core_unix threads.posix crc32)
  (preprocess
   (pps ppx_js_style -- -allow-unannotated-ignores))
  (foreign_stubs

--- a/test/test_crc32.ml
+++ b/test/test_crc32.ml
@@ -1,0 +1,38 @@
+(** CRC32 conformance vectors. *)
+
+let rec unroll crc str off len =
+  if len = 0
+  then crc
+  else (
+    let crc = Crc32.digest_string str off 1 crc in
+    unroll crc str (off + 1) (len - 1))
+;;
+
+let check name input expected () =
+  let crc = unroll Crc32.default input 0 (String.length input) in
+  Alcotest.(check int32) name expected crc
+;;
+
+let const x _ = x
+
+let tests =
+  [ Alcotest.test_case "empty" `Quick (check "empty" "" 0l)
+  ; Alcotest.test_case "zero byte" `Quick (check "zero" "\x00" 0xd202ef8dl)
+  ; Alcotest.test_case
+      "four 0xFF bytes"
+      `Quick
+      (check "ffffffff" "\xff\xff\xff\xff" 0xffffffffl)
+  ; Alcotest.test_case
+      "check value 123456789"
+      `Quick
+      (check "check" "123456789" 0xcbf43926l)
+  ; Alcotest.test_case
+      "Donne quote"
+      `Quick
+      (check "donne" "Thou hast made me, and shall thy work decay?" 0xf1fabe1dl)
+  ; Alcotest.test_case
+      "1000 segments"
+      `Quick
+      (check "long" (String.concat "%" (List.init 1000 (const "abcdef"))) 0x0adc436fl)
+  ]
+;;

--- a/test/test_hegel.ml
+++ b/test/test_hegel.ml
@@ -7,6 +7,7 @@ let () =
   Alcotest.run
     "hegel"
     [ "protocol", Test_protocol.tests
+    ; "crc32", Test_crc32.tests
     ; "cbor_helpers", Test_cbor_helpers.tests
     ; "connection", Test_connection.tests
     ; "client", Test_client.tests


### PR DESCRIPTION
Checkseum is not included in the Jane Street core. They use their own internal crc32 functions which we do not have access to. 