### PR TITLE
Phase 2: combinator & collection printer propagation

### DIFF
--- a/examples/collections.ml
+++ b/examples/collections.ml
@@ -28,7 +28,11 @@ let%hegel_test test_list_min_size tc =
 (** Property: [map] transforms every element. Here we map integers to their
     absolute values and check all are >= 0. *)
 let%hegel_test test_map_combinator tc =
-  let abs_gen = map (fun v -> abs v) (integers ~min_value:(-100) ~max_value:100 ()) in
+  let abs_gen =
+    with_printer
+      (fun i -> Core.Sexp.Atom (string_of_int i))
+      (map (fun v -> abs v) (integers ~min_value:(-100) ~max_value:100 ()))
+  in
   let lst = Hegel.draw tc (lists abs_gen ~min_size:1 ~max_size:10 ()) in
   List.iter (fun x -> assert (x >= 0)) lst
 [@@settings Hegel.settings ~test_cases:100 ()]
@@ -46,7 +50,7 @@ let%hegel_test test_flat_map_combinator tc =
            (lists (integers ~min_value:0 ~max_value:99 ()) ~min_size:n ~max_size:n ()))
       (integers ~min_value:1 ~max_value:5 ())
   in
-  let n, lst = Hegel.draw tc pair_gen in
+  let n, lst = Hegel.draw_silent tc pair_gen in
   assert (List.length lst = n)
 [@@settings Hegel.settings ~test_cases:50 ()]
 ;;
@@ -54,7 +58,13 @@ let%hegel_test test_flat_map_combinator tc =
 (** Property: [sampled_from] always returns one of the specified values. *)
 let%hegel_test test_sampled_from tc =
   let options = [ 10; 20; 30; 40 ] in
-  let v = Hegel.draw tc (sampled_from options) in
+  (* [sampled_from] is unprintable; [with_printer] makes it drawable with the
+     printing [Hegel.draw]. *)
+  let v =
+    Hegel.draw
+      tc
+      (with_printer (fun i -> Core.Sexp.Atom (string_of_int i)) (sampled_from options))
+  in
   assert (v = 10 || v = 20 || v = 30 || v = 40)
 [@@settings Hegel.settings ~test_cases:100 ()]
 ;;

--- a/lib/generators_collections.ml
+++ b/lib/generators_collections.ml
@@ -2,12 +2,19 @@ open! Core
 open Generators_core
 
 (** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
-    dictionaries (hash maps).
+    dictionaries (hash maps) over printable [keys] and [values].
 
     When both [keys] and [values] are basic generators, sends a [dict] schema to
     the server (fast path). When either is non-basic, uses the collection
     protocol to generate key-value pairs one at a time. *)
