### PR TITLE
Drop Cbor.Simple

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -228,7 +228,7 @@ The Hegel server speaks CBOR. Generator schemas are CBOR maps:
 ### PPX Deriver Implementation
 
 1. **PPX generates `unit -> 'a` functions, not `generator` values**: The Hegel generator
-   system operates at the CBOR level — `generate gen` returns `Cbor.Simple.t`. For
+   system operates at the CBOR level — `generate gen` returns `Cbor.t`. For
    type-directed derivation to be ergonomic, the PPX generates functions that call
    `generate` internally and extract typed OCaml values. This means derived generators
    are `unit -> my_type` thunks, not `Hegel.Generators.generator` values.

--- a/lib/cbor/cbor.ml
+++ b/lib/cbor/cbor.ml
@@ -100,226 +100,223 @@ let is_indefinite byte1 = get_additional byte1 = 31
 let int64_max_int = Int64.of_int max_int
 let two_min_int32 = 2 * Int32.to_int Int32.min_int
 
-module Simple = struct
-  type t =
-    [ `Null
-    | `Undefined
-    | `Simple of int
-    | `Bool of bool
-    | `Int of int
-    | `Float of float
-    | `Bytes of string
-    | `Text of string
-    | `Array of t list
-    | `Map of (t * t) list
-    | `Tag of int * t
-    ]
+type t =
+  [ `Null
+  | `Undefined
+  | `Simple of int
+  | `Bool of bool
+  | `Int of int
+  | `Float of float
+  | `Bytes of string
+  | `Text of string
+  | `Array of t list
+  | `Map of (t * t) list
+  | `Tag of int * t
+  ]
 
