### PR TITLE
Phase 1: core draw-printing mechanism + counterexample header

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,7 @@
  (name ppx_hegel_generator)
  (synopsis "PPX deriver for Hegel generator derivation")
  (description
-  "Automatically derives Hegel generators for OCaml types annotated with [@@deriving generator].")
+  "Automatically derives Hegel generators for OCaml types annotated with [@@deriving hegel].")
  (depends
   (ocaml
    (>= 5.2))

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -191,13 +191,19 @@ let with_print_blob b s = { s with print_blob = b }
 let with_report_multiple_failures b s = { s with report_multiple_failures = b }
 
 (** Per-test-case state passed explicitly to the test function. Holds the
-    native test-case handle, the final-replay flag, and abort state. *)
+    native test-case handle, the final-replay flag, whether verbose output is
+    on, abort state, the current generation-span depth (used to print only the
+    outermost drawn value), and the per-name occurrence counter that numbers
+    repeatable draws. *)
 type test_case =
   { handle : Ffi.test_case
   ; mode : mode
   ; stateful_step_count : int
   ; is_final : bool
+  ; verbosity : verbosity
   ; mutable test_aborted : bool
+  ; mutable draw_depth : int
+  ; draw_counts : int String.Table.t
   }
 
 (** Domain-local flag to detect nested test cases. *)
@@ -265,9 +271,28 @@ let primitive_boolean tc p forced =
     [false]. *)
 let assume _tc condition = if not condition then raise Assume_rejected
 
-(** [note tc message] records a message that will be printed on the final
-    (failing) replay. *)
-let note tc message = if tc.is_final then eprintf "%s\n%!" message
+(** [note tc message] prints [message] to stderr subject to the run's
+    {!type:verbosity}: never under [Quiet], only on the final (failing) replay
+    under [Normal], and on every test case under [Verbose] or [Debug]. *)
+let note tc message =
+  let should_print =
+    match tc.verbosity with
+    | Quiet -> false
+    | Normal -> tc.is_final
+    | Verbose | Debug -> true
+  in
+  if should_print then eprintf "%s\n%!" message
+;;
+
+(** [draw_display_name tc ~label ~repeatable] returns the display name to print
+    for a drawn value, bumping the per-test-case occurrence counter for [label].
+    A [repeatable] name is numbered on every occurrence ([label_1], [label_2],
+    …), while a non-repeatable name is printed bare. *)
+let draw_display_name tc ~label ~repeatable =
+  let n = Option.value (Hashtbl.find tc.draw_counts label) ~default:0 + 1 in
+  Hashtbl.set tc.draw_counts ~key:label ~data:n;
+  if repeatable then sprintf "%s_%d" label n else label
+;;
 
 (** [target tc value label] records a targeting observation to guide the search
     engine toward higher values. *)
@@ -393,19 +418,22 @@ let build_ffi_settings (settings : settings) ~database_key =
   s
 ;;
 
-(** [run_test_case ~settings ~test_fn handle] runs [test_fn] over a single native
-    test-case [handle], maps the outcome to a {!Ffi.status}, and marks the case
-    complete. Returns [Some (origin, exn)] when the case was {e interesting}
+(** [run_test_case ~mode ~verbose ~test_fn handle] runs [test_fn] over a single 
+    native test-case [handle], maps the outcome to a {!Ffi.status}, and marks 
+    the case complete. Returns [Some (origin, exn)] when the case was {e interesting}
     (the body raised an unexpected exception), otherwise [None]. Shared by the
     engine-run and failure-blob replay paths. *)
 let run_test_case ~(settings : settings) ~test_fn handle =
   let is_final = Ffi.is_final_replay handle in
-  let tc =
+  let (tc : test_case) =
     { handle
     ; mode = settings.mode
-    ; stateful_step_count = settings.stateful_step_count
     ; is_final
+    ; verbosity = settings.verbosity
+    ; stateful_step_count = settings.stateful_step_count
     ; test_aborted = false
+    ; draw_depth = 0
+    ; draw_counts = String.Table.create ()
     }
   in
   Stdlib.Domain.DLS.set in_test_context true;

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -127,13 +127,19 @@ val with_print_blob : bool -> settings -> settings
 val with_report_multiple_failures : bool -> settings -> settings
 
 (** Per-test-case state passed explicitly to the test function. Holds the
-    native test-case handle, the final-replay flag, and abort state. *)
+    native test-case handle, the final-replay flag, whether verbose output is
+    on, abort state, the current generation-span depth (used to print only the
+    outermost drawn value), and the per-name occurrence counter that numbers
+    repeatable draws. *)
 type test_case =
   { handle : Hegel_ffi.Ffi.test_case
   ; mode : mode
   ; stateful_step_count : int
   ; is_final : bool
+  ; verbosity : verbosity
   ; mutable test_aborted : bool
+  ; mutable draw_depth : int
+  ; draw_counts : int Core.String.Table.t
   }
 
 (** [extract_origin exn] extracts an InterestingOrigin string from an exception.
@@ -158,9 +164,16 @@ val primitive_boolean : test_case -> float -> bool option -> bool
     [false]. *)
 val assume : test_case -> bool -> unit
 
-(** [note tc message] records a message that will be printed on the final
-    (failing) replay. *)
+(** [note tc message] prints [message] to stderr subject to the run's
+    {!type:verbosity}: never under [Quiet], only on the final (failing) replay
+    under [Normal], and on every test case under [Verbose] or [Debug]. *)
 val note : test_case -> string -> unit
+
+(** [draw_display_name tc ~label ~repeatable] returns the display name to print
+    for a drawn value, bumping the per-test-case occurrence counter for [label].
+    A [repeatable] name is numbered on every occurrence ([label_1], [label_2],
+    …), while a non-repeatable name is printed bare. *)
+val draw_display_name : test_case -> label:string -> repeatable:bool -> string
 
 (** [target tc value label] records a targeting observation to guide the search
     engine toward higher values. *)

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -2,7 +2,15 @@
 
     This module provides a composable generator API for property-based testing.
     Generators produce typed OCaml values and can be combined using {!map},
-    {!flat_map}, and {!filter}. *)
+    {!flat_map}, and {!filter}.
+
+    Every generator carries a phantom ['p] recording whether it holds a printer.
+    Primitive and composite generators are {!printable} and may be drawn with
+    {!draw}, which prints the drawn value on a failing replay. {!map},
+    {!flat_map}, {!sampled_from}, and {!just} hand the output type to user code
+    and so are {!unprintable}: they can be drawn with {!draw_silent}, or made
+    printable with {!with_printer}. Composite combinators ({!lists}, {!tuples2},
+    {!one_of}, …) require printable components and produce printable results. *)
 
 (** Constants for span labels used in generation tracking. *)
 module Labels : sig
@@ -24,56 +32,16 @@ module Labels : sig
   val stateful_rule : int
 end
 