-let hashmaps keys values ?(min_size = 0) ?max_size () =
+let hashmaps
+      (keys : ('a, printable) generator)
+      (values : ('b, printable) generator)
+      ?(min_size = 0)
+      ?max_size
+      ()
+  : (('a * 'b) list, printable) generator
+  =
   if min_size < 0
   then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
   (match max_size with
@@ -17,132 +24,149 @@ let hashmaps keys values ?(min_size = 0) ?max_size () =
      raise
        (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
    | _ -> ());
-  match as_basic keys, as_basic values with
-  | Some (key_schema, key_transform), Some (val_schema, val_transform) ->
-    let pairs =
-      List.filter_opt
-        [ Some (`Text "type", `Text "dict")
-        ; Some (`Text "keys", key_schema)
-        ; Some (`Text "values", val_schema)
-        ; Some (`Text "min_size", `Int min_size)
-        ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
-        ]
-    in
-    let transform raw =
-      match raw with
-      | `Array kv_pairs ->
-        List.map kv_pairs ~f:(function
-          | `Array [ k; v ] -> key_transform k, val_transform v
-          | _ -> failwith "hashmaps: expected [k, v] pair from server")
-      | _ -> failwith "hashmaps: expected array from server"
-    in
-    Basic
-      { schema = `Map pairs
-      ; transform
-      ; unique_safe = basic_unique_safe keys && basic_unique_safe values
-      }
-  | _ ->
-    (* dict semantics require unique keys, so we dedup client-side here just
-       like [lists ~unique:true] does *)
-    Composite
-      { label = Labels.map
-      ; generate_fn =
-          (fun data ->
-            let coll = new_collection ~min_size ?max_size data () in
-            let rec collect acc =
-              if collection_more coll data
-              then (
-                let k = do_draw keys data in
-                if List.exists acc ~f:(fun (k', _) -> Poly.equal k' k)
-                then (
-                  collection_reject coll data;
-                  collect acc)
-                else (
-                  let v = do_draw values data in
-                  collect ((k, v) :: acc)))
-              else List.rev acc
-            in
-            collect [])
-      }
-;;
-
-(** [lists elements ?min_size ?max_size ?unique ()] creates a generator for
-    lists.
-
-    When [elements] is a [Basic] generator, sends a [list] schema to the server
-    and lets it generate the entire list (fast path). The element transform is
-    lifted to apply to every item in the resulting list.
-
-    When [elements] is non-basic (e.g. filtered or flat-mapped), uses the
-    collection protocol inside a {!Labels.list} span to generate elements one at
-    a time. A fresh collection is created on each call to [generate].
-
-    When [unique] is [true], the generated list will contain only distinct
-    elements. For basic elements this is handled server-side; for non-basic
-    elements, duplicates are rejected via the collection protocol. *)
-let lists elements ?(min_size = 0) ?max_size ?(unique = false) () =
-  if min_size < 0
-  then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
-  (match max_size with
-   | Some ms when ms < 0 ->
-     raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
-   | Some ms when min_size > ms ->
-     raise
-       (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
-   | _ -> ());
-  match as_basic elements with
-  | Some (elem_schema, elem_transform) when (not unique) || basic_unique_safe elements ->
-    (* Server-side uniqueness is only safe when the element transform
-       preserves distinctness (i.e. is injective). Otherwise distinct raw
-       values from the server can collapse to the same OCaml value, leaving
-       the post-transform list with duplicates. When that happens we fall
-       through to the [unique]-aware dedup path below. *)
-    let pairs =
-      List.filter_opt
-        [ Some (`Text "type", `Text "list")
-        ; Some (`Text "unique", `Bool unique)
-        ; Some (`Text "elements", elem_schema)
-        ; Some (`Text "min_size", `Int min_size)
-        ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
-        ]
-    in
-    let raw_schema = `Map pairs in
-    let list_transform raw_list =
-      match raw_list with
-      | `Array items -> List.map items ~f:elem_transform
-      | _ -> failwith "Internal error: server returned non-array for list schema"
-    in
-    Basic
-      { schema = raw_schema
-      ; transform = list_transform
-      ; unique_safe = basic_unique_safe elements
-      }
-  | _ ->
-    if not unique
-    then
-      (* Non-basic element without uniqueness: use CompositeList. *)
-      CompositeList { elements; min_size; max_size }
-    else
-      (* Non-basic with uniqueness: use Composite with collection protocol
-           and duplicate rejection.  The server's own rejection limit
-           (via [many.reject]) will send StopTest when too many duplicates
-           occur, which [collection_reject] converts to [Data_exhausted]. *)
+  let pk = printer keys
+  and pv = printer values in
+  let sexp_of kvs =
+    Sexp.List (List.map kvs ~f:(fun (k, v) -> Sexp.List [ pk k; pv v ]))
+  in
+  let core =
+    match as_basic_core (core_of keys), as_basic_core (core_of values) with
+    | Some (key_schema, key_transform), Some (val_schema, val_transform) ->
+      let pairs =
+        List.filter_opt
+          [ Some (`Text "type", `Text "dict")
+          ; Some (`Text "keys", key_schema)
+          ; Some (`Text "values", val_schema)
+          ; Some (`Text "min_size", `Int min_size)
+          ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
+          ]
+      in
+      let transform raw =
+        match raw with
+        | `Array kv_pairs ->
+          List.map kv_pairs ~f:(function
+            | `Array [ k; v ] -> key_transform k, val_transform v
+            | _ -> failwith "hashmaps: expected [k, v] pair from server")
+        | _ -> failwith "hashmaps: expected array from server"
+      in
+      Basic
+        { schema = `Map pairs
+        ; transform
+        ; unique_safe = basic_unique_safe keys && basic_unique_safe values
+        }
+    | _ ->
+      (* dict semantics require unique keys, so we dedup client-side here just
+         like [lists ~unique:true] does *)
       Composite
-        { label = Labels.list
+        { label = Labels.map
         ; generate_fn =
             (fun data ->
               let coll = new_collection ~min_size ?max_size data () in
               let rec collect acc =
                 if collection_more coll data
                 then (
-                  let elem = do_draw elements data in
-                  if List.mem acc elem ~equal:Poly.equal
+                  let k = do_draw (core_of keys) data in
+                  if List.exists acc ~f:(fun (k', _) -> Poly.equal k' k)
                   then (
                     collection_reject coll data;
                     collect acc)
-                  else collect (elem :: acc))
+                  else (
+                    let v = do_draw (core_of values) data in
+                    collect ((k, v) :: acc)))
                 else List.rev acc
               in
               collect [])
         }
+  in
+  Printable { core; sexp_of }
+;;
+
+(** [lists elements ?min_size ?max_size ?unique ()] creates a generator for
+    lists of printable [elements].
+
+    When [elements] is a [Basic] generator, sends a [list] schema to the server
+    and lets it generate the entire list (fast path). When [elements] is
+    non-basic (e.g. filtered or flat-mapped), uses the collection protocol
+    inside a {!Labels.list} span to generate elements one at a time.
+
+    When [unique] is [true], the generated list will contain only distinct
+    elements. For basic elements this is handled server-side; for non-basic
+    elements, duplicates are rejected via the collection protocol. *)
+let lists
+      (elements : ('a, printable) generator)
+      ?(min_size = 0)
+      ?max_size
+      ?(unique = false)
+      ()
+  : ('a list, printable) generator
+  =
+  if min_size < 0
+  then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
+  (match max_size with
+   | Some ms when ms < 0 ->
+     raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
+   | Some ms when min_size > ms ->
+     raise
+       (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+   | _ -> ());
+  let elt = printer elements in
+  let sexp_of xs = Sexp.List (List.map xs ~f:elt) in
+  let core =
+    match as_basic_core (core_of elements) with
+    | Some (elem_schema, elem_transform) when (not unique) || basic_unique_safe elements
+      ->
+      (* Server-side uniqueness is only safe when the element transform
+         preserves distinctness (i.e. is injective). Otherwise distinct raw
+         values from the server can collapse to the same OCaml value, leaving
+         the post-transform list with duplicates. When that happens we fall
+         through to the [unique]-aware dedup path below. *)
+      let pairs =
+        List.filter_opt
+          [ Some (`Text "type", `Text "list")
+          ; Some (`Text "unique", `Bool unique)
+          ; Some (`Text "elements", elem_schema)
+          ; Some (`Text "min_size", `Int min_size)
+          ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
+          ]
+      in
+      let list_transform raw_list =
+        match raw_list with
+        | `Array items -> List.map items ~f:elem_transform
+        | _ -> failwith "Internal error: server returned non-array for list schema"
+      in
+      Basic
+        { schema = `Map pairs
+        ; transform = list_transform
+        ; unique_safe = basic_unique_safe elements
+        }
+    | _ ->
+      if not unique
+      then
+        (* Non-basic element without uniqueness: use CompositeList. *)
+        CompositeList { elements = core_of elements; min_size; max_size }
+      else
+        (* Non-basic with uniqueness: use Composite with collection protocol
+           and duplicate rejection. The server's own rejection limit (via
+           [many.reject]) will send StopTest when too many duplicates occur,
+           which [collection_reject] converts to [Data_exhausted]. *)
+        Composite
+          { label = Labels.list
+          ; generate_fn =
+              (fun data ->
+                let coll = new_collection ~min_size ?max_size data () in
+                let rec collect acc =
+                  if collection_more coll data
+                  then (
+                    let elem = do_draw (core_of elements) data in
+                    if List.mem acc elem ~equal:Poly.equal
+                    then (
+                      collection_reject coll data;
+                      collect acc)
+                    else collect (elem :: acc))
+                  else List.rev acc
+                in
+                collect [])
+          }
+  in
+  Printable { core; sexp_of }
 ;;