-  let encode item =
-    let open Encode in
-    let b = start () in
-    let rec write = function
-      | `Null -> put b ~maj:7 22
-      | `Undefined -> put b ~maj:7 23
-      | `Bool false -> put b ~maj:7 20
-      | `Bool true -> put b ~maj:7 21
-      | `Simple n when (n >= 0 && n <= 23) || (n >= 32 && n <= 255) -> put b ~maj:7 n
-      | `Simple n -> fail "encode: simple(%d)" n
-      | `Int n -> int b n
-      | `Float f ->
-        init b ~maj:7 27;
-        put_n b 8 BE.set_double f
-      | `Bytes s ->
-        put b ~maj:2 (String.length s);
-        Buffer.add_string b s
-      | `Text s ->
-        put b ~maj:3 (String.length s);
-        Buffer.add_string b s
-      | `Array l ->
-        put b ~maj:4 (List.length l);
-        List.iter write l
-      | `Map m ->
-        put b ~maj:5 (List.length m);
-        List.iter
-          (fun (a, b) ->
-             write a;
-             write b)
-          m
-      | `Tag (t, v) ->
-        put b ~maj:6 t;
-        write v
-    in
-    write item;
-    Buffer.contents b
-  ;;
-
-  let extract_number byte1 r =
-    match get_additional byte1 with
-    | n when n < 24 -> n
-    | 24 -> get_byte r
-    | 25 -> get_n r 2 SE.get_uint16
-    | 26 ->
-      let n = Int32.to_int @@ get_n r 4 SE.get_int32 in
-      if n < 0 then n - two_min_int32 else n
-    | 27 ->
-      let n = get_n r 8 SE.get_int64 in
-      if n > int64_max_int || n < 0L then fail "extract_number: %Lu" n;
-      Int64.to_int n
-    | n -> fail "bad additional %d" n
-  ;;
-
-  let get_float16 s i =
-    let half = (Char.code s.[i] lsl 8) + Char.code s.[i + 1] in
-    let mant = half land 0x3ff in
-    let value =
-      match (half lsr 10) land 0x1f with
-      (* exp *)
-      | 31 when mant = 0 -> infinity
-      | 31 -> nan
-      | 0 -> ldexp (float mant) ~-24
-      | exp -> ldexp (float @@ (mant + 1024)) (exp - 25)
-    in
-    if half land 0x8000 = 0 then value else ~-.value
-  ;;
-
-  exception Break
-
-  let extract_list byte1 r f =
-    if is_indefinite byte1
-    then (
-      let l = ref [] in
-      try
-        while true do
-          l := f r :: !l
-        done;
-        assert false
-      with
-      | Break -> List.rev !l)
-    else (
-      let n = extract_number byte1 r in
-      Array.to_list @@ Array.init n (fun _ -> f r))
-  ;;
-
-  let rec extract_pair r =
-    let a = extract r in
-    let b =
-      try extract r with
-      | Break -> fail "extract_pair: unexpected break"
-    in
-    a, b
-
-  and extract_string byte1 r f =
-    if is_indefinite byte1
-    then (
-      let b = Buffer.create 10 in
-      try
-        while true do
-          Buffer.add_string b (f @@ extract r)
-        done;
-        assert false
-      with
-      | Break -> Buffer.contents b)
-    else (
-      let n = extract_number byte1 r in
-      get_s r n)
-
-  and extract r =
-    let byte1 = get_byte r in
-    match byte1 lsr 5 with
-    | 0 -> `Int (extract_number byte1 r)
-    | 1 -> `Int (-1 - extract_number byte1 r)
-    | 2 ->
-      `Bytes
-        (extract_string byte1 r (function
-           | `Bytes s -> s
-           | _ -> fail "extract: not a bytes chunk"))
-    | 3 ->
-      `Text
-        (extract_string byte1 r (function
-           | `Text s -> s
-           | _ -> fail "extract: not a text chunk"))
-    | 4 -> `Array (extract_list byte1 r extract)
-    | 5 -> `Map (extract_list byte1 r extract_pair)
-    | 6 ->
-      let tag = extract_number byte1 r in
-      let v = extract r in
-      `Tag (tag, v)
-    | 7 ->
-      (match get_additional byte1 with
-       | n when n < 20 -> `Simple n
-       | 20 -> `Bool false
-       | 21 -> `Bool true
-       | 22 -> `Null
-       | 23 -> `Undefined
-       | 24 -> `Simple (get_byte r)
-       | 25 -> `Float (get_n r 2 get_float16)
-       | 26 -> `Float (get_n r 4 SE.get_float)
-       | 27 -> `Float (get_n r 8 SE.get_double)
-       | 31 -> raise Break
-       | a -> fail "extract: (7,%d)" a)
-    | _ -> assert false
-  ;;
-
-  let decode_partial s =
-    let i = ref 0 in
-    let x =
-      try extract (s, i) with
-      | Break -> fail "decode: unexpected break"
-    in
-    x, String.sub s !i (String.length s - !i)
-  ;;
-
-  let decode s : t =
-    let x, rest = decode_partial s in
-    if rest = ""
-    then x
-    else
-      fail
-        "decode: extra data: len %d pos %d"
-        (String.length s)
-        (String.length s - String.length rest)
-  ;;
-
-  let to_diagnostic item =
-    let b = Buffer.create 10 in
-    let put s = Buffer.add_string b s in
-    let rec write = function
-      | `Null -> put "null"
-      | `Bool false -> put "false"
-      | `Bool true -> put "true"
-      | `Simple n -> bprintf b "simple(%d)" n
-      | `Undefined -> put "undefined"
-      | `Int n -> bprintf b "%d" n
-      | `Float f ->
-        (match classify_float f with
-         | FP_nan -> put "NaN"
-         | FP_infinite -> put (if f < 0. then "-Infinity" else "Infinity")
-         | FP_zero | FP_normal | FP_subnormal -> put (string_of_float f))
-      | `Bytes s -> bprintf b "h'%s'" (Encode.to_hex s)
-      | `Text s -> bprintf b "\"%s\"" s
-      | `Array l ->
-        put "[";
-        l
-        |> list_iteri (fun i x ->
-          if i <> 0 then put ", ";
-          write x);
-        put "]"
-      | `Map m ->
-        put "{";
+let encode item =
+  let open Encode in
+  let b = start () in
+  let rec write = function
+    | `Null -> put b ~maj:7 22
+    | `Undefined -> put b ~maj:7 23
+    | `Bool false -> put b ~maj:7 20
+    | `Bool true -> put b ~maj:7 21
+    | `Simple n when (n >= 0 && n <= 23) || (n >= 32 && n <= 255) -> put b ~maj:7 n
+    | `Simple n -> fail "encode: simple(%d)" n
+    | `Int n -> int b n
+    | `Float f ->
+      init b ~maj:7 27;
+      put_n b 8 BE.set_double f
+    | `Bytes s ->
+      put b ~maj:2 (String.length s);
+      Buffer.add_string b s
+    | `Text s ->
+      put b ~maj:3 (String.length s);
+      Buffer.add_string b s
+    | `Array l ->
+      put b ~maj:4 (List.length l);
+      List.iter write l
+    | `Map m ->
+      put b ~maj:5 (List.length m);
+      List.iter
+        (fun (a, b) ->
+           write a;
+           write b)
         m
-        |> list_iteri (fun i (k, v) ->
-          if i <> 0 then put ", ";
-          write k;
-          put ": ";
-          write v);
-        put "}"
-      | `Tag (t, v) ->
-        bprintf b "%i(" t;
-        write v;
-        put ")"
-    in
-    write item;
-    Buffer.contents b
-  ;;
-end
-(* Simple *)
+    | `Tag (t, v) ->
+      put b ~maj:6 t;
+      write v
+  in
+  write item;
+  Buffer.contents b
+;;
+
+let extract_number byte1 r =
+  match get_additional byte1 with
+  | n when n < 24 -> n
+  | 24 -> get_byte r
+  | 25 -> get_n r 2 SE.get_uint16
+  | 26 ->
+    let n = Int32.to_int @@ get_n r 4 SE.get_int32 in
+    if n < 0 then n - two_min_int32 else n
+  | 27 ->
+    let n = get_n r 8 SE.get_int64 in
+    if n > int64_max_int || n < 0L then fail "extract_number: %Lu" n;
+    Int64.to_int n
+  | n -> fail "bad additional %d" n
+;;
+
+let get_float16 s i =
+  let half = (Char.code s.[i] lsl 8) + Char.code s.[i + 1] in
+  let mant = half land 0x3ff in
+  let value =
+    match (half lsr 10) land 0x1f with
+    (* exp *)
+    | 31 when mant = 0 -> infinity
+    | 31 -> nan
+    | 0 -> ldexp (float mant) ~-24
+    | exp -> ldexp (float @@ (mant + 1024)) (exp - 25)
+  in
+  if half land 0x8000 = 0 then value else ~-.value
+;;
+
+exception Break
+
+let extract_list byte1 r f =
+  if is_indefinite byte1
+  then (
+    let l = ref [] in
+    try
+      while true do
+        l := f r :: !l
+      done;
+      assert false
+    with
+    | Break -> List.rev !l)
+  else (
+    let n = extract_number byte1 r in
+    Array.to_list @@ Array.init n (fun _ -> f r))
+;;
+
+let rec extract_pair r =
+  let a = extract r in
+  let b =
+    try extract r with
+    | Break -> fail "extract_pair: unexpected break"
+  in
+  a, b
+
+and extract_string byte1 r f =
+  if is_indefinite byte1
+  then (
+    let b = Buffer.create 10 in
+    try
+      while true do
+        Buffer.add_string b (f @@ extract r)
+      done;
+      assert false
+    with
+    | Break -> Buffer.contents b)
+  else (
+    let n = extract_number byte1 r in
+    get_s r n)
+
+and extract r =
+  let byte1 = get_byte r in
+  match byte1 lsr 5 with
+  | 0 -> `Int (extract_number byte1 r)
+  | 1 -> `Int (-1 - extract_number byte1 r)
+  | 2 ->
+    `Bytes
+      (extract_string byte1 r (function
+         | `Bytes s -> s
+         | _ -> fail "extract: not a bytes chunk"))
+  | 3 ->
+    `Text
+      (extract_string byte1 r (function
+         | `Text s -> s
+         | _ -> fail "extract: not a text chunk"))
+  | 4 -> `Array (extract_list byte1 r extract)
+  | 5 -> `Map (extract_list byte1 r extract_pair)
+  | 6 ->
+    let tag = extract_number byte1 r in
+    let v = extract r in
+    `Tag (tag, v)
+  | 7 ->
+    (match get_additional byte1 with
+     | n when n < 20 -> `Simple n
+     | 20 -> `Bool false
+     | 21 -> `Bool true
+     | 22 -> `Null
+     | 23 -> `Undefined
+     | 24 -> `Simple (get_byte r)
+     | 25 -> `Float (get_n r 2 get_float16)
+     | 26 -> `Float (get_n r 4 SE.get_float)
+     | 27 -> `Float (get_n r 8 SE.get_double)
+     | 31 -> raise Break
+     | a -> fail "extract: (7,%d)" a)
+  | _ -> assert false
+;;
+
+let decode_partial s =
+  let i = ref 0 in
+  let x =
+    try extract (s, i) with
+    | Break -> fail "decode: unexpected break"
+  in
+  x, String.sub s !i (String.length s - !i)
+;;
+
+let decode s : t =
+  let x, rest = decode_partial s in
+  if rest = ""
+  then x
+  else
+    fail
+      "decode: extra data: len %d pos %d"
+      (String.length s)
+      (String.length s - String.length rest)
+;;
+
+let to_diagnostic item =
+  let b = Buffer.create 10 in
+  let put s = Buffer.add_string b s in
+  let rec write = function
+    | `Null -> put "null"
+    | `Bool false -> put "false"
+    | `Bool true -> put "true"
+    | `Simple n -> bprintf b "simple(%d)" n
+    | `Undefined -> put "undefined"
+    | `Int n -> bprintf b "%d" n
+    | `Float f ->
+      (match classify_float f with
+       | FP_nan -> put "NaN"
+       | FP_infinite -> put (if f < 0. then "-Infinity" else "Infinity")
+       | FP_zero | FP_normal | FP_subnormal -> put (string_of_float f))
+    | `Bytes s -> bprintf b "h'%s'" (Encode.to_hex s)
+    | `Text s -> bprintf b "\"%s\"" s
+    | `Array l ->
+      put "[";
+      l
+      |> list_iteri (fun i x ->
+        if i <> 0 then put ", ";
+        write x);
+      put "]"
+    | `Map m ->
+      put "{";
+      m
+      |> list_iteri (fun i (k, v) ->
+        if i <> 0 then put ", ";
+        write k;
+        put ": ";
+        write v);
+      put "}"
+    | `Tag (t, v) ->
+      bprintf b "%i(" t;
+      write v;
+      put ")"
+  in
+  write item;
+  Buffer.contents b
+;;