-type 'a generator =
-  | Basic :
-      { schema : Cbor.t
-      ; transform : Cbor.t -> 'a
-      ; unique_safe : bool
-      }
-      -> 'a generator
-  | Mapped :
-      { source : 'b generator
-      ; f : 'b -> 'a
-      }
-      -> 'a generator
-  | FlatMapped :
-      { source : 'b generator
-      ; f : 'b -> 'a generator
-      }
-      -> 'a generator
-  | Filtered :
-      { source : 'a generator
-      ; predicate : 'a -> bool
-      }
-      -> 'a generator
-  | CompositeList :
-      { elements : 'a generator
-      ; min_size : int
-      ; max_size : int option
-      }
-      -> 'a list generator
-  | Composite :
-      { label : int
-      ; generate_fn : Client.test_case -> 'a
-      }
-      -> 'a generator
-  (** The type of generators. Generators produce typed OCaml values and can
-          be combined using {!map}, {!flat_map}, and {!filter}.
+(** A generator producing values of type ['a]. The phantom ['p] is {!printable}
+    when the generator carries a printer (and so may be drawn with {!draw}) and
+    {!unprintable} otherwise. *)
+type ('a, 'p) generator
 
-          - [Basic] generators hold a raw schema and a mandatory client-side
-            transform. Calling {!map} on a [Basic] generator preserves the
-            schema and composes transforms.
-          - [Mapped] generators wrap a source generator and a transform
-            function.
-          - [FlatMapped] generators wrap a source and a function returning a
-            generator.
-          - [Filtered] generators wrap a source and a predicate.
-          - [CompositeList] generators use the collection protocol to generate
-            lists of non-basic elements, creating a fresh collection per
-            generate call.
-          - [Composite] generators wrap a [generate_fn] taking test case data
-            inside a span with the given [label]. Used for tuples and one_of
-            with non-basic elements. *)
+(** Phantom witness that a generator carries a printer; see {!generator}. *)
+type printable
+
+(** Phantom witness that a generator carries no printer; see {!generator}. *)
+type unprintable
 
 (** Maximum number of filter attempts before calling [assume false]. *)
 val max_filter_attempts : int
@@ -112,53 +80,99 @@ val collection_more : collection -> Client.test_case -> bool
     Raises {!Client.Data_exhausted} on StopTest. *)
 val collection_reject : collection -> Client.test_case -> unit
 
-(** [do_draw gen tc] produces a typed value from generator [gen] using the given
-    test case [tc]. *)
-val do_draw : 'a generator -> Client.test_case -> 'a
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen] using test case [tc].
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
-val draw : Client.test_case -> 'a generator -> 'a
+    On the final replay of a failing test (or on every case under verbose
+    output), an outermost draw prints its value through {!Client.note} as
+    [name = value]. The [name] is [label] when given, else ["draw"]; an unlabeled
+    draw is numbered ([draw_1], [draw_2], …) while a [label] is printed bare.
+    Draws nested inside a span (e.g. composite elements) are suppressed so only
+    the outermost value shows. To draw a generator with no printer, use
+    {!draw_silent} or attach a printer with {!with_printer}. *)
+val draw : ?label:string -> Client.test_case -> ('a, printable) generator -> 'a
 
-(** [map f gen] transforms values from [gen] using [f].
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw}). It prints [label = value] (bare), or [label_1 = value],
+    [label_2 = value], … when [repeatable] is set — which the PPX does for a
+    binding name that is reused or drawn in a loop. *)
+val draw_named
+  :  label:string
+  -> repeatable:bool
+  -> Client.test_case
+  -> ('a, printable) generator
+  -> 'a
 
-    When [gen] is a [Basic] generator, the schema is preserved and transforms
-    are composed. Otherwise, a [Mapped] generator is created. *)
-val map : ('a -> 'b) -> 'a generator -> 'b generator
+(** [draw_silent tc gen] produces a typed value from any generator without
+    recording it for the final-replay output. Use it for draws whose value is
+    not a useful part of the printed counterexample, or for generators that
+    carry no printer. *)
+val draw_silent : Client.test_case -> ('a, 'p) generator -> 'a
 
-(** [flat_map f gen] creates a dependent generator. The function [f] receives
-    the generated value and returns a new generator whose value is the final
-    result. *)
-val flat_map : ('a -> 'b generator) -> 'a generator -> 'b generator
+(** [with_printer sexp_of gen] attaches (or replaces) [gen]'s printer, yielding
+    a printable generator that {!draw} accepts. This is how a [map]/[flat_map]/
+    [sampled_from]/[just] result is made drawable with {!draw}; the printer is
+    often supplied as [\[%sexp_of: t\]]. *)
+val with_printer : ('a -> Core.Sexp.t) -> ('a, 'p) generator -> ('a, printable) generator
 