--- a/lib/generators_combinators.ml
+++ b/lib/generators_combinators.ml
@@ -6,7 +6,8 @@ open Generators_primitives
     non-empty list of values.
 
     Implemented as an integer index generator: picks an index in [0, n-1] and
-    returns [options.(index)]. *)
+    returns [options.(index)]. The output type is the caller's, so the result
+    carries no printer; use {!with_printer} to draw it with {!draw}. *)
 let sampled_from options =
   let arr = Array.of_list options in
   let n = Array.length arr in
@@ -14,23 +15,18 @@ let sampled_from options =
   map (fun i -> arr.(i)) (integers ~min_value:0 ~max_value:(n - 1) ())
 ;;
 
-(** [one_of generators] creates a generator that picks from one of the given
-    [generators].
-
-    Two code paths depending on generator types:
-    - All basic: a single [one_of] schema with the raw child schemas. The
-      server's response is [[index, value]]; the index selects which branch's
-      transform to apply.
-    - Any non-basic: compositional via [ONE_OF] span.
-
-    Requires at least one generator. *)
-let one_of (generators : 'a generator list) =
-  if List.length generators = 0 then failwith "one_of requires at least one generator";
-  let basics = List.filter_map generators ~f:as_basic in
-  if List.length basics <> List.length generators
+(** [one_of_core cores] builds the generation structure that picks among
+    [cores]. When every core is [Basic], a single [one_of] schema is used and
+    the server's [[index, value]] response selects the branch transform.
+    Otherwise an index is drawn inside a {!Labels.one_of} span and that branch
+    is generated compositionally. *)
+let one_of_core : type a. a core list -> a core =
+  fun cores ->
+  let basics = List.filter_map cores ~f:as_basic_core in
+  if List.length basics <> List.length cores
   then (
-    (* Composite path: generate index in ONE_OF span, then delegate *)
-    let gens = Array.of_list generators in
+    (* Composite path: generate index in ONE_OF span, then delegate. *)
+    let gens = Array.of_list cores in
     let n = Array.length gens in
     Composite
       { label = Labels.one_of
@@ -58,24 +54,42 @@ let one_of (generators : 'a generator list) =
       | `Array [ raw_idx; value ] -> transforms.(Cbor_helpers.extract_int raw_idx) value
       | _ -> failwith "one_of: expected [index, value] from server"
     in
+    (* Distinct raw [index, value] pairs from the server can map to the same
+       OCaml value when two branches produce overlapping outputs, so the
+       dispatch transform is not known to preserve uniqueness. *)
     Basic
       { schema =
           `Map [ `Text "type", `Text "one_of"; `Text "generators", `Array child_schemas ]
       ; transform = dispatch
-      ; (* Distinct raw [index, value] pairs from the server can map to the
-           same OCaml value when two branches produce overlapping outputs
-           (e.g. [one_of [integers 0..10; integers 5..15]] can yield 7 from
-           either branch). We can't prove disjointness, so the dispatch
-           transform is not known to preserve uniqueness. *)
-        unique_safe = false
+      ; unique_safe = false
       })
+;;
+
+(** [one_of generators] creates a generator that picks from one of the given
+    [generators], all of which must be printable. The drawn value renders with
+    the first branch's printer (branches share a type). Requires at least one
+    generator. *)
+let one_of (generators : ('a, printable) generator list) : ('a, printable) generator =
+  match generators with
+  | [] -> failwith "one_of requires at least one generator"
+  | first :: _ ->
+    Printable
+      { core = one_of_core (List.map generators ~f:core_of); sexp_of = printer first }
 ;;
 
 (** [optional element] creates a generator that produces either [None] or
     [Some value] from [element].
 
-    Equivalent to [one_of [just None; map (fun x -> Some x) element]]. *)
-let optional element = one_of [ just None; map (fun x -> Some x) element ]
+    Equivalent to [one_of [just None; map (fun x -> Some x) element]]; the
+    [None]/[(Some v)] value renders through [Option.sexp_of_t] applied to
+    [element]'s printer (the round-trippable form: [()] for [None], [(v)] for
+    [Some v]). *)
+let optional (element : ('a, printable) generator) : ('a option, printable) generator =
+  Printable
+    { core = one_of_core [ core_of (just None); core_of (map Option.some element) ]
+    ; sexp_of = Option.sexp_of_t (printer element)
+    }
+;;
 
 (** [ip_addresses ?version ()] creates a generator for IP address strings.
 
@@ -85,124 +99,148 @@ let optional element = one_of [ just None; map (fun x -> Some x) element ]
 let rec ip_addresses ?version () =
   match version with
   | Some 4 ->
-    Basic
-      { schema = `Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 4 ]
-      ; transform = Cbor_helpers.extract_string
-      ; unique_safe = true
-      }
+    basic
+      ~schema:(`Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 4 ])
+      ~transform:Cbor_helpers.extract_string
+      ~sexp_of:sexp_of_string
+      ()
   | Some 6 ->
-    Basic
-      { schema = `Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 6 ]
-      ; transform = Cbor_helpers.extract_string
-      ; unique_safe = true
-      }
+    basic
+      ~schema:(`Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 6 ])
+      ~transform:Cbor_helpers.extract_string
+      ~sexp_of:sexp_of_string
+      ()
   | None -> one_of [ ip_addresses ~version:4 (); ip_addresses ~version:6 () ]
   | Some v -> failwith (sprintf "ip_addresses: invalid version %d" v)
 ;;
 
-(** [tuples2 g1 g2] creates a generator for 2-element tuples.
-
-    When both elements are basic, a single [generate] command is sent using a
-    [tuple] schema. Otherwise, elements are generated separately inside a
-    {!Labels.tuple} span. *)
-let tuples2 (type a b) (g1 : a generator) (g2 : b generator) : (a * b) generator =
-  match as_basic g1, as_basic g2 with
-  | Some (s1, t1), Some (s2, t2) ->
-    let combined =
-      `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2 ] ]
-    in
-    Basic
-      { schema = combined
-      ; transform =
-          (fun raw ->
-            match raw with
-            | `Array [ v1; v2 ] -> t1 v1, t2 v2
-            | _ -> failwith "tuples2: expected 2-element array from server")
-      ; unique_safe = basic_unique_safe g1 && basic_unique_safe g2
-      }
-  | _ ->
-    Composite
-      { label = Labels.tuple
-      ; generate_fn =
-          (fun data ->
-            let a = do_draw g1 data in
-            let b = do_draw g2 data in
-            a, b)
-      }
-;;
-
-(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples.
-
-    When all elements are basic, a single [generate] command is sent. Otherwise,
-    elements are generated separately inside a {!Labels.tuple} span. *)
-let tuples3 (type a b c) (g1 : a generator) (g2 : b generator) (g3 : c generator)
-  : (a * b * c) generator
+(** [tuples2 g1 g2] creates a generator for 2-element tuples of printable
+    components. When both are basic, a single [generate] uses a [tuple] schema;
+    otherwise elements are generated separately inside a {!Labels.tuple} span. *)
+let tuples2 (type a b) (g1 : (a, printable) generator) (g2 : (b, printable) generator)
+  : (a * b, printable) generator
   =