--- a/lib/cbor/cbor.mli
+++ b/lib/cbor/cbor.mli
@@ -2,23 +2,21 @@
 
 exception Error of string
 
-module Simple : sig
-  type t =
-    [ `Null
-    | `Undefined
-    | `Simple of int
-    | `Bool of bool
-    | `Int of int
-    | `Float of float
-    | `Bytes of string
-    | `Text of string
-    | `Array of t list
-    | `Map of (t * t) list
-    | `Tag of int * t
-    ]
+type t =
+  [ `Null
+  | `Undefined
+  | `Simple of int
+  | `Bool of bool
+  | `Int of int
+  | `Float of float
+  | `Bytes of string
+  | `Text of string
+  | `Array of t list
+  | `Map of (t * t) list
+  | `Tag of int * t
+  ]
 
-  val encode : t -> string
-  val decode : string -> t
-  val decode_partial : string -> t * string
-  val to_diagnostic : t -> string
-end
+val encode : t -> string
+val decode : string -> t
+val decode_partial : string -> t * string
+val to_diagnostic : t -> string

--- a/lib/cbor_helpers.ml
+++ b/lib/cbor_helpers.ml
@@ -6,11 +6,11 @@
 
 open! Core
 
-(** The type of CBOR values, re-exported from [Cbor.Simple]. *)
-type t = Cbor.Simple.t
+(** The type of CBOR values, re-exported from [Cbor]. *)
+type t = Cbor.t
 
 (** [encode v] serializes the CBOR value [v] to a binary string. *)