-(** [filter predicate gen] filters values from [gen] using [predicate]. Tries
-    multiple times; calls [assume false] if all attempts fail. *)
-val filter : ('a -> bool) -> 'a generator -> 'a generator
+(** [printer gen] is the printer carried by the printable generator [gen]. *)
+val printer : ('a, printable) generator -> 'a -> Core.Sexp.t
 
-(** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
-val schema : 'a generator -> Cbor.t option
+(** [composite generate_fn] builds a generator from an imperative [generate_fn]
+    that draws sub-values from the test case and assembles a result — the
+    OCaml/imperative counterpart to the schema-driven combinators, useful when a
+    value is easiest to describe by drawing its parts in sequence (this is also
+    the form [@@deriving hegel] emits). Carries no printer (the output type
+    is the caller's), so it is {!unprintable}: draw it with {!draw_silent}, or
+    {!with_printer} it to draw with {!draw}. *)
+val composite : (Client.test_case -> 'a) -> ('a, unprintable) generator
 
-(** [is_basic gen] returns [true] if [gen] is a [Basic] generator. *)
-val is_basic : 'a generator -> bool
+(** [map f gen] transforms values from [gen] using [f]. The result carries no
+    printer (the output type is the user's); use {!with_printer} to draw it with
+    {!draw}.
 
-(** [as_basic gen] returns [Some (schema, transform)] if [gen] is [Basic], or
-    [None] otherwise. *)
-val as_basic : 'a generator -> (Cbor.t * (Cbor.t -> 'a)) option
+    When [gen]'s core is [Basic], the schema is preserved and transforms are
+    composed; otherwise a mapped core is created. *)
+val map : ('a -> 'b) -> ('a, 'p) generator -> ('b, unprintable) generator
 
-(** [basic_unique_safe gen] returns [true] iff [gen] is a [Basic] generator
-    whose transform is known to preserve distinctness over the schema's value
-    space. Used to decide whether [lists ~unique:true] can take the
-    server-side fast path or must fall back to client-side dedup. *)
-val basic_unique_safe : 'a generator -> bool
+(** [flat_map f gen] creates a dependent generator. [f] receives the generated
+    value and returns a generator whose value is the final result. The result
+    carries no printer; use {!with_printer} to draw it with {!draw}. *)
+val flat_map
+  :  ('a -> ('b, 'q) generator)
+  -> ('a, 'p) generator
+  -> ('b, unprintable) generator
+
+(** [filter predicate gen] filters values from [gen] using [predicate], keeping
+    [gen]'s printability. Tries multiple times; calls [assume false] if all
+    attempts fail. *)
+val filter : ('a -> bool) -> ('a, 'p) generator -> ('a, 'p) generator
+
+(** [schema gen] returns the schema for a [Basic]-core generator, or [None]. *)
+val schema : ('a, 'p) generator -> Cbor.t option
+
+(** [is_basic gen] returns [true] if [gen] has a [Basic] core. *)
+val is_basic : ('a, 'p) generator -> bool
+
+(** [as_basic gen] returns [Some (schema, transform)] if [gen] has a [Basic]
+    core, or [None] otherwise. *)
+val as_basic : ('a, 'p) generator -> (Cbor.t * (Cbor.t -> 'a)) option
+
+(** [basic_unique_safe gen] returns [true] iff [gen] has a [Basic] core whose
+    transform is known to preserve distinctness over the schema's value space.
+    Used to decide whether [lists ~unique:true] can take the server-side fast
+    path or must fall back to client-side dedup. *)
+val basic_unique_safe : ('a, 'p) generator -> bool
 
 (** {2 Primitive generators} *)
 
 (** [booleans ()] creates a generator for boolean values. *)
-val booleans : unit -> bool generator
+val booleans : unit -> (bool, printable) generator
 
 (** [integers ?min_value ?max_value ()] creates a generator for integers within
     the given bounds. *)
-val integers : ?min_value:int -> ?max_value:int -> unit -> int generator
+val integers : ?min_value:int -> ?max_value:int -> unit -> (int, printable) generator
 
 (** [floats ?min_value ?max_value ?exclude_min ?exclude_max ?allow_nan
      ?allow_infinity ()] creates a generator for floating-point values. *)
@@ -170,7 +184,7 @@ val floats
   -> ?allow_nan:bool
   -> ?allow_infinity:bool
   -> unit
-  -> float generator
+  -> (float, printable) generator
 
 (** [text ?min_size ?max_size ?codec ?min_codepoint ?max_codepoint ?categories
      ?exclude_categories ?include_characters ?exclude_characters ?alphabet ()]
@@ -204,7 +218,7 @@ val text
   -> ?exclude_characters:string
   -> ?alphabet:string
   -> unit
-  -> string generator
+  -> (string, printable) generator
 
 (** [characters ?codec ?min_codepoint ?max_codepoint ?categories
      ?exclude_categories ?include_characters ?exclude_characters ()] creates a
@@ -222,90 +236,104 @@ val characters
   -> ?include_characters:string
   -> ?exclude_characters:string
   -> unit
-  -> string generator
+  -> (string, printable) generator
 
 (** [binary ?min_size ?max_size ()] creates a generator for binary byte strings.
 *)
-val binary : ?min_size:int -> ?max_size:int -> unit -> string generator
+val binary : ?min_size:int -> ?max_size:int -> unit -> (string, printable) generator
 
-(** [just value] creates a generator that always produces [value]. *)
-val just : 'a -> 'a generator
+(** [just value] creates a generator that always produces [value]. The output
+    type is the caller's, so the result carries no printer. *)
+val just : 'a -> ('a, unprintable) generator
 
 (** {2 Collection generators} *)
 
 (** [lists elements ?min_size ?max_size ?unique ()] creates a generator for
-    lists. When [unique] is [true], elements will be distinct. *)
+    lists of [elements]. When [unique] is [true], elements will be
+    distinct. *)
 val lists
-  :  'a generator
+  :  ('a, printable) generator
   -> ?min_size:int
   -> ?max_size:int
   -> ?unique:bool
   -> unit
-  -> 'a list generator
+  -> ('a list, printable) generator
 
 (** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
-    dictionaries (hash maps). When both [keys] and [values] are basic
-    generators, uses the server-side dict schema. When either is non-basic,
-    falls back to the collection protocol. *)
+    dictionaries (hash maps) over printable [keys] and [values]. When both are
+    basic generators, uses the server-side dict schema; when either is
+    non-basic, falls back to the collection protocol. *)
 val hashmaps
-  :  'a generator
-  -> 'b generator
+  :  ('a, printable) generator
+  -> ('b, printable) generator
   -> ?min_size:int
   -> ?max_size:int
   -> unit
-  -> ('a * 'b) list generator
+  -> (('a * 'b) list, printable) generator
 
 (** [sampled_from options] creates a generator that samples uniformly from a
-    non-empty list of values. *)
-val sampled_from : 'a list -> 'a generator
+    non-empty list of values. The output type is the caller's, so the result
+    carries no printer. *)
+val sampled_from : 'a list -> ('a, unprintable) generator
 
 (** [one_of generators] creates a generator that picks from one of the given
-    [generators]. Requires at least 2 generators. *)
-val one_of : 'a generator list -> 'a generator
+    printable [generators]. Requires at least one generator; the drawn value
+    renders with the first branch's printer. *)
+val one_of : ('a, printable) generator list -> ('a, printable) generator
 
 (** [optional element] creates a generator that produces either [None] or
-    [Some value] from [element]. *)
-val optional : 'a generator -> 'a option generator
+    [Some value] from the printable [element]. *)
+val optional : ('a, printable) generator -> ('a option, printable) generator
 
 (** {2 Tuple generators} *)
 
-(** [tuples2 g1 g2] creates a generator for 2-element tuples. *)
-val tuples2 : 'a generator -> 'b generator -> ('a * 'b) generator
+(** [tuples2 g1 g2] creates a generator for 2-element tuples of printable
+    components. *)
+val tuples2
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ('a * 'b, printable) generator
 
-(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples. *)
-val tuples3 : 'a generator -> 'b generator -> 'c generator -> ('a * 'b * 'c) generator
+(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples of printable
+    components. *)
+val tuples3
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ('c, printable) generator
+  -> ('a * 'b * 'c, printable) generator
 
-(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples. *)
+(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples of printable
+    components. *)
 val tuples4
-  :  'a generator
-  -> 'b generator
-  -> 'c generator
-  -> 'd generator
-  -> ('a * 'b * 'c * 'd) generator
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ('c, printable) generator
+  -> ('d, printable) generator
+  -> ('a * 'b * 'c * 'd, printable) generator
 
 (** {2 Format generators} *)
 
 (** [emails ()] creates a generator for valid email address strings. *)
-val emails : unit -> string generator
+val emails : unit -> (string, printable) generator
 
 (** [urls ()] creates a generator for valid URL strings. *)
-val urls : unit -> string generator
+val urls : unit -> (string, printable) generator
 
 (** [domains ?max_length ()] creates a generator for domain name strings. *)
-val domains : ?max_length:int -> unit -> string generator
+val domains : ?max_length:int -> unit -> (string, printable) generator
 
 (** [dates ()] creates a generator for ISO 8601 date strings (YYYY-MM-DD). *)
-val dates : unit -> string generator
+val dates : unit -> (string, printable) generator
 
 (** [times ()] creates a generator for time strings. *)
-val times : unit -> string generator
+val times : unit -> (string, printable) generator
 
 (** [datetimes ()] creates a generator for ISO 8601 datetime strings. *)
-val datetimes : unit -> string generator
+val datetimes : unit -> (string, printable) generator
 
 (** [ip_addresses ?version ()] creates a generator for IP address strings. *)
-val ip_addresses : ?version:int -> unit -> string generator
+val ip_addresses : ?version:int -> unit -> (string, printable) generator
 
 (** [from_regex pattern ?fullmatch ()] creates a generator for strings matching
     a regular expression [pattern]. *)
-val from_regex : string -> ?fullmatch:bool -> unit -> string generator
+val from_regex : string -> ?fullmatch:bool -> unit -> (string, printable) generator

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -20,77 +20,158 @@ module Labels = struct
   let stateful_rule = 16
 end
 
-(** The type of generators. Generators produce typed OCaml values and can be
-    combined using {!map}, {!flat_map}, and {!filter}.
+(** The pure generation structure of a generator, carrying no printer. A
+    {!generator} is a {!core} paired (or not) with a printer; see {!generator}.
 
-    - [Basic] generators hold a raw schema and a mandatory client-side
-      transform. Calling {!map} on a [Basic] generator preserves the schema and
-      composes transforms. The [unique_safe] flag tracks whether [transform] is
-      known to preserve distinctness over the schema's value space (i.e. is
-      injective); leaf generators set it to [true], and [map] sets it to
-      [false] since the user's function may collapse distinct inputs.
-    - [Mapped] generators wrap a source generator and a transform function.
-    - [FlatMapped] generators wrap a source and a function returning a
-      generator.
-    - [Filtered] generators wrap a source and a predicate.
-    - [CompositeList] generators use the collection protocol to generate lists
-      of non-basic elements, creating a fresh collection per generate call.
-    - [Composite] generators wrap a [generate_fn] thunk inside a span with the
-      given [label]. Used for tuples and one_of with non-basic elements. *)
-type 'a generator =
+    - [Basic] cores hold a raw schema and a mandatory client-side transform.
+      Mapping a [Basic] preserves the schema and composes transforms. The
+      [unique_safe] flag tracks whether [transform] is known to preserve
+      distinctness over the schema's value space (i.e. is injective); leaf
+      generators set it to [true], and [map] sets it to [false] since the
+      user's function may collapse distinct inputs.
+    - [Mapped] cores wrap a source and a transform function.
+    - [FlatMapped] cores wrap a source and a function returning a core.
+    - [Filtered] cores wrap a source and a predicate.
+    - [CompositeList] cores use the collection protocol to generate lists of
+      non-basic elements, creating a fresh collection per generate call.
+    - [Composite] cores wrap a [generate_fn] thunk inside a span with the given
+      [label]. Used for tuples and one_of with non-basic elements. *)
+type 'a core =
   | Basic :
       { schema : Cbor.t
       ; transform : Cbor.t -> 'a
       ; unique_safe : bool
       }
-      -> 'a generator
+      -> 'a core
   | Mapped :
-      { source : 'b generator
+      { source : 'b core
       ; f : 'b -> 'a
       }
-      -> 'a generator
+      -> 'a core
   | FlatMapped :
-      { source : 'b generator
-      ; f : 'b -> 'a generator
+      { source : 'b core
+      ; f : 'b -> 'a core
       }
-      -> 'a generator
+      -> 'a core
   | Filtered :
-      { source : 'a generator
+      { source : 'a core
       ; predicate : 'a -> bool
       }
-      -> 'a generator
+      -> 'a core
   | CompositeList :
-      { elements : 'a generator
+      { elements : 'a core
       ; min_size : int
       ; max_size : int option
       }
-      -> 'a list generator
+      -> 'a list core
   | Composite :
       { label : int
       ; generate_fn : Client.test_case -> 'a
       }
-      -> 'a generator
+      -> 'a core
+
+(** Phantom witness that a generator carries a printer and so may be drawn with
+    {!draw}. *)
+type printable
+
+(** Phantom witness that a generator carries no printer; such a generator can
+    only be drawn with {!draw_silent} (or upgraded with {!with_printer}). *)
+type unprintable
+
+(** A generator: a {!core} (how to generate) plus a phantom ['p] recording
+    whether a printer is present. [Printable] structurally carries the printer,
+    so {!draw} can always render its value; [Unprintable] carries none.
+
+    Generators produce typed OCaml values and can be combined using {!map},
+    {!flat_map}, and {!filter}. The phantom is what makes {!draw} require a
+    printer at compile time while {!draw_silent} accepts any generator. *)
+type ('a, 'p) generator =
+  | Printable :
+      { core : 'a core
+      ; sexp_of : 'a -> Sexp.t
+      }
+      -> ('a, printable) generator
+  | Unprintable : { core : 'a core } -> ('a, unprintable) generator
+
+(** [core_of gen] is the generation structure of [gen], discarding printability.
+*)
+let core_of : type a p. (a, p) generator -> a core = function
+  | Printable { core; _ } -> core
+  | Unprintable { core } -> core
+;;
+
+(** [basic ~schema ~transform ~sexp_of ?unique_safe ()] builds a printable
+    {!Basic} generator. [sexp_of] is the printer used to render a drawn value on
+    the final replay. [unique_safe] defaults to [true] (leaf generators preserve
+    distinctness); set it to [false] for transforms that may collapse distinct
+    inputs. *)
+let basic ~schema ~transform ~sexp_of ?(unique_safe = true) () =
+  Printable { core = Basic { schema; transform; unique_safe }; sexp_of }
+;;
+
+(** [basic_silent ~schema ~transform ()] builds an unprintable {!Basic}
+    generator, for leaves whose output type has no known printer (e.g. {!just}).
+    Its transform is treated as not distinctness-preserving ([unique_safe =
+    false]); such leaves are constants today, which collapse all inputs. *)
+let basic_silent ~schema ~transform () =
+  Unprintable { core = Basic { schema; transform; unique_safe = false } }
+;;
+
+(** [with_printer sexp_of gen] attaches (or replaces) [gen]'s printer, yielding a
+    printable generator that {!draw} accepts. This is the explicit way to make a
+    [map]/[flat_map]/[sampled_from]/[just] result printable. *)
+let with_printer : type a p. (a -> Sexp.t) -> (a, p) generator -> (a, printable) generator
+  =
+  fun sexp_of gen -> Printable { core = core_of gen; sexp_of }
+;;
+
+(** [printer gen] is the printer carried by the printable generator [gen]. *)
+let printer : type a. (a, printable) generator -> a -> Sexp.t =
+  fun (Printable { sexp_of; _ }) -> sexp_of
+;;
+
+(** [composite generate_fn] builds an unprintable generator from an imperative
+    [generate_fn] that draws sub-values from the test case and returns a value.
+    The draws run inside a span, so they are suppressed on the final replay and
+    only an outer [draw] of the whole value prints. Carries no printer (the
+    output type is the caller's); use {!with_printer} to draw it with {!draw}.
+    This is the form [@@deriving hegel] emits. *)
+let composite generate_fn =
+  Unprintable { core = Composite { label = Labels.fixed_dict; generate_fn } }
+;;
 
 (** Maximum number of filter attempts before calling [assume false]. *)
 let max_filter_attempts = 3
 
 (** [group label data f] runs [f ()] inside a span with the given [label]. The
-    span is stopped with [discard:false] regardless of whether [f] raises. *)
+    span is stopped with [discard:false] regardless of whether [f] raises.
+
+    A group also increments [draw_depth] for the duration of [f], marking [f]'s
+    draws as nested so only the outermost value prints on the final replay. (A
+    counter, not a flag, so nested groups compose.) *)
 let group label data f =
   Client.start_span ~label data;
-  Exn.protect ~finally:(fun () -> Client.stop_span data) ~f:(fun () -> f ())
+  data.Client.draw_depth <- data.Client.draw_depth + 1;
+  Exn.protect
+    ~finally:(fun () ->
+      data.Client.draw_depth <- data.Client.draw_depth - 1;
+      Client.stop_span data)
+    ~f
 ;;
 
-(** [discardable_group label data f] runs [f ()] inside a span with [label]. If
-    [f] raises, the span is stopped with [discard:true]; otherwise
-    [discard:false]. *)
+(** [discardable_group label data f] runs [f ()] inside a span with [label],
+    incrementing [draw_depth] like {!group}. If [f] raises, the span is stopped
+    with [discard:true]; otherwise [discard:false]. *)
 let discardable_group label data f =
   Client.start_span ~label data;
+  data.Client.draw_depth <- data.Client.draw_depth + 1;
   match f () with
   | v ->
+    data.Client.draw_depth <- data.Client.draw_depth - 1;
     Client.stop_span data;
     v
   | exception e ->
+    data.Client.draw_depth <- data.Client.draw_depth - 1;
     Client.stop_span ~discard:true data;
     raise e
 ;;
@@ -149,11 +230,11 @@ let collection_reject coll data =
     Client.collection_reject data ~collection_id)
 ;;
 
-(** [do_draw gen data] produces a typed value from generator [gen] using the
-    given test case [data]. *)
-let rec do_draw : type a. a generator -> Client.test_case -> a =
-  fun gen data ->
-  match gen with
+(** [do_draw core data] produces a typed value from generation structure [core]
+    using the given test case [data]. *)
+let rec do_draw : type a. a core -> Client.test_case -> a =
+  fun core data ->
+  match core with
   | Basic { schema; transform; _ } -> transform (Client.generate_from_schema schema data)
   | Mapped { source; f } ->
     group Labels.mapped data (fun () ->
@@ -162,8 +243,8 @@ let rec do_draw : type a. a generator -> Client.test_case -> a =
   | FlatMapped { source; f } ->
     discardable_group Labels.flat_map data (fun () ->
       let first = do_draw source data in
-      let second_gen = f first in
-      do_draw second_gen data)
+      let second_core = f first in
+      do_draw second_core data)
   | Filtered { source; predicate } ->
     let rec attempt i =
       if i > max_filter_attempts
@@ -192,60 +273,135 @@ let rec do_draw : type a. a generator -> Client.test_case -> a =
   | Composite { label; generate_fn } -> group label data (fun () -> generate_fn data)
 ;;
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
-let draw tc gen = do_draw gen tc
-
-(** [map f gen] transforms values from [gen] using [f].
-
-    When [gen] is a [Basic] generator, the schema is preserved and transforms
-    are composed. Otherwise, a [Mapped] generator is created. *)
-let map : type a b. (a -> b) -> a generator -> b generator =
-  fun f gen ->
-  match gen with
-  | Basic { schema; transform; _ } ->
-    (* The user's [f] may collapse distinct inputs, so the composed transform
-       is no longer known to preserve uniqueness. Consumers that rely on this
-       (e.g. [lists ~unique:true]) must fall back to a post-transform dedup
-       path when [unique_safe] is [false]. *)
-    Basic { schema; transform = (fun x -> f (transform x)); unique_safe = false }
-  | other -> Mapped { source = other; f }
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; it is not intended for direct use
+    (prefer {!draw}). On the final replay of a failing test (or on every case
+    under verbose output), an outermost draw prints its value through
+    {!Client.note} as [name = value], where [name] is [label], printed bare on
+    its sole use and numbered ([label_1], [label_2], …) when [repeatable] is set
+    — which the PPX does for a binding name that is reused or drawn in a loop.
+    Draws nested inside a span (e.g. composite elements) are suppressed so only
+    the outermost value shows. *)
+let draw_named
+  : type a.
+    label:string -> repeatable:bool -> Client.test_case -> (a, printable) generator -> a
+  =
+  fun ~label ~repeatable tc (Printable { core; sexp_of }) ->
+  let value = do_draw core tc in
+  if tc.Client.draw_depth = 0
+  then (
+    let name = Client.draw_display_name tc ~label ~repeatable in
+    let rendered = Sexp.to_string_hum (sexp_of value) in
+    Client.note tc (sprintf "%s = %s" name rendered));
+  value
 ;;
 
-(** [flat_map f gen] creates a dependent generator. The function [f] receives
-    the generated value and returns a new generator whose value is the final
-    result. *)
-let flat_map f gen = FlatMapped { source = gen; f }
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen] using test case [tc].
 
-(** [filter predicate gen] filters values from [gen] using [predicate]. Tries up
-    to {!max_filter_attempts} times; calls [assume false] if all attempts fail.
-*)
-let filter predicate gen = Filtered { source = gen; predicate }
+    On the final replay of a failing test (or on every case under verbose
+    output), an outermost draw prints its value through {!Client.note} as
+    [name = value]. The [name] is [label] when given, else ["draw"]; an
+    unlabeled draw is numbered ([draw_1], [draw_2], …) while a [label] is printed
+    bare. Draws nested inside a span (e.g. composite elements) are suppressed so
+    only the outermost value shows. To draw a generator that carries no printer,
+    use {!draw_silent}, or attach a printer with {!with_printer}. *)
+let draw ?label tc gen =
+  draw_named
+    ~label:(Option.value label ~default:"draw")
+    ~repeatable:(Option.is_none label)
+    tc
+    gen
+;;
 
-(** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
-let schema : type a. a generator -> Cbor.t option = function
+(** [draw_silent tc gen] produces a typed value from any generator [gen] without
+    recording it for the final-replay output. Use it for draws whose value is
+    not a useful part of the printed counterexample, or for generators that
+    carry no printer. *)
+let draw_silent : type a p. Client.test_case -> (a, p) generator -> a =
+  fun tc gen -> do_draw (core_of gen) tc
+;;
+
+(** [map f gen] transforms values from [gen] using [f]. The result carries no
+    printer (the output type is the user's), so it is {!unprintable}; use
+    {!with_printer} to make it drawable with {!draw}.
+
+    When [gen]'s core is [Basic], the schema is preserved and transforms are
+    composed; otherwise a [Mapped] core is created. *)
+let map : type a b p. (a -> b) -> (a, p) generator -> (b, unprintable) generator =
+  fun f gen ->
+  match core_of gen with
+  | Basic { schema; transform; _ } ->
+    (* The user's [f] may collapse distinct inputs, so the composed transform
+       is no longer known to preserve uniqueness. *)
+    Unprintable
+      { core =
+          Basic { schema; transform = (fun x -> f (transform x)); unique_safe = false }
+      }
+  | other -> Unprintable { core = Mapped { source = other; f } }
+;;
+
+(** [flat_map f gen] creates a dependent generator. [f] receives the generated
+    value and returns a generator whose value is the final result. The result
+    carries no printer; use {!with_printer} to draw it with {!draw}. *)
+let flat_map
+  : type a b p q.
+    (a -> (b, q) generator) -> (a, p) generator -> (b, unprintable) generator
+  =
+  fun f gen ->
+  Unprintable { core = FlatMapped { source = core_of gen; f = (fun x -> core_of (f x)) } }
+;;
+
+(** [filter predicate gen] filters values from [gen] using [predicate], keeping
+    [gen]'s printability. Tries up to {!max_filter_attempts} times; calls
+    [assume false] if all attempts fail. *)
+let filter : type a p. (a -> bool) -> (a, p) generator -> (a, p) generator =
+  fun predicate gen ->
+  match gen with
+  | Printable { core; sexp_of } ->
+    Printable { core = Filtered { source = core; predicate }; sexp_of }
+  | Unprintable { core } -> Unprintable { core = Filtered { source = core; predicate } }
+;;
+
+(** [schema_core core] returns the schema for a [Basic] core, or [None]. *)
+let schema_core : type a. a core -> Cbor.t option = function
   | Basic { schema; _ } -> Some schema
   | _ -> None
 ;;
 
-(** [is_basic gen] returns [true] if [gen] is a [Basic] generator. *)
-let is_basic : type a. a generator -> bool = function
+(** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
+let schema : type a p. (a, p) generator -> Cbor.t option =
+  fun gen -> schema_core (core_of gen)
+;;
+
+(** [is_basic gen] returns [true] if [gen] has a [Basic] core. *)
+let is_basic : type a p. (a, p) generator -> bool =
+  fun gen ->
+  match core_of gen with
   | Basic _ -> true
   | _ -> false
 ;;
 
-(** [as_basic gen] returns [Some (schema, transform)] if [gen] is [Basic], or
-    [None] otherwise. *)
-let as_basic : type a. a generator -> (Cbor.t * (Cbor.t -> a)) option = function
+(** [as_basic_core core] returns [Some (schema, transform)] if [core] is
+    [Basic], or [None] otherwise. *)
+let as_basic_core : type a. a core -> (Cbor.t * (Cbor.t -> a)) option = function
   | Basic { schema; transform; _ } -> Some (schema, transform)
   | _ -> None
 ;;
 
-(** [basic_unique_safe gen] returns [true] iff [gen] is a [Basic] generator
-    whose transform is known to preserve distinctness (i.e. is injective over
-    the schema's value space). Used by [lists ~unique:true] to decide between
-    the server-side fast path and the client-side dedup fallback. *)
-let basic_unique_safe : type a. a generator -> bool = function
+(** [as_basic gen] returns [Some (schema, transform)] if [gen] has a [Basic]
+    core, or [None] otherwise. *)
+let as_basic : type a p. (a, p) generator -> (Cbor.t * (Cbor.t -> a)) option =
+  fun gen -> as_basic_core (core_of gen)
+;;
+
+(** [basic_unique_safe gen] returns [true] iff [gen] has a [Basic] core whose
+    transform is known to preserve distinctness (i.e. is injective over the
+    schema's value space). Used by [lists ~unique:true] to decide between the
+    server-side fast path and the client-side dedup fallback. *)
+let basic_unique_safe : type a p. (a, p) generator -> bool =
+  fun gen ->
+  match core_of gen with
   | Basic { unique_safe; _ } -> unique_safe
   | _ -> false
 ;;

--- a/lib/generators_primitives.ml
+++ b/lib/generators_primitives.ml
@@ -15,16 +15,16 @@ let integers ?min_value ?max_value () =
       ; Option.map max_value ~f:(fun v -> `Text "max_value", `Int v)
       ]
   in
-  Basic { schema = `Map pairs; transform = Cbor_helpers.extract_int; unique_safe = true }
+  basic ~schema:(`Map pairs) ~transform:Cbor_helpers.extract_int ~sexp_of:sexp_of_int ()
 ;;
 
 (** [booleans ()] creates a generator for boolean values. *)
 let booleans () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "boolean" ]
-    ; transform = Cbor_helpers.extract_bool
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "boolean" ])
+    ~transform:Cbor_helpers.extract_bool
+    ~sexp_of:sexp_of_bool
+    ()
 ;;
 
 (** [floats ?min_value ?max_value ?exclude_min ?exclude_max ?allow_nan
@@ -85,8 +85,11 @@ let floats
         ; Option.map max_value ~f:(fun v -> `Text "max_value", `Float v)
         ]
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_float; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_float
+    ~sexp_of:sexp_of_float
+    ()
 ;;
 
 (** Unicode general categories that include surrogate codepoints. OCaml strings
@@ -213,8 +216,11 @@ let text
       ]
     @ char_pairs
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_string; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [characters ?codec ?min_codepoint ?max_codepoint ?categories
@@ -250,8 +256,11 @@ let characters
     [ `Text "type", `Text "string"; `Text "min_size", `Int 1; `Text "max_size", `Int 1 ]
     @ char_pairs
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_string; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [binary ?min_size ?max_size ()] creates a generator for binary byte strings.
@@ -273,20 +282,23 @@ let binary ?(min_size = 0) ?max_size () =
       ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
       ]
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_bytes; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_bytes
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [just value] creates a generator that always produces [value].
 
     The schema uses [{"constant": null}] and the transform ignores the server
-    result, returning the constant [value]. *)
+    result, returning the constant [value]. The output type is chosen by the
+    caller, so no printer is carried. *)
 let just value =
-  Basic
-    { schema = `Map [ `Text "type", `Text "constant"; `Text "value", `Null ]
-    ; transform = (fun _ -> value)
-    ; unique_safe = false
-    }
+  basic_silent
+    ~schema:(`Map [ `Text "type", `Text "constant"; `Text "value", `Null ])
+    ~transform:(fun _ -> value)
+    ()
 ;;
 
 (** [from_regex pattern ?fullmatch ()] creates a generator for strings matching
@@ -295,34 +307,34 @@ let just value =
     When [fullmatch] is [true] (the default), the entire string must match the
     pattern. When [false], a substring match suffices. *)
 let from_regex pattern ?(fullmatch = true) () =
-  Basic
-    { schema =
-        `Map
+  basic
+    ~schema:
+      (`Map
           [ `Text "type", `Text "regex"
           ; `Text "pattern", `Text pattern
           ; `Text "fullmatch", `Bool fullmatch
-          ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+          ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [emails ()] creates a generator for valid email address strings. *)
 let emails () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "email" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "email" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [urls ()] creates a generator for valid URL strings. *)
 let urls () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "url" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "url" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [domains ?max_length ()] creates a generator for domain name strings.
@@ -340,33 +352,36 @@ let domains ?max_length () =
       ; Option.map max_length ~f:(fun ml -> `Text "max_length", `Int ml)
       ]
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_string; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [dates ()] creates a generator for ISO 8601 date strings (YYYY-MM-DD). *)
 let dates () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "date" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "date" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [times ()] creates a generator for time strings. *)
 let times () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "time" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "time" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [datetimes ()] creates a generator for ISO 8601 datetime strings. *)
 let datetimes () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "datetime" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "datetime" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;

--- a/lib/hegel.ml
+++ b/lib/hegel.ml
@@ -10,7 +10,7 @@ module Client = Client
 (** Generator combinators for composable test data generation. *)
 module Generators = Generators
 
-(** Runtime support for [@@deriving generator]. *)
+(** Runtime support for [@@deriving hegel]. *)
 module Derive = Derive
 
 (** Stateful property-based testing on top of {!Generators}. *)
@@ -30,17 +30,32 @@ let run_hegel_test = Client.run_hegel_test
     [false]. *)
 let assume = Client.assume
 
-(** [note tc message] records a message that will be printed on the final
-    (failing) run. *)
+(** [note tc message] prints [message] to stderr subject to the run's verbosity:
+    never under [Quiet], only on the final (failing) replay under [Normal], and
+    on every test case under [Verbose] or [Debug]. *)
 let note = Client.note
 
 (** [target tc value label] sends a target command to guide the search engine
     toward higher values. *)
 let target = Client.target
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen]. On the final replay of a failing test, an outermost draw prints its
+    value. See {!Generators.draw}. *)
 let draw = Generators.draw
+
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw}). See {!Generators.draw_named}. *)
+let draw_named = Generators.draw_named
+
+(** [draw_silent tc gen] is {!draw} without printing the value on the final
+    replay, and accepts a generator with no printer. *)
+let draw_silent = Generators.draw_silent
+
+(** [with_printer sexp_of gen] attaches [sexp_of] so [gen] can be drawn with
+    {!draw}. See {!Generators.with_printer}. *)
+let with_printer = Generators.with_printer
 
 (** [default_settings ()] creates default test settings with CI auto-detection.
 *)

--- a/lib/hegel.mli
+++ b/lib/hegel.mli
@@ -10,7 +10,7 @@ module Client = Client
 (** Generator combinators for composable test data generation. *)
 module Generators = Generators
 
-(** Runtime support for [@@deriving generator]. *)
+(** Runtime support for [@@deriving hegel]. *)
 module Derive = Derive
 
 (** Stateful property-based testing on top of {!Generators}. *)
@@ -43,9 +43,38 @@ val note : Client.test_case -> string -> unit
     toward higher values. *)
 val target : Client.test_case -> float -> string -> unit
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
-val draw : Client.test_case -> 'a Generators.generator -> 'a
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen] using test case [tc]. On the final replay of a failing test (or on
+    every case under verbose output), an outermost draw prints its value as
+    [name = value], where [name] is [label] (else ["draw"]); an unlabeled draw is
+    numbered ([draw_1], [draw_2], …) while a [label] is printed bare. See
+    {!Generators.draw}. *)
+val draw
+  :  ?label:string
+  -> Client.test_case
+  -> ('a, Generators.printable) Generators.generator
+  -> 'a
+
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw}). See {!Generators.draw_named}. *)
+val draw_named
+  :  label:string
+  -> repeatable:bool
+  -> Client.test_case
+  -> ('a, Generators.printable) Generators.generator
+  -> 'a
+
+(** [draw_silent tc gen] is {!draw} without printing the value on the final
+    replay, and accepts a generator with no printer. *)
+val draw_silent : Client.test_case -> ('a, 'p) Generators.generator -> 'a
+
+(** [with_printer sexp_of gen] attaches [sexp_of] as [gen]'s printer so it can
+    be drawn with {!draw}. See {!Generators.with_printer}. *)
+val with_printer
+  :  ('a -> Core.Sexp.t)
+  -> ('a, 'p) Generators.generator
+  -> ('a, Generators.printable) Generators.generator
 
 (** [default_settings ()] creates default test settings with CI auto-detection.
 *)

--- a/test/expect_tests/test_failure_blobs_record.ml
+++ b/test/expect_tests/test_failure_blobs_record.ml
@@ -98,21 +98,26 @@ let%expect_test "only the first blob is actually replayed" =
 exception A
 exception B
 
-let%expect_test "recording reports multiple distinct failures" =
+let%hegel_test multi_fail_test tc =
   let int_gen = Hegel.Generators.integers ~min_value:0 ~max_value:100 () in
-  let prop tc =
-    let v = Hegel.draw tc int_gen in
-    if v >= 60 then raise A;
-    if v <= 30 then raise B
-  in
-  let settings =
-    Hegel.settings ~test_cases:300 ~seed:9 ()
-    |> Hegel.Client.with_print_blob true
-    |> Hegel.Client.with_report_multiple_failures true
-  in
-  match Hegel.run_hegel_test ~settings prop with
+  let v = Hegel.draw tc int_gen in
+  if v >= 60 then raise A;
+  if v <= 30 then raise B
+[@@settings
+  Hegel.settings ~test_cases:300 ~seed:9 ()
+  |> Hegel.Client.with_print_blob true
+  |> Hegel.Client.with_report_multiple_failures true]
+;;
+
+let%expect_test "recording reports multiple distinct failures" =
+  match multi_fail_test () with
   | () -> assert false
   | exception Failure msg ->
     assert (contains ~needle:"Multiple failures (2)" msg);
-    assert (count ~needle:"failure blob:" msg = 2)
+    assert (count ~needle:"failure blob:" msg = 2);
+    [%expect
+      {|
+    v = 60
+    v = 0
+    |}]
 ;;

--- a/test/expect_tests/test_note_verbosity.ml
+++ b/test/expect_tests/test_note_verbosity.ml
@@ -1,0 +1,83 @@
+(** Snapshot tests for [Hegel.note]'s verbosity gating: silent under [Quiet],
+    final-replay-only under [Normal], every case under [Verbose]/[Debug]. *)
+
+let marker = "NOTE_MARKER"
+let int_gen = Hegel.Generators.integers ~min_value:0 ~max_value:100 ()
+
+(** A passing property (5 cases) that notes the marker on every case. *)
+let run_passing verbosity =
+  let settings =
+    Hegel.settings ~test_cases:5 ~seed:1 () |> Hegel.Client.with_verbosity verbosity
+  in
+  Hegel.run_hegel_test ~settings (fun tc ->
+    ignore (Hegel.draw tc int_gen : int);
+    Hegel.note tc marker)
+;;
+
+(** A property that fails (so the engine performs a final replay) and notes the
+    marker on every case. *)
+let run_failing verbosity =
+  let settings =
+    Hegel.settings ~test_cases:5 ~seed:1 () |> Hegel.Client.with_verbosity verbosity
+  in
+  try
+    Hegel.run_hegel_test ~settings (fun tc ->
+      Hegel.note tc marker;
+      failwith "boom")
+  with
+  | _ -> ()
+;;
+
+let%expect_test "Quiet suppresses notes entirely" =
+  run_passing Quiet;
+  [%expect {| |}]
+;;
+
+let%expect_test "Normal notes only on the final failing replay" =
+  run_passing Normal;
+  run_failing Normal;
+  [%expect {| NOTE_MARKER |}]
+;;
+
+let%expect_test "Verbose notes on every case (not just the final replay)" =
+  run_passing Verbose;
+  [%expect
+    {|
+    draw_1 = 0
+    NOTE_MARKER
+    Running test case
+    draw_1 = 59
+    NOTE_MARKER
+    Running test case
+    draw_1 = 34
+    NOTE_MARKER
+    Running test case
+    draw_1 = 47
+    NOTE_MARKER
+    Running test case
+    draw_1 = 41
+    NOTE_MARKER
+    |}]
+;;
+
+let%expect_test "Debug notes on every case (not just the final replay)" =
+  run_passing Debug;
+  [%expect
+    {|
+    draw_1 = 0
+    NOTE_MARKER
+    draw_1 = 59
+    NOTE_MARKER
+    test case #2: status = Valid, choices = 1
+    draw_1 = 34
+    NOTE_MARKER
+    test case #3: status = Valid, choices = 1
+    draw_1 = 47
+    NOTE_MARKER
+    test case #4: status = Valid, choices = 1
+    draw_1 = 41
+    NOTE_MARKER
+    test case #5: status = Valid, choices = 1
+    Test done. interesting_test_cases=0
+    |}]
+;;

--- a/test/test_generators_core.ml
+++ b/test/test_generators_core.ml
@@ -194,7 +194,7 @@ let test_map_doubles_e2e () =
   Hegel.run_hegel_test ~settings:(Client.settings ~test_cases:10 ()) (fun tc ->
     let gen = integers ~min_value:1 ~max_value:5 () |> map (fun v -> v * 2) in
     Alcotest.(check bool) "still basic" true (is_basic gen);
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (v >= 2 && v <= 10);
     assert (v mod 2 = 0))
 ;;
@@ -215,7 +215,7 @@ let test_double_map_e2e () =
        let typ = Cbor_helpers.extract_string (List.assoc (`Text "type") pairs) in
        Alcotest.(check string) "schema type" "integer" typ
      | None -> Alcotest.fail "expected schema");
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (List.mem v [ 3; 5; 7; 9; 11 ]))
 ;;
 
@@ -226,7 +226,7 @@ let test_map_on_filtered_e2e () =
       filter (fun v -> v > 5) (integers ~min_value:0 ~max_value:10 ())
       |> map (fun v -> v * 2)
     in
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (v > 10 && v <= 20))
 ;;
 
@@ -239,7 +239,7 @@ let test_flat_map_e2e () =
         (integers ~min_value:1 ~max_value:5 ())
     in
     Alcotest.(check bool) "not basic" false (is_basic gen);
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (v >= 0))
 ;;
 
@@ -297,6 +297,145 @@ let test_discardable_group_e2e () =
     assert (n >= 0 && n <= 10))
 ;;
 
+(** [printer gen] renders [value] to [expected]. ([gen] is printable, so its
+    printer is total — no [option].) *)
+let check_printer name gen value expected =
+  Alcotest.(check string) name expected (Core.Sexp.to_string (printer gen value))
+;;
+
+let test_printer_int () = check_printer "int" (integers ()) 42 "42"
+let test_printer_bool () = check_printer "bool" (booleans ()) true "true"
+let test_printer_text () = check_printer "text" (text ()) "hi" "hi"
+
+(* [filter] is type-preserving, so it delegates to the source's printer. *)
+let test_printer_filter_delegates () =
+  check_printer "filter" (filter (fun _ -> true) (integers ())) 5 "5"
+;;
+
+(* [with_printer] upgrades an unprintable generator (here [map] over a [Basic])
+   to printable using the supplied printer. *)
+let test_with_printer () =
+  check_printer
+    "with_printer"
+    (with_printer Core.Int.sexp_of_t (map (fun v -> v * 2) (integers ())))
+    21
+    "21"
+;;
+
+(* [filter] over an unprintable generator stays unprintable; it can still be
+   drawn via [draw_silent] and reports a non-basic core. *)
+let test_filter_on_unprintable () =
+  let gen = filter (fun _ -> true) (sampled_from [ 1; 2; 3 ]) in
+  Alcotest.(check bool) "not basic" false (is_basic gen)
+;;
+
+(* Lists render via both the server-side path (basic elements) and the
+   collection path (non-basic but printable elements). *)
+let test_printer_list_basic () =
+  check_printer "list" (lists (integers ()) ()) [ 1; 2; 3 ] "(1 2 3)"
+;;
+
+let test_printer_list_composite () =
+  check_printer
+    "list composite"
+    (lists (filter (fun _ -> true) (integers ())) ())
+    [ 1; 2 ]
+    "(1 2)"
+;;
+
+let test_printer_list_unique_composite () =
+  check_printer
+    "list unique"
+    (lists (filter (fun _ -> true) (integers ())) ~unique:true ())
+    [ 1; 2 ]
+    "(1 2)"
+;;
+
+(* Tuples render via both the all-basic (single schema) and composite paths. *)
+let test_printer_tuple2 () =
+  check_printer "tuple2" (tuples2 (integers ()) (integers ())) (1, 2) "(1 2)"
+;;
+
+let test_printer_tuple2_composite () =
+  check_printer
+    "tuple2 composite"
+    (tuples2 (filter (fun _ -> true) (integers ())) (integers ()))
+    (1, 2)
+    "(1 2)"
+;;
+
+let test_printer_tuple3 () =
+  check_printer
+    "tuple3"
+    (tuples3 (integers ()) (integers ()) (integers ()))
+    (1, 2, 3)
+    "(1 2 3)"
+;;
+
+let test_printer_tuple4 () =
+  check_printer
+    "tuple4"
+    (tuples4 (integers ()) (integers ()) (integers ()) (integers ()))
+    (1, 2, 3, 4)
+    "(1 2 3 4)"
+;;
+
+(* one_of branches share a type, so any branch's printer renders the result. *)
+let test_printer_one_of_basic () =
+  check_printer
+    "one_of basic"
+    (one_of
+       [ integers ~min_value:0 ~max_value:5 (); integers ~min_value:6 ~max_value:9 () ])
+    3
+    "3"
+;;
+
+let test_printer_one_of_composite () =
+  check_printer
+    "one_of composite"
+    (one_of [ filter (fun _ -> true) (integers ()); integers () ])
+    3
+    "3"
+;;
+
+(* Hashmaps render via both the dict-schema (basic) and collection paths. *)
+let test_printer_hashmap_basic () =
+  check_printer
+    "hashmap"
+    (hashmaps (integers ()) (integers ()) ())
+    [ 1, 2; 3, 4 ]
+    "((1 2)(3 4))"
+;;
+
+let test_printer_hashmap_composite () =
+  check_printer
+    "hashmap composite"
+    (hashmaps (filter (fun _ -> true) (integers ())) (integers ()) ())
+    [ 1, 2 ]
+    "((1 2))"
+;;
+
+(* optional composes an ['a option] printer from the element's, rendering
+   [None] / [(Some v)] via [Option.sexp_of_t]. The element being non-basic
+   (here filtered) exercises optional's composite [one_of] path. *)
+(* [Option.sexp_of_t]'s round-trippable form: [(v)] for [Some v], [()] for
+   [None]. *)
+let test_printer_optional_some () =
+  check_printer "optional some" (optional (integers ())) (Some 5) "(5)"
+;;
+
+let test_printer_optional_none () =
+  check_printer "optional none" (optional (integers ())) None "()"
+;;
+
+let test_printer_optional_composite () =
+  check_printer
+    "optional composite"
+    (optional (filter (fun _ -> true) (integers ())))
+    (Some 7)
+    "(7)"
+;;
+
 let tests =
   [ Alcotest.test_case "span label constants" `Quick test_span_label_constants
   ; Alcotest.test_case "basic generator schema" `Quick test_basic_generator_schema
@@ -351,5 +490,28 @@ let tests =
   ; Alcotest.test_case "filter exhaustion e2e" `Quick test_filter_exhaustion_e2e
   ; Alcotest.test_case "group e2e" `Quick test_group_e2e
   ; Alcotest.test_case "discardable_group e2e" `Quick test_discardable_group_e2e
+  ; Alcotest.test_case "printer int" `Quick test_printer_int
+  ; Alcotest.test_case "printer bool" `Quick test_printer_bool
+  ; Alcotest.test_case "printer text" `Quick test_printer_text
+  ; Alcotest.test_case "printer filter delegates" `Quick test_printer_filter_delegates
+  ; Alcotest.test_case "with_printer" `Quick test_with_printer
+  ; Alcotest.test_case "filter on unprintable" `Quick test_filter_on_unprintable
+  ; Alcotest.test_case "printer list basic" `Quick test_printer_list_basic
+  ; Alcotest.test_case "printer list composite" `Quick test_printer_list_composite
+  ; Alcotest.test_case
+      "printer list unique composite"
+      `Quick
+      test_printer_list_unique_composite
+  ; Alcotest.test_case "printer tuple2" `Quick test_printer_tuple2
+  ; Alcotest.test_case "printer tuple2 composite" `Quick test_printer_tuple2_composite
+  ; Alcotest.test_case "printer tuple3" `Quick test_printer_tuple3
+  ; Alcotest.test_case "printer tuple4" `Quick test_printer_tuple4
+  ; Alcotest.test_case "printer one_of basic" `Quick test_printer_one_of_basic
+  ; Alcotest.test_case "printer one_of composite" `Quick test_printer_one_of_composite
+  ; Alcotest.test_case "printer hashmap basic" `Quick test_printer_hashmap_basic
+  ; Alcotest.test_case "printer hashmap composite" `Quick test_printer_hashmap_composite
+  ; Alcotest.test_case "printer optional some" `Quick test_printer_optional_some
+  ; Alcotest.test_case "printer optional none" `Quick test_printer_optional_none
+  ; Alcotest.test_case "printer optional composite" `Quick test_printer_optional_composite
   ]
 ;;

--- a/test/test_generators_primitives.ml
+++ b/test/test_generators_primitives.ml
@@ -43,10 +43,10 @@ let test_just_schema () =
 (** Test: just transform ignores server value. *)
 let test_just_transform () =
   let gen = just "hello" in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     Alcotest.(check string) "ignores server" "hello" (transform (`Int 999))
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: from_regex schema with default fullmatch. *)
@@ -458,7 +458,7 @@ let test_characters_with_categories () =
 (** Test: just always returns the constant. *)
 let test_just_e2e () =
   Hegel.run_hegel_test ~settings:(Client.settings ~test_cases:10 ()) (fun tc ->
-    let v = Hegel.draw tc (just 42) in
+    let v = Hegel.draw_silent tc (just 42) in
     Alcotest.(check int) "always 42" 42 v)
 ;;
 

--- a/test/test_generators_schema.ml
+++ b/test/test_generators_schema.ml
@@ -311,7 +311,7 @@ let%hegel_test test_binary_e2e tc =
 (** Test: sampled_from() E2E — values come from the options list. *)
 let%hegel_test test_sampled_from_e2e tc =
   let options = [ 10; 20; 30 ] in
-  let n = Hegel.draw tc (sampled_from options) in
+  let n = Hegel.draw_silent tc (sampled_from options) in
   assert (List.mem n [ 10; 20; 30 ])
 [@@settings Client.settings ~test_cases:10 ()]
 ;;


### PR DESCRIPTION
**Stacked PR 1 of 5** — splits `better-printing` (auto-print drawn values on the final replay) into reviewable phases. Targets `main`.

Introduces printable/unprintable generator GADT and the final-replay printing path:
- `generators_core.ml`: `('a,'p) generator` GADT over a pure `'a core`, with `draw` / `draw_silent` / `with_printer` / `basic` / `basic_silent` and a total printer on `Printable`.
- `client.ml/.mli`: `draw_depth` gate + the `Counterexample found` header on the failing replay; note-verbosity tuning.
- `generators_primitives.ml`: every primitive/format generator carries a `Core.sexp_of_*` printer.
- `hegel.ml/.mli`, `generators.mli`: exposed surface.

Tests: core/primitives/schema unit checks; `note_verbosity` and `failure_blobs_record` expect snapshots.

> Split for review by phase; only the phase-5 tip is independently CI-green (it is tree-identical to `better-printing`). Intermediate phases are coherent review slices that stack in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)