-  match as_basic g1, as_basic g2, as_basic g3 with
-  | Some (s1, t1), Some (s2, t2), Some (s3, t3) ->
-    let combined =
-      `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3 ] ]
-    in
-    Basic
-      { schema = combined
-      ; transform =
-          (fun raw ->
-            match raw with
-            | `Array [ v1; v2; v3 ] -> t1 v1, t2 v2, t3 v3
-            | _ -> failwith "tuples3: expected 3-element array from server")
-      ; unique_safe = basic_unique_safe g1 && basic_unique_safe g2 && basic_unique_safe g3
-      }
-  | _ ->
-    Composite
-      { label = Labels.tuple
-      ; generate_fn =
-          (fun data ->
-            let a = do_draw g1 data in
-            let b = do_draw g2 data in
-            let c = do_draw g3 data in
-            a, b, c)
-      }
+  let p1 = printer g1
+  and p2 = printer g2 in
+  let sexp_of (a, b) = Sexp.List [ p1 a; p2 b ] in
+  let core =
+    match as_basic_core (core_of g1), as_basic_core (core_of g2) with
+    | Some (s1, t1), Some (s2, t2) ->
+      Basic
+        { schema =
+            `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2 ] ]
+        ; transform =
+            (fun raw ->
+              match raw with
+              | `Array [ v1; v2 ] -> t1 v1, t2 v2
+              | _ -> failwith "tuples2: expected 2-element array from server")
+        ; unique_safe = basic_unique_safe g1 && basic_unique_safe g2
+        }
+    | _ ->
+      Composite
+        { label = Labels.tuple
+        ; generate_fn =
+            (fun data ->
+              let a = do_draw (core_of g1) data in
+              let b = do_draw (core_of g2) data in
+              a, b)
+        }
+  in
+  Printable { core; sexp_of }
 ;;
 