-let encode = Cbor.Simple.encode
+let encode = Cbor.encode
 
 (** CBOR tag used by Hegel to encode strings as raw UTF-8 bytes (WTF-8). *)
 let hegel_string_tag = 91
@@ -29,7 +29,7 @@ let rec convert_tagged_strings = function
 
 (** [decode s] deserializes a CBOR value from the binary string [s], converting
     Hegel's tag-91 encoded strings to plain text values. *)
-let decode s = Cbor.Simple.decode s |> convert_tagged_strings
+let decode s = Cbor.decode s |> convert_tagged_strings
 
 (** [type_name v] returns a human-readable name for the CBOR type of [v]. *)
 let type_name = function

--- a/lib/cbor_helpers.mli
+++ b/lib/cbor_helpers.mli
@@ -4,8 +4,8 @@
     values, plus type-safe extractor functions that produce clear error messages
     when a value has an unexpected type. *)
 
-(** The type of CBOR values, re-exported from [Cbor.Simple]. *)
-type t = Cbor.Simple.t
+(** The type of CBOR values, re-exported from [Cbor]. *)
+type t = Cbor.t
 
 (** [encode v] serializes the CBOR value [v] to a binary string. *)
 val encode : t -> string

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -214,7 +214,7 @@ let note tc message = if tc.is_final then eprintf "%s\n%!" message
     toward higher values. *)
 let target tc value label =
   let stream = tc.stream in