-(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples.
+(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples of printable
+    components. *)
+let tuples3
+      (type a b c)
+      (g1 : (a, printable) generator)
+      (g2 : (b, printable) generator)
+      (g3 : (c, printable) generator)
+  : (a * b * c, printable) generator
+  =
+  let p1 = printer g1
+  and p2 = printer g2
+  and p3 = printer g3 in
+  let sexp_of (a, b, c) = Sexp.List [ p1 a; p2 b; p3 c ] in
+  let core =
+    match
+      as_basic_core (core_of g1), as_basic_core (core_of g2), as_basic_core (core_of g3)
+    with
+    | Some (s1, t1), Some (s2, t2), Some (s3, t3) ->
+      Basic
+        { schema =
+            `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3 ] ]
+        ; transform =
+            (fun raw ->
+              match raw with
+              | `Array [ v1; v2; v3 ] -> t1 v1, t2 v2, t3 v3
+              | _ -> failwith "tuples3: expected 3-element array from server")
+        ; unique_safe =
+            basic_unique_safe g1 && basic_unique_safe g2 && basic_unique_safe g3
+        }
+    | _ ->
+      Composite
+        { label = Labels.tuple
+        ; generate_fn =
+            (fun data ->
+              let a = do_draw (core_of g1) data in
+              let b = do_draw (core_of g2) data in
+              let c = do_draw (core_of g3) data in
+              a, b, c)
+        }
+  in
+  Printable { core; sexp_of }
+;;
 
-    When all elements are basic, a single [generate] command is sent. Otherwise,
-    elements are generated separately inside a {!Labels.tuple} span. *)
+(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples of printable
+    components. *)
 let tuples4
       (type a b c d)
-      (g1 : a generator)
-      (g2 : b generator)
-      (g3 : c generator)
-      (g4 : d generator)
-  : (a * b * c * d) generator
+      (g1 : (a, printable) generator)
+      (g2 : (b, printable) generator)
+      (g3 : (c, printable) generator)
+      (g4 : (d, printable) generator)
+  : (a * b * c * d, printable) generator
   =
-  match as_basic g1, as_basic g2, as_basic g3, as_basic g4 with
-  | Some (s1, t1), Some (s2, t2), Some (s3, t3), Some (s4, t4) ->
-    let combined =
-      `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3; s4 ] ]
-    in
-    Basic
-      { schema = combined
-      ; transform =
-          (fun raw ->
-            match raw with
-            | `Array [ v1; v2; v3; v4 ] -> t1 v1, t2 v2, t3 v3, t4 v4
-            | _ -> failwith "tuples4: expected 4-element array from server")
-      ; unique_safe =
-          basic_unique_safe g1
-          && basic_unique_safe g2
-          && basic_unique_safe g3
-          && basic_unique_safe g4
-      }
-  | _ ->
-    Composite
-      { label = Labels.tuple
-      ; generate_fn =
-          (fun data ->
-            let a = do_draw g1 data in
-            let b = do_draw g2 data in
-            let c = do_draw g3 data in
-            let d = do_draw g4 data in
-            a, b, c, d)
-      }
+  let p1 = printer g1
+  and p2 = printer g2
+  and p3 = printer g3
+  and p4 = printer g4 in
+  let sexp_of (a, b, c, d) = Sexp.List [ p1 a; p2 b; p3 c; p4 d ] in
+  let core =
+    match
+      ( as_basic_core (core_of g1)
+      , as_basic_core (core_of g2)
+      , as_basic_core (core_of g3)
+      , as_basic_core (core_of g4) )
+    with
+    | Some (s1, t1), Some (s2, t2), Some (s3, t3), Some (s4, t4) ->
+      Basic
+        { schema =
+            `Map
+              [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3; s4 ] ]
+        ; transform =
+            (fun raw ->
+              match raw with
+              | `Array [ v1; v2; v3; v4 ] -> t1 v1, t2 v2, t3 v3, t4 v4
+              | _ -> failwith "tuples4: expected 4-element array from server")
+        ; unique_safe =
+            basic_unique_safe g1
+            && basic_unique_safe g2
+            && basic_unique_safe g3
+            && basic_unique_safe g4
+        }
+    | _ ->
+      Composite
+        { label = Labels.tuple
+        ; generate_fn =
+            (fun data ->
+              let a = do_draw (core_of g1) data in
+              let b = do_draw (core_of g2) data in
+              let c = do_draw (core_of g3) data in
+              let d = do_draw (core_of g4) data in
+              a, b, c, d)
+        }
+  in
+  Printable { core; sexp_of }
 ;;