-  let (_ : Cbor.Simple.t) =
+  let (_ : Cbor.t) =
     pending_get
       (request
          stream
@@ -233,7 +233,7 @@ let start_span ?(label = 0) tc =
   then ()
   else (
     let stream = tc.stream in
-    let (_ : Cbor.Simple.t) =
+    let (_ : Cbor.t) =
       pending_get
         (request
            stream
@@ -248,7 +248,7 @@ let stop_span ?(discard = false) tc =
   then ()
   else (
     let stream = tc.stream in
-    let (_ : Cbor.Simple.t) =
+    let (_ : Cbor.t) =
       pending_get
         (request
            stream
@@ -379,7 +379,7 @@ let run_test_case _client stream test_fn ~is_final =
        | Data_was_exhausted | Flaky_strategy_definition -> assert false
      in
      (try
-        let (_ : Cbor.Simple.t) =
+        let (_ : Cbor.t) =
           pending_get
             (request
                stream
@@ -453,7 +453,7 @@ let run_test client ~settings ?database_key test_fn =
           ]
       in
       let fields = base_fields @ database_field @ suppress_field @ phases_field in
-      let (_ : Cbor.Simple.t) = pending_get (request client.control (`Map fields)) in
+      let (_ : Cbor.t) = pending_get (request client.control (`Map fields)) in
       ());
   let receive_and_run_test_case ~is_final =
     let message_id, message = receive_request test_stream () in
@@ -497,7 +497,7 @@ let run_test client ~settings ?database_key test_fn =
       send_response_raw
         test_stream
         message_id
-        (Cbor.Simple.encode
+        (Cbor.encode
            (`Map
                [ `Text "error", `Text (sprintf "Unrecognised event %s" event)
                ; `Text "type", `Text "InvalidMessage"

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -114,7 +114,7 @@ val extract_origin : exn -> string
     a generate command to the server. Raises {!Data_exhausted} if the server
     signals StopTest or {!Flaky_strategy} if it signals FlakyStrategyDefinition.
 *)
-val generate_from_schema : Cbor.Simple.t -> test_case -> Cbor.Simple.t
+val generate_from_schema : Cbor.t -> test_case -> Cbor.t
 
 (** [assume tc condition] rejects the current test case if [condition] is
     [false]. *)

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -39,7 +39,7 @@ exception
   Request_error of
     { message : string
     ; error_type : string
-    ; data : (Cbor.Simple.t * Cbor.Simple.t) list
+    ; data : (Cbor.t * Cbor.t) list
     }
 
 (** [result_or_error body] extracts the ["result"] field from a CBOR map, or
@@ -237,7 +237,7 @@ let reader_loop conn =
               { stream_id = pkt.stream_id
               ; message_id = pkt.message_id
               ; is_reply = true
-              ; payload = Cbor.Simple.encode (`Map [ `Text "error", `Text error_msg ])
+              ; payload = Cbor.encode (`Map [ `Text "error", `Text error_msg ])
               }
           with
           | _ -> ()))
@@ -459,7 +459,7 @@ let send_request_raw ch payload =
 
 (** [send_request ch message] sends a CBOR-encoded request and returns the
     message ID. *)
-let send_request ch message = send_request_raw ch (Cbor.Simple.encode message)
+let send_request ch message = send_request_raw ch (Cbor.encode message)
 
 (** [receive_response_raw ch message_id ?timeout ()] waits for raw response
     bytes to a request with the given [message_id]. *)
@@ -504,7 +504,7 @@ let send_response_raw ch message_id payload =
 (** [send_response_value ch message_id value] sends a success response with
     [value] wrapped as [{"result": value}]. *)
 let send_response_value ch message_id value =
-  send_response_raw ch message_id (Cbor.Simple.encode (`Map [ `Text "result", value ]))
+  send_response_raw ch message_id (Cbor.encode (`Map [ `Text "result", value ]))
 ;;
 
 (** [close_stream ch] closes the stream and notifies the peer. Idempotent. *)
@@ -542,7 +542,7 @@ let close_stream ch =
 type pending_request =
   { pr_stream : stream
   ; pr_message_id : int32
-  ; mutable pr_value : Cbor.Simple.t option
+  ; mutable pr_value : Cbor.t option
   }
 
 (** [request ch message] sends a CBOR request and returns a {!pending_request}

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -19,12 +19,12 @@ exception
   Request_error of
     { message : string
     ; error_type : string
-    ; data : (Cbor.Simple.t * Cbor.Simple.t) list
+    ; data : (Cbor.t * Cbor.t) list
     }
 
 (** [result_or_error body] extracts the ["result"] field from a CBOR map, or
     raises {!Request_error} if an ["error"] field is present. *)
-val result_or_error : Cbor.Simple.t -> Cbor.Simple.t
+val result_or_error : Cbor.t -> Cbor.t
 
 (** Connection state after handshake. *)
 type connection_state =
@@ -125,7 +125,7 @@ val send_request_raw : stream -> string -> int32
 
 (** [send_request ch message] sends a CBOR-encoded request and returns the
     message ID. *)
-val send_request : stream -> Cbor.Simple.t -> int32
+val send_request : stream -> Cbor.t -> int32
 
 (** [receive_response_raw ch message_id ?timeout ()] waits for raw response
     bytes to a request with the given [message_id]. *)
@@ -133,7 +133,7 @@ val receive_response_raw : stream -> int32 -> ?timeout:float -> unit -> string
 
 (** [receive_response ch message_id ?timeout ()] waits for and decodes a
     response, extracting the result or raising {!Request_error}. *)
-val receive_response : stream -> int32 -> ?timeout:float -> unit -> Cbor.Simple.t
+val receive_response : stream -> int32 -> ?timeout:float -> unit -> Cbor.t
 
 (** [receive_request_raw ch ?timeout ()] receives raw request bytes and returns
     [(message_id, payload)]. *)
@@ -141,14 +141,14 @@ val receive_request_raw : stream -> ?timeout:float -> unit -> int32 * string
 
 (** [receive_request ch ?timeout ()] receives and CBOR-decodes a request,
     returning [(message_id, decoded_value)]. *)
-val receive_request : stream -> ?timeout:float -> unit -> int32 * Cbor.Simple.t
+val receive_request : stream -> ?timeout:float -> unit -> int32 * Cbor.t
 
 (** [send_response_raw ch message_id payload] sends raw bytes as a reply. *)
 val send_response_raw : stream -> int32 -> string -> unit
 
 (** [send_response_value ch message_id value] sends a success response with
     [value] wrapped as [{"result": value}]. *)
-val send_response_value : stream -> int32 -> Cbor.Simple.t -> unit
+val send_response_value : stream -> int32 -> Cbor.t -> unit
 
 (** [close_stream ch] closes the stream and notifies the peer. Idempotent. *)
 val close_stream : stream -> unit
@@ -157,17 +157,17 @@ val close_stream : stream -> unit
 type pending_request =
   { pr_stream : stream
   ; pr_message_id : int32
-  ; mutable pr_value : Cbor.Simple.t option
+  ; mutable pr_value : Cbor.t option
   }
 
 (** [request ch message] sends a CBOR request and returns a {!pending_request}
     handle. *)
-val request : stream -> Cbor.Simple.t -> pending_request
+val request : stream -> Cbor.t -> pending_request
 
 (** [pending_get pr] blocks until the response arrives and returns the result.
     Caches the response so subsequent calls return the same value or raise the
     same error. *)
-val pending_get : pending_request -> Cbor.Simple.t
+val pending_get : pending_request -> Cbor.t
 
 (** [process_one_message ch ?timeout ()] waits for and routes one incoming
     message for stream [ch]. Dispatches replies to the stream's responses table

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -26,8 +26,8 @@ end
 
 type 'a generator =
   | Basic :
-      { schema : Cbor.Simple.t
-      ; transform : Cbor.Simple.t -> 'a
+      { schema : Cbor.t
+      ; transform : Cbor.t -> 'a
       }
       -> 'a generator
   | Mapped :
@@ -89,7 +89,7 @@ val discardable_group : int -> Client.test_case -> (unit -> 'a) -> 'a
 (** A collection handle for generating variable-length sequences. *)
 type collection =
   { mutable finished : bool
-  ; mutable collection_id : Cbor.Simple.t option
+  ; mutable collection_id : Cbor.t option
   ; min_size : int
   ; max_size : int option
   }
@@ -135,14 +135,14 @@ val flat_map : ('a -> 'b generator) -> 'a generator -> 'b generator
 val filter : ('a -> bool) -> 'a generator -> 'a generator
 
 (** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
-val schema : 'a generator -> Cbor.Simple.t option
+val schema : 'a generator -> Cbor.t option
 
 (** [is_basic gen] returns [true] if [gen] is a [Basic] generator. *)
 val is_basic : 'a generator -> bool
 
 (** [as_basic gen] returns [Some (schema, transform)] if [gen] is [Basic], or
     [None] otherwise. *)
-val as_basic : 'a generator -> (Cbor.Simple.t * (Cbor.Simple.t -> 'a)) option
+val as_basic : 'a generator -> (Cbor.t * (Cbor.t -> 'a)) option
 
 (** {2 Primitive generators} *)
 

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -37,8 +37,8 @@ end
       given [label]. Used for tuples and one_of with non-basic elements. *)
 type 'a generator =
   | Basic :
-      { schema : Cbor.Simple.t
-      ; transform : Cbor.Simple.t -> 'a
+      { schema : Cbor.t
+      ; transform : Cbor.t -> 'a
       }
       -> 'a generator
   | Mapped :
@@ -99,7 +99,7 @@ let discardable_group label data f =
     calls once the server signals completion. *)
 type collection =
   { mutable finished : bool
-  ; mutable collection_id : Cbor.Simple.t option
+  ; mutable collection_id : Cbor.t option
   ; min_size : int
   ; max_size : int option
   }
@@ -180,7 +180,7 @@ let collection_reject coll data =
     let collection_id = get_collection_id coll data in
     let stream = data.Client.stream in
     try
-      let (_ : Cbor.Simple.t) =
+      let (_ : Cbor.t) =
         pending_get
           (request
              stream
@@ -266,7 +266,7 @@ let flat_map f gen = FlatMapped { source = gen; f }
 let filter predicate gen = Filtered { source = gen; predicate }
 
 (** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
-let schema : type a. a generator -> Cbor.Simple.t option = function
+let schema : type a. a generator -> Cbor.t option = function
   | Basic { schema; _ } -> Some schema
   | _ -> None
 ;;
@@ -279,8 +279,7 @@ let is_basic : type a. a generator -> bool = function
 
 (** [as_basic gen] returns [Some (schema, transform)] if [gen] is [Basic], or
     [None] otherwise. *)
-let as_basic : type a. a generator -> (Cbor.Simple.t * (Cbor.Simple.t -> a)) option =
-  function
+let as_basic : type a. a generator -> (Cbor.t * (Cbor.t -> a)) option = function
   | Basic { schema; transform } -> Some (schema, transform)
   | _ -> None
 ;;

--- a/test/test_cbor_vectors.ml
+++ b/test/test_cbor_vectors.ml
@@ -1,12 +1,12 @@
 (** Each JSON entry becomes one Alcotest case that:
 
     1. Hex-decodes the [hex] field to obtain the wire-format CBOR.
-    2. Decodes with [Cbor.Simple.decode] and checks the diagnostic string
+    2. Decodes with [Cbor.decode] and checks the diagnostic string
        against the expected [diagnostic], or the JSON-converted value against
        the expected [decoded] JSON.
 *)
 
-module Simple = Cbor.Simple
+module Simple = Cbor
 
 type result =
   | Decoded of Yojson.Safe.t
@@ -60,7 +60,7 @@ let rec json_of_cbor : Simple.t -> Yojson.Safe.t = function
     `String (Printf.sprintf "%d(%s)" t (Yojson.Safe.to_string (json_of_cbor v)))
 ;;
 
-(** Vectors whose [decoded] value falls outside what [Cbor.Simple] can
+(** Vectors whose [decoded] value falls outside what [Cbor] can
     represent — 64-bit unsigned literals and bignum tags. The upstream test
     has the same exclusion list. *)
 let appendix_a_ignored = [ 10; 11; 12; 13; 71 ]

--- a/test/test_client.ml
+++ b/test/test_client.ml
@@ -856,7 +856,7 @@ let test_pool_request_stop_test () =
          send_response_raw
            data_ch
            msg_id
-           (Cbor.Simple.encode
+           (Cbor.encode
               (`Map
                   [ `Text "error", `Text "data exhausted"
                   ; `Text "type", `Text "StopTest"
@@ -1270,7 +1270,7 @@ let test_send_error_reply_fails_silently () =
     { Protocol.stream_id = 99l
     ; message_id = 1l
     ; is_reply = false
-    ; payload = Cbor.Simple.encode (`Map [ `Text "command", `Text "hello" ])
+    ; payload = Cbor.encode (`Map [ `Text "command", `Text "hello" ])
     }
   in
   Protocol.write_packet peer_write_fd pkt;

--- a/test/test_connection.ml
+++ b/test/test_connection.ml
@@ -509,7 +509,7 @@ let test_message_to_nonexistent_stream () =
     { stream_id = 999l
     ; message_id = 1l
     ; is_reply = false
-    ; payload = Cbor.Simple.encode (`Map [ `Text "command", `Text "test" ])
+    ; payload = Cbor.encode (`Map [ `Text "command", `Text "test" ])
     };
   (* Also send a control stream message so the peer processes packets *)
   ignore (send_request_raw (control_stream client_conn) "ping");
@@ -859,7 +859,7 @@ let test_message_to_dead_stream_in_reader () =
     { stream_id = ch_id
     ; message_id = 1l
     ; is_reply = false
-    ; payload = Cbor.Simple.encode (`Map [ `Text "test", `Text "data" ])
+    ; payload = Cbor.encode (`Map [ `Text "test", `Text "data" ])
     };
   (* Also send something to control so we can synchronize *)
   ignore (send_request_raw (control_stream client_conn) "sync");

--- a/test/test_generators_core.ml
+++ b/test/test_generators_core.ml
@@ -68,10 +68,7 @@ let test_double_map_on_basic () =
   (* Verify schema is preserved through both maps *)
   match schema gen, schema m2 with
   | Some s1, Some s2 ->
-    Alcotest.(check bool)
-      "schema unchanged"
-      true
-      (Cbor.Simple.encode s1 = Cbor.Simple.encode s2)
+    Alcotest.(check bool) "schema unchanged" true (Cbor.encode s1 = Cbor.encode s2)
   | _ -> Alcotest.fail "expected both schemas"
 ;;
 
@@ -203,7 +200,7 @@ let test_collection_more_stoptest () =
          send_response_raw
            peer_ch
            msg_id
-           (Cbor.Simple.encode
+           (Cbor.encode
               (`Map
                   [ `Text "error", `Text "Test case is being abandoned"
                   ; `Text "type", `Text "StopTest"


### PR DESCRIPTION
Drops Cbor.Simple module and moves functions in Cbor.Simple to Cbor. The vendored cbor has an implementation that follows the stricter CTAP2 standard, which we do not use, so there's no need to differentiate between specs.