--- a/test/test_generators_collections.ml
+++ b/test/test_generators_collections.ml
@@ -38,8 +38,9 @@ let test_lists_basic_no_max_schema () =
 (** Test: lists(basic_elem_with_transform) produces a Basic generator whose
     transform applies the element transform to every item in the result list. *)
 let test_lists_basic_with_element_transform () =
-  (* Build a basic generator with a transform (doubles the value) *)
-  let elem = map (fun v -> v * 2) (integers ()) in
+  (* Build a basic generator with a transform (doubles the value); [with_printer]
+     makes the mapped element drawable/composable while preserving its core. *)
+  let elem = with_printer Core.Int.sexp_of_t (map (fun v -> v * 2) (integers ())) in
   Alcotest.(check bool) "elem is_basic" true (is_basic elem);
   let gen = lists elem () in
   Alcotest.(check bool) "gen is_basic" true (is_basic gen);
@@ -61,13 +62,13 @@ let test_lists_non_basic_is_not_basic () =
 (** Test: lists basic transform raises on non-array input. *)
 let test_lists_basic_non_array_raises () =
   let gen = lists (integers ()) () in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42) : _) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (* ==== Validation tests ==== *)
@@ -268,7 +269,9 @@ let%hegel_test test_hashmaps_non_basic_values_e2e tc =
 let%hegel_test test_lists_unique_under_map_e2e tc =
   let gen =
     lists
-      (map (fun _ -> 0) (integers ~min_value:0 ~max_value:1 ()))
+      (with_printer
+         Core.Int.sexp_of_t
+         (map (fun _ -> 0) (integers ~min_value:0 ~max_value:1 ())))
       ~min_size:2
       ~max_size:2
       ~unique:true

--- a/test/test_generators_combinators.ml
+++ b/test/test_generators_combinators.ml
@@ -9,7 +9,9 @@ let test_one_of_empty () =
 ;;
 
 (** Test: one_of with a single generator is accepted. *)
-let test_one_of_single_accepted () = ignore (one_of [ booleans () ] : bool generator)
+let test_one_of_single_accepted () =
+  ignore (one_of [ booleans () ] : (bool, printable) generator)
+;;
 
 (** Test: sampled_from raises when given an empty list. *)
 let test_sampled_from_empty () =
@@ -23,7 +25,10 @@ let test_sampled_from_empty () =
     schemas so any partial tuple-wrapping regression would be visible. *)
 let test_one_of_basic_schema () =
   let gen =
-    one_of [ integers ~min_value:0 ~max_value:10 (); map (fun _ -> 0) (booleans ()) ]
+    one_of
+      [ integers ~min_value:0 ~max_value:10 ()
+      ; with_printer Core.Int.sexp_of_t (map (fun _ -> 0) (booleans ()))
+      ]
   in
   Alcotest.(check bool) "is_basic" true (is_basic gen);
   match schema gen with
@@ -61,17 +66,20 @@ let test_one_of_non_basic () =
 (** Test: one_of [index, value] dispatch transform. *)
 let test_one_of_dispatch () =
   let gen =
-    one_of [ map (fun x -> x * 2) (integers ()); map (fun x -> x + 100) (integers ()) ]
+    one_of
+      [ with_printer Core.Int.sexp_of_t (map (fun x -> x * 2) (integers ()))
+      ; with_printer Core.Int.sexp_of_t (map (fun x -> x + 100) (integers ()))
+      ]
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     (* index 0 → first branch, value 5 → 5 * 2 = 10 *)
     let result = transform (`Array [ `Int 0; `Int 5 ]) in
     Alcotest.(check int) "dispatched first" 10 result;
     (* index 1 → second branch, value 7 → 7 + 100 = 107 *)
     let result2 = transform (`Array [ `Int 1; `Int 7 ]) in
     Alcotest.(check int) "dispatched second" 107 result2
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: one_of dispatch bad format raises. *)
@@ -82,13 +90,13 @@ let test_one_of_dispatch_bad_format () =
       ; integers ~min_value:100 ~max_value:200 ()
       ]
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "bad format raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: optional creates one_of-based generator. *)
@@ -152,24 +160,24 @@ let test_tuples2_basic_schema () =
 (** Test: tuples2 basic transform. *)
 let test_tuples2_basic_transform () =
   let gen = tuples2 (integers ()) (booleans ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let a, b = transform (`Array [ `Int 5; `Bool true ]) in
     Alcotest.(check int) "first" 5 a;
     Alcotest.(check bool) "second" true b
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples2 basic transform bad format raises. *)
 let test_tuples2_bad_format () =
   let gen = tuples2 (integers ()) (booleans ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples2 non-basic is not basic. *)
@@ -194,25 +202,25 @@ let test_tuples3_basic_schema () =
 (** Test: tuples3 basic transform. *)
 let test_tuples3_basic_transform () =
   let gen = tuples3 (integers ()) (booleans ()) (integers ~min_value:0 ~max_value:5 ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let a, b, c = transform (`Array [ `Int 1; `Bool false; `Int 3 ]) in
     Alcotest.(check int) "first" 1 a;
     Alcotest.(check bool) "second" false b;
     Alcotest.(check int) "third" 3 c
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples3 bad format raises. *)
 let test_tuples3_bad_format () =
   let gen = tuples3 (integers ()) (booleans ()) (integers ~min_value:0 ~max_value:5 ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples3 non-basic is not basic. *)
@@ -243,14 +251,14 @@ let test_tuples4_basic_transform () =
       (integers ~min_value:0 ~max_value:5 ())
       (floats ())
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let a, b, c, d = transform (`Array [ `Int 1; `Bool true; `Int 3; `Float 3.14 ]) in
     Alcotest.(check int) "first" 1 a;
     Alcotest.(check bool) "second" true b;
     Alcotest.(check int) "third" 3 c;
     Alcotest.(check (float 0.01)) "fourth" 3.14 d
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples4 bad format raises. *)
@@ -262,13 +270,13 @@ let test_tuples4_bad_format () =
       (integers ~min_value:0 ~max_value:5 ())
       (floats ())
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples4 non-basic is not basic. *)
@@ -283,7 +291,12 @@ let test_tuples4_non_basic () =
 (** Test: one_of with basic generators works e2e. *)
 let test_one_of_e2e () =
   Hegel.run_hegel_test ~settings:(Client.settings ~test_cases:50 ()) (fun tc ->
-    let gen = one_of [ integers ~min_value:0 ~max_value:10 (); just 99 ] in
+    let gen =
+      one_of
+        [ integers ~min_value:0 ~max_value:10 ()
+        ; with_printer Core.Int.sexp_of_t (just 99)
+        ]
+    in
     let v = Hegel.draw tc gen in
     assert ((v >= 0 && v <= 10) || v = 99))
 ;;


### PR DESCRIPTION
**Stacked PR 2 of 5.** Targets `phase-1-core-printing` (PR #75).

`lists` / `tuples` / `one_of` / `hashmaps` / `optional` now require printable components and compose a total printer, so a drawn composite self-prints as one sexp on the failing replay. `filter` preserves printability across both arms.

- `generators_combinators.ml`: `tuples2/3/4` and `one_of` compute the printer from component printers; `optional` composes a round-trippable option printer.
- `generators_collections.ml`: `lists` / `hashmaps` propagate printers across basic / `CompositeList` / unique-`Composite` paths.

Tests + `examples/collections.ml` updated.

> Review-only slice; see PR #75 for the CI-green caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)