### PR TITLE
Core draw-printing mechanism

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -66,7 +66,7 @@
  (name ppx_hegel_generator)
  (synopsis "PPX deriver for Hegel generator derivation")
  (description
-  "Automatically derives Hegel generators for OCaml types annotated with [@@deriving generator].")
+  "Automatically derives Hegel generators for OCaml types annotated with [@@deriving hegel].")
  (depends
   (ocaml
    (>= 5.2))

--- a/examples/collections.ml
+++ b/examples/collections.ml
@@ -28,7 +28,11 @@ let%hegel_test test_list_min_size tc =
 (** Property: [map] transforms every element. Here we map integers to their
     absolute values and check all are >= 0. *)
 let%hegel_test test_map_combinator tc =
-  let abs_gen = map (fun v -> abs v) (integers ~min_value:(-100) ~max_value:100 ()) in
+  let abs_gen =
+    with_printer
+      (fun i -> Core.Sexp.Atom (string_of_int i))
+      (map (fun v -> abs v) (integers ~min_value:(-100) ~max_value:100 ()))
+  in
   let lst = Hegel.draw tc (lists abs_gen ~min_size:1 ~max_size:10 ()) in
   List.iter (fun x -> assert (x >= 0)) lst
 [@@settings Hegel.settings ~test_cases:100 ()]
@@ -46,7 +50,7 @@ let%hegel_test test_flat_map_combinator tc =
            (lists (integers ~min_value:0 ~max_value:99 ()) ~min_size:n ~max_size:n ()))
       (integers ~min_value:1 ~max_value:5 ())
   in
-  let n, lst = Hegel.draw tc pair_gen in
+  let n, lst = Hegel.draw_silent tc pair_gen in
   assert (List.length lst = n)
 [@@settings Hegel.settings ~test_cases:50 ()]
 ;;
@@ -54,7 +58,13 @@ let%hegel_test test_flat_map_combinator tc =
 (** Property: [sampled_from] always returns one of the specified values. *)
 let%hegel_test test_sampled_from tc =
   let options = [ 10; 20; 30; 40 ] in
-  let v = Hegel.draw tc (sampled_from options) in
+  (* [sampled_from] is unprintable; [with_printer] makes it drawable with the
+     printing [Hegel.draw]. *)
+  let v =
+    Hegel.draw
+      tc
+      (with_printer (fun i -> Core.Sexp.Atom (string_of_int i)) (sampled_from options))
+  in
   assert (v = 10 || v = 20 || v = 30 || v = 40)
 [@@settings Hegel.settings ~test_cases:100 ()]
 ;;

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -191,7 +191,10 @@ let with_print_blob b s = { s with print_blob = b }
 let with_report_multiple_failures b s = { s with report_multiple_failures = b }
 
 (** Per-test-case state passed explicitly to the test function. Holds the
-    native test-case handle, the final-replay flag, and abort state. *)
+    native test-case handle, the final-replay flag, whether verbose output is
+    on, abort state, the current generation-span depth (used to print only the
+    outermost drawn value), and the per-name occurrence counter that numbers
+    repeatable draws. *)
 type test_case =
   { handle : Ffi.test_case
   ; mode : mode
@@ -199,6 +202,8 @@ type test_case =
   ; is_final : bool
   ; verbosity : verbosity
   ; mutable test_aborted : bool
+  ; mutable draw_depth : int
+  ; draw_counts : int String.Table.t
   }
 
 (** Domain-local flag to detect nested test cases. *)
@@ -277,6 +282,16 @@ let note tc message =
     | Verbose | Debug -> true
   in
   if should_print then eprintf "%s\n%!" message
+;;
+
+(** [draw_display_name tc ~label ~repeatable] returns the display name to print
+    for a drawn value, bumping the per-test-case occurrence counter for [label].
+    A [repeatable] name is numbered on every occurrence ([label_1], [label_2],
+    …), while a non-repeatable name is printed bare. *)
+let draw_display_name tc ~label ~repeatable =
+  let n = Option.value (Hashtbl.find tc.draw_counts label) ~default:0 + 1 in
+  Hashtbl.set tc.draw_counts ~key:label ~data:n;
+  if repeatable then sprintf "%s_%d" label n else label
 ;;
 
 (** [target tc value label] records a targeting observation to guide the search
@@ -403,20 +418,22 @@ let build_ffi_settings (settings : settings) ~database_key =
   s
 ;;
 
-(** [run_test_case ~settings ~test_fn handle] runs [test_fn] over a single native
-    test-case [handle], maps the outcome to a {!Ffi.status}, and marks the case
-    complete. Returns [Some (origin, exn)] when the case was {e interesting}
+(** [run_test_case ~mode ~verbose ~test_fn handle] runs [test_fn] over a single 
+    native test-case [handle], maps the outcome to a {!Ffi.status}, and marks 
+    the case complete. Returns [Some (origin, exn)] when the case was {e interesting}
     (the body raised an unexpected exception), otherwise [None]. Shared by the
     engine-run and failure-blob replay paths. *)
 let run_test_case ~(settings : settings) ~test_fn handle =
   let is_final = Ffi.is_final_replay handle in
-  let tc =
+  let (tc : test_case) =
     { handle
     ; mode = settings.mode
-    ; stateful_step_count = settings.stateful_step_count
     ; is_final
     ; verbosity = settings.verbosity
+    ; stateful_step_count = settings.stateful_step_count
     ; test_aborted = false
+    ; draw_depth = 0
+    ; draw_counts = String.Table.create ()
     }
   in
   Stdlib.Domain.DLS.set in_test_context true;

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -127,7 +127,10 @@ val with_print_blob : bool -> settings -> settings
 val with_report_multiple_failures : bool -> settings -> settings
 
 (** Per-test-case state passed explicitly to the test function. Holds the
-    native test-case handle, the final-replay flag, and abort state. *)
+    native test-case handle, the final-replay flag, whether verbose output is
+    on, abort state, the current generation-span depth (used to print only the
+    outermost drawn value), and the per-name occurrence counter that numbers
+    repeatable draws. *)
 type test_case =
   { handle : Hegel_ffi.Ffi.test_case
   ; mode : mode
@@ -135,6 +138,8 @@ type test_case =
   ; is_final : bool
   ; verbosity : verbosity
   ; mutable test_aborted : bool
+  ; mutable draw_depth : int
+  ; draw_counts : int Core.String.Table.t
   }
 
 (** [extract_origin exn] extracts an InterestingOrigin string from an exception.
@@ -163,6 +168,12 @@ val assume : test_case -> bool -> unit
     {!type:verbosity}: never under [Quiet], only on the final (failing) replay
     under [Normal], and on every test case under [Verbose] or [Debug]. *)
 val note : test_case -> string -> unit
+
+(** [draw_display_name tc ~label ~repeatable] returns the display name to print
+    for a drawn value, bumping the per-test-case occurrence counter for [label].
+    A [repeatable] name is numbered on every occurrence ([label_1], [label_2],
+    …), while a non-repeatable name is printed bare. *)
+val draw_display_name : test_case -> label:string -> repeatable:bool -> string
 
 (** [target tc value label] records a targeting observation to guide the search
     engine toward higher values. *)

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -2,7 +2,15 @@
 
     This module provides a composable generator API for property-based testing.
     Generators produce typed OCaml values and can be combined using {!map},
-    {!flat_map}, and {!filter}. *)
+    {!flat_map}, and {!filter}.
+
+    Every generator carries a phantom ['p] recording whether it holds a printer.
+    Primitive and composite generators are {!printable} and may be drawn with
+    {!draw}, which prints the drawn value on a failing replay. {!map},
+    {!flat_map}, {!sampled_from}, and {!just} hand the output type to user code
+    and so are {!unprintable}: they can be drawn with {!draw_silent}, or made
+    printable with {!with_printer}. Composite combinators ({!lists}, {!tuples2},
+    {!one_of}, …) require printable components and produce printable results. *)
 
 (** Constants for span labels used in generation tracking. *)
 module Labels : sig
@@ -24,56 +32,16 @@ module Labels : sig
   val stateful_rule : int
 end
 
-type 'a generator =
-  | Basic :
-      { schema : Cbor.t
-      ; transform : Cbor.t -> 'a
-      ; unique_safe : bool
-      }
-      -> 'a generator
-  | Mapped :
-      { source : 'b generator
-      ; f : 'b -> 'a
-      }
-      -> 'a generator
-  | FlatMapped :
-      { source : 'b generator
-      ; f : 'b -> 'a generator
-      }
-      -> 'a generator
-  | Filtered :
-      { source : 'a generator
-      ; predicate : 'a -> bool
-      }
-      -> 'a generator
-  | CompositeList :
-      { elements : 'a generator
-      ; min_size : int
-      ; max_size : int option
-      }
-      -> 'a list generator
-  | Composite :
-      { label : int
-      ; generate_fn : Client.test_case -> 'a
-      }
-      -> 'a generator
-  (** The type of generators. Generators produce typed OCaml values and can
-          be combined using {!map}, {!flat_map}, and {!filter}.
+(** A generator producing values of type ['a]. The phantom ['p] is {!printable}
+    when the generator carries a printer (and so may be drawn with {!draw}) and
+    {!unprintable} otherwise. *)
+type ('a, 'p) generator
 
-          - [Basic] generators hold a raw schema and a mandatory client-side
-            transform. Calling {!map} on a [Basic] generator preserves the
-            schema and composes transforms.
-          - [Mapped] generators wrap a source generator and a transform
-            function.
-          - [FlatMapped] generators wrap a source and a function returning a
-            generator.
-          - [Filtered] generators wrap a source and a predicate.
-          - [CompositeList] generators use the collection protocol to generate
-            lists of non-basic elements, creating a fresh collection per
-            generate call.
-          - [Composite] generators wrap a [generate_fn] taking test case data
-            inside a span with the given [label]. Used for tuples and one_of
-            with non-basic elements. *)
+(** Phantom witness that a generator carries a printer; see {!generator}. *)
+type printable
+
+(** Phantom witness that a generator carries no printer; see {!generator}. *)
+type unprintable
 
 (** Maximum number of filter attempts before calling [assume false]. *)
 val max_filter_attempts : int
@@ -112,53 +80,99 @@ val collection_more : collection -> Client.test_case -> bool
     Raises {!Client.Data_exhausted} on StopTest. *)
 val collection_reject : collection -> Client.test_case -> unit
 
-(** [do_draw gen tc] produces a typed value from generator [gen] using the given
-    test case [tc]. *)
-val do_draw : 'a generator -> Client.test_case -> 'a
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen] using test case [tc].
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
-val draw : Client.test_case -> 'a generator -> 'a
+    On the final replay of a failing test (or on every case under verbose
+    output), an outermost draw prints its value through {!Client.note} as
+    [name = value]. The [name] is [label] when given, else ["draw"]; an unlabeled
+    draw is numbered ([draw_1], [draw_2], …) while a [label] is printed bare.
+    Draws nested inside a span (e.g. composite elements) are suppressed so only
+    the outermost value shows. To draw a generator with no printer, use
+    {!draw_silent} or attach a printer with {!with_printer}. *)
+val draw : ?label:string -> Client.test_case -> ('a, printable) generator -> 'a
 
-(** [map f gen] transforms values from [gen] using [f].
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw}). It prints [label = value] (bare), or [label_1 = value],
+    [label_2 = value], … when [repeatable] is set — which the PPX does for a
+    binding name that is reused or drawn in a loop. *)
+val draw_named
+  :  label:string
+  -> repeatable:bool
+  -> Client.test_case
+  -> ('a, printable) generator
+  -> 'a
 
-    When [gen] is a [Basic] generator, the schema is preserved and transforms
-    are composed. Otherwise, a [Mapped] generator is created. *)
-val map : ('a -> 'b) -> 'a generator -> 'b generator
+(** [draw_silent tc gen] produces a typed value from any generator without
+    recording it for the final-replay output. Use it for draws whose value is
+    not a useful part of the printed counterexample, or for generators that
+    carry no printer. *)
+val draw_silent : Client.test_case -> ('a, 'p) generator -> 'a
 
-(** [flat_map f gen] creates a dependent generator. The function [f] receives
-    the generated value and returns a new generator whose value is the final
-    result. *)
-val flat_map : ('a -> 'b generator) -> 'a generator -> 'b generator
+(** [with_printer sexp_of gen] attaches (or replaces) [gen]'s printer, yielding
+    a printable generator that {!draw} accepts. This is how a [map]/[flat_map]/
+    [sampled_from]/[just] result is made drawable with {!draw}; the printer is
+    often supplied as [\[%sexp_of: t\]]. *)
+val with_printer : ('a -> Core.Sexp.t) -> ('a, 'p) generator -> ('a, printable) generator
 
-(** [filter predicate gen] filters values from [gen] using [predicate]. Tries
-    multiple times; calls [assume false] if all attempts fail. *)
-val filter : ('a -> bool) -> 'a generator -> 'a generator
+(** [printer gen] is the printer carried by the printable generator [gen]. *)
+val printer : ('a, printable) generator -> 'a -> Core.Sexp.t
 
-(** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
-val schema : 'a generator -> Cbor.t option
+(** [composite generate_fn] builds a generator from an imperative [generate_fn]
+    that draws sub-values from the test case and assembles a result — the
+    OCaml/imperative counterpart to the schema-driven combinators, useful when a
+    value is easiest to describe by drawing its parts in sequence (this is also
+    the form [@@deriving hegel] emits). Carries no printer (the output type
+    is the caller's), so it is {!unprintable}: draw it with {!draw_silent}, or
+    {!with_printer} it to draw with {!draw}. *)
+val composite : (Client.test_case -> 'a) -> ('a, unprintable) generator
 
-(** [is_basic gen] returns [true] if [gen] is a [Basic] generator. *)
-val is_basic : 'a generator -> bool
+(** [map f gen] transforms values from [gen] using [f]. The result carries no
+    printer (the output type is the user's); use {!with_printer} to draw it with
+    {!draw}.
 
-(** [as_basic gen] returns [Some (schema, transform)] if [gen] is [Basic], or
-    [None] otherwise. *)
-val as_basic : 'a generator -> (Cbor.t * (Cbor.t -> 'a)) option
+    When [gen]'s core is [Basic], the schema is preserved and transforms are
+    composed; otherwise a mapped core is created. *)
+val map : ('a -> 'b) -> ('a, 'p) generator -> ('b, unprintable) generator
 
-(** [basic_unique_safe gen] returns [true] iff [gen] is a [Basic] generator
-    whose transform is known to preserve distinctness over the schema's value
-    space. Used to decide whether [lists ~unique:true] can take the
-    server-side fast path or must fall back to client-side dedup. *)
-val basic_unique_safe : 'a generator -> bool
+(** [flat_map f gen] creates a dependent generator. [f] receives the generated
+    value and returns a generator whose value is the final result. The result
+    carries no printer; use {!with_printer} to draw it with {!draw}. *)
+val flat_map
+  :  ('a -> ('b, 'q) generator)
+  -> ('a, 'p) generator
+  -> ('b, unprintable) generator
+
+(** [filter predicate gen] filters values from [gen] using [predicate], keeping
+    [gen]'s printability. Tries multiple times; calls [assume false] if all
+    attempts fail. *)
+val filter : ('a -> bool) -> ('a, 'p) generator -> ('a, 'p) generator
+
+(** [schema gen] returns the schema for a [Basic]-core generator, or [None]. *)
+val schema : ('a, 'p) generator -> Cbor.t option
+
+(** [is_basic gen] returns [true] if [gen] has a [Basic] core. *)
+val is_basic : ('a, 'p) generator -> bool
+
+(** [as_basic gen] returns [Some (schema, transform)] if [gen] has a [Basic]
+    core, or [None] otherwise. *)
+val as_basic : ('a, 'p) generator -> (Cbor.t * (Cbor.t -> 'a)) option
+
+(** [basic_unique_safe gen] returns [true] iff [gen] has a [Basic] core whose
+    transform is known to preserve distinctness over the schema's value space.
+    Used to decide whether [lists ~unique:true] can take the server-side fast
+    path or must fall back to client-side dedup. *)
+val basic_unique_safe : ('a, 'p) generator -> bool
 
 (** {2 Primitive generators} *)
 
 (** [booleans ()] creates a generator for boolean values. *)
-val booleans : unit -> bool generator
+val booleans : unit -> (bool, printable) generator
 
 (** [integers ?min_value ?max_value ()] creates a generator for integers within
     the given bounds. *)
-val integers : ?min_value:int -> ?max_value:int -> unit -> int generator
+val integers : ?min_value:int -> ?max_value:int -> unit -> (int, printable) generator
 
 (** [floats ?min_value ?max_value ?exclude_min ?exclude_max ?allow_nan
      ?allow_infinity ()] creates a generator for floating-point values. *)
@@ -170,7 +184,7 @@ val floats
   -> ?allow_nan:bool
   -> ?allow_infinity:bool
   -> unit
-  -> float generator
+  -> (float, printable) generator
 
 (** [text ?min_size ?max_size ?codec ?min_codepoint ?max_codepoint ?categories
      ?exclude_categories ?include_characters ?exclude_characters ?alphabet ()]
@@ -204,7 +218,7 @@ val text
   -> ?exclude_characters:string
   -> ?alphabet:string
   -> unit
-  -> string generator
+  -> (string, printable) generator
 
 (** [characters ?codec ?min_codepoint ?max_codepoint ?categories
      ?exclude_categories ?include_characters ?exclude_characters ()] creates a
@@ -222,90 +236,104 @@ val characters
   -> ?include_characters:string
   -> ?exclude_characters:string
   -> unit
-  -> string generator
+  -> (string, printable) generator
 
 (** [binary ?min_size ?max_size ()] creates a generator for binary byte strings.
 *)
-val binary : ?min_size:int -> ?max_size:int -> unit -> string generator
+val binary : ?min_size:int -> ?max_size:int -> unit -> (string, printable) generator
 
-(** [just value] creates a generator that always produces [value]. *)
-val just : 'a -> 'a generator
+(** [just value] creates a generator that always produces [value]. The output
+    type is the caller's, so the result carries no printer. *)
+val just : 'a -> ('a, unprintable) generator
 
 (** {2 Collection generators} *)
 
 (** [lists elements ?min_size ?max_size ?unique ()] creates a generator for
-    lists. When [unique] is [true], elements will be distinct. *)
+    lists of [elements]. When [unique] is [true], elements will be
+    distinct. *)
 val lists
-  :  'a generator
+  :  ('a, printable) generator
   -> ?min_size:int
   -> ?max_size:int
   -> ?unique:bool
   -> unit
-  -> 'a list generator
+  -> ('a list, printable) generator
 
 (** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
-    dictionaries (hash maps). When both [keys] and [values] are basic
-    generators, uses the server-side dict schema. When either is non-basic,
-    falls back to the collection protocol. *)
+    dictionaries (hash maps) over printable [keys] and [values]. When both are
+    basic generators, uses the server-side dict schema; when either is
+    non-basic, falls back to the collection protocol. *)
 val hashmaps
-  :  'a generator
-  -> 'b generator
+  :  ('a, printable) generator
+  -> ('b, printable) generator
   -> ?min_size:int
   -> ?max_size:int
   -> unit
-  -> ('a * 'b) list generator
+  -> (('a * 'b) list, printable) generator
 
 (** [sampled_from options] creates a generator that samples uniformly from a
-    non-empty list of values. *)
-val sampled_from : 'a list -> 'a generator
+    non-empty list of values. The output type is the caller's, so the result
+    carries no printer. *)
+val sampled_from : 'a list -> ('a, unprintable) generator
 
 (** [one_of generators] creates a generator that picks from one of the given
-    [generators]. Requires at least 2 generators. *)
-val one_of : 'a generator list -> 'a generator
+    printable [generators]. Requires at least one generator; the drawn value
+    renders with the first branch's printer. *)
+val one_of : ('a, printable) generator list -> ('a, printable) generator
 
 (** [optional element] creates a generator that produces either [None] or
-    [Some value] from [element]. *)
-val optional : 'a generator -> 'a option generator
+    [Some value] from the printable [element]. *)
+val optional : ('a, printable) generator -> ('a option, printable) generator
 
 (** {2 Tuple generators} *)
 
-(** [tuples2 g1 g2] creates a generator for 2-element tuples. *)
-val tuples2 : 'a generator -> 'b generator -> ('a * 'b) generator
+(** [tuples2 g1 g2] creates a generator for 2-element tuples of printable
+    components. *)
+val tuples2
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ('a * 'b, printable) generator
 
-(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples. *)
-val tuples3 : 'a generator -> 'b generator -> 'c generator -> ('a * 'b * 'c) generator
+(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples of printable
+    components. *)
+val tuples3
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ('c, printable) generator
+  -> ('a * 'b * 'c, printable) generator
 
-(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples. *)
+(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples of printable
+    components. *)
 val tuples4
-  :  'a generator
-  -> 'b generator
-  -> 'c generator
-  -> 'd generator
-  -> ('a * 'b * 'c * 'd) generator
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ('c, printable) generator
+  -> ('d, printable) generator
+  -> ('a * 'b * 'c * 'd, printable) generator
 
 (** {2 Format generators} *)
 
 (** [emails ()] creates a generator for valid email address strings. *)
-val emails : unit -> string generator
+val emails : unit -> (string, printable) generator
 
 (** [urls ()] creates a generator for valid URL strings. *)
-val urls : unit -> string generator
+val urls : unit -> (string, printable) generator
 
 (** [domains ?max_length ()] creates a generator for domain name strings. *)
-val domains : ?max_length:int -> unit -> string generator
+val domains : ?max_length:int -> unit -> (string, printable) generator
 
 (** [dates ()] creates a generator for ISO 8601 date strings (YYYY-MM-DD). *)
-val dates : unit -> string generator
+val dates : unit -> (string, printable) generator
 
 (** [times ()] creates a generator for time strings. *)
-val times : unit -> string generator
+val times : unit -> (string, printable) generator
 
 (** [datetimes ()] creates a generator for ISO 8601 datetime strings. *)
-val datetimes : unit -> string generator
+val datetimes : unit -> (string, printable) generator
 
 (** [ip_addresses ?version ()] creates a generator for IP address strings. *)
-val ip_addresses : ?version:int -> unit -> string generator
+val ip_addresses : ?version:int -> unit -> (string, printable) generator
 
 (** [from_regex pattern ?fullmatch ()] creates a generator for strings matching
     a regular expression [pattern]. *)
-val from_regex : string -> ?fullmatch:bool -> unit -> string generator
+val from_regex : string -> ?fullmatch:bool -> unit -> (string, printable) generator

--- a/lib/generators_collections.ml
+++ b/lib/generators_collections.ml
@@ -2,12 +2,19 @@ open! Core
 open Generators_core
 
 (** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
-    dictionaries (hash maps).
+    dictionaries (hash maps) over printable [keys] and [values].
 
     When both [keys] and [values] are basic generators, sends a [dict] schema to
     the server (fast path). When either is non-basic, uses the collection
     protocol to generate key-value pairs one at a time. *)
-let hashmaps keys values ?(min_size = 0) ?max_size () =
+let hashmaps
+      (keys : ('a, printable) generator)
+      (values : ('b, printable) generator)
+      ?(min_size = 0)
+      ?max_size
+      ()
+  : (('a * 'b) list, printable) generator
+  =
   if min_size < 0
   then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
   (match max_size with
@@ -17,132 +24,149 @@ let hashmaps keys values ?(min_size = 0) ?max_size () =
      raise
        (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
    | _ -> ());
-  match as_basic keys, as_basic values with
-  | Some (key_schema, key_transform), Some (val_schema, val_transform) ->
-    let pairs =
-      List.filter_opt
-        [ Some (`Text "type", `Text "dict")
-        ; Some (`Text "keys", key_schema)
-        ; Some (`Text "values", val_schema)
-        ; Some (`Text "min_size", `Int min_size)
-        ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
-        ]
-    in
-    let transform raw =
-      match raw with
-      | `Array kv_pairs ->
-        List.map kv_pairs ~f:(function
-          | `Array [ k; v ] -> key_transform k, val_transform v
-          | _ -> failwith "hashmaps: expected [k, v] pair from server")
-      | _ -> failwith "hashmaps: expected array from server"
-    in
-    Basic
-      { schema = `Map pairs
-      ; transform
-      ; unique_safe = basic_unique_safe keys && basic_unique_safe values
-      }
-  | _ ->
-    (* dict semantics require unique keys, so we dedup client-side here just
-       like [lists ~unique:true] does *)
-    Composite
-      { label = Labels.map
-      ; generate_fn =
-          (fun data ->
-            let coll = new_collection ~min_size ?max_size data () in
-            let rec collect acc =
-              if collection_more coll data
-              then (
-                let k = do_draw keys data in
-                if List.exists acc ~f:(fun (k', _) -> Poly.equal k' k)
-                then (
-                  collection_reject coll data;
-                  collect acc)
-                else (
-                  let v = do_draw values data in
-                  collect ((k, v) :: acc)))
-              else List.rev acc
-            in
-            collect [])
-      }
-;;
-
-(** [lists elements ?min_size ?max_size ?unique ()] creates a generator for
-    lists.
-
-    When [elements] is a [Basic] generator, sends a [list] schema to the server
-    and lets it generate the entire list (fast path). The element transform is
-    lifted to apply to every item in the resulting list.
-
-    When [elements] is non-basic (e.g. filtered or flat-mapped), uses the
-    collection protocol inside a {!Labels.list} span to generate elements one at
-    a time. A fresh collection is created on each call to [generate].
-
-    When [unique] is [true], the generated list will contain only distinct
-    elements. For basic elements this is handled server-side; for non-basic
-    elements, duplicates are rejected via the collection protocol. *)
-let lists elements ?(min_size = 0) ?max_size ?(unique = false) () =
-  if min_size < 0
-  then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
-  (match max_size with
-   | Some ms when ms < 0 ->
-     raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
-   | Some ms when min_size > ms ->
-     raise
-       (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
-   | _ -> ());
-  match as_basic elements with
-  | Some (elem_schema, elem_transform) when (not unique) || basic_unique_safe elements ->
-    (* Server-side uniqueness is only safe when the element transform
-       preserves distinctness (i.e. is injective). Otherwise distinct raw
-       values from the server can collapse to the same OCaml value, leaving
-       the post-transform list with duplicates. When that happens we fall
-       through to the [unique]-aware dedup path below. *)
-    let pairs =
-      List.filter_opt
-        [ Some (`Text "type", `Text "list")
-        ; Some (`Text "unique", `Bool unique)
-        ; Some (`Text "elements", elem_schema)
-        ; Some (`Text "min_size", `Int min_size)
-        ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
-        ]
-    in
-    let raw_schema = `Map pairs in
-    let list_transform raw_list =
-      match raw_list with
-      | `Array items -> List.map items ~f:elem_transform
-      | _ -> failwith "Internal error: server returned non-array for list schema"
-    in
-    Basic
-      { schema = raw_schema
-      ; transform = list_transform
-      ; unique_safe = basic_unique_safe elements
-      }
-  | _ ->
-    if not unique
-    then
-      (* Non-basic element without uniqueness: use CompositeList. *)
-      CompositeList { elements; min_size; max_size }
-    else
-      (* Non-basic with uniqueness: use Composite with collection protocol
-           and duplicate rejection.  The server's own rejection limit
-           (via [many.reject]) will send StopTest when too many duplicates
-           occur, which [collection_reject] converts to [Data_exhausted]. *)
+  let pk = printer keys
+  and pv = printer values in
+  let sexp_of kvs =
+    Sexp.List (List.map kvs ~f:(fun (k, v) -> Sexp.List [ pk k; pv v ]))
+  in
+  let core =
+    match as_basic_core (core_of keys), as_basic_core (core_of values) with
+    | Some (key_schema, key_transform), Some (val_schema, val_transform) ->
+      let pairs =
+        List.filter_opt
+          [ Some (`Text "type", `Text "dict")
+          ; Some (`Text "keys", key_schema)
+          ; Some (`Text "values", val_schema)
+          ; Some (`Text "min_size", `Int min_size)
+          ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
+          ]
+      in
+      let transform raw =
+        match raw with
+        | `Array kv_pairs ->
+          List.map kv_pairs ~f:(function
+            | `Array [ k; v ] -> key_transform k, val_transform v
+            | _ -> failwith "hashmaps: expected [k, v] pair from server")
+        | _ -> failwith "hashmaps: expected array from server"
+      in
+      Basic
+        { schema = `Map pairs
+        ; transform
+        ; unique_safe = basic_unique_safe keys && basic_unique_safe values
+        }
+    | _ ->
+      (* dict semantics require unique keys, so we dedup client-side here just
+         like [lists ~unique:true] does *)
       Composite
-        { label = Labels.list
+        { label = Labels.map
         ; generate_fn =
             (fun data ->
               let coll = new_collection ~min_size ?max_size data () in
               let rec collect acc =
                 if collection_more coll data
                 then (
-                  let elem = do_draw elements data in
-                  if List.mem acc elem ~equal:Poly.equal
+                  let k = do_draw (core_of keys) data in
+                  if List.exists acc ~f:(fun (k', _) -> Poly.equal k' k)
                   then (
                     collection_reject coll data;
                     collect acc)
-                  else collect (elem :: acc))
+                  else (
+                    let v = do_draw (core_of values) data in
+                    collect ((k, v) :: acc)))
                 else List.rev acc
               in
               collect [])
         }
+  in
+  Printable { core; sexp_of }
+;;
+
+(** [lists elements ?min_size ?max_size ?unique ()] creates a generator for
+    lists of printable [elements].
+
+    When [elements] is a [Basic] generator, sends a [list] schema to the server
+    and lets it generate the entire list (fast path). When [elements] is
+    non-basic (e.g. filtered or flat-mapped), uses the collection protocol
+    inside a {!Labels.list} span to generate elements one at a time.
+
+    When [unique] is [true], the generated list will contain only distinct
+    elements. For basic elements this is handled server-side; for non-basic
+    elements, duplicates are rejected via the collection protocol. *)
+let lists
+      (elements : ('a, printable) generator)
+      ?(min_size = 0)
+      ?max_size
+      ?(unique = false)
+      ()
+  : ('a list, printable) generator
+  =
+  if min_size < 0
+  then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
+  (match max_size with
+   | Some ms when ms < 0 ->
+     raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
+   | Some ms when min_size > ms ->
+     raise
+       (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+   | _ -> ());
+  let elt = printer elements in
+  let sexp_of xs = Sexp.List (List.map xs ~f:elt) in
+  let core =
+    match as_basic_core (core_of elements) with
+    | Some (elem_schema, elem_transform) when (not unique) || basic_unique_safe elements
+      ->
+      (* Server-side uniqueness is only safe when the element transform
+         preserves distinctness (i.e. is injective). Otherwise distinct raw
+         values from the server can collapse to the same OCaml value, leaving
+         the post-transform list with duplicates. When that happens we fall
+         through to the [unique]-aware dedup path below. *)
+      let pairs =
+        List.filter_opt
+          [ Some (`Text "type", `Text "list")
+          ; Some (`Text "unique", `Bool unique)
+          ; Some (`Text "elements", elem_schema)
+          ; Some (`Text "min_size", `Int min_size)
+          ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
+          ]
+      in
+      let list_transform raw_list =
+        match raw_list with
+        | `Array items -> List.map items ~f:elem_transform
+        | _ -> failwith "Internal error: server returned non-array for list schema"
+      in
+      Basic
+        { schema = `Map pairs
+        ; transform = list_transform
+        ; unique_safe = basic_unique_safe elements
+        }
+    | _ ->
+      if not unique
+      then
+        (* Non-basic element without uniqueness: use CompositeList. *)
+        CompositeList { elements = core_of elements; min_size; max_size }
+      else
+        (* Non-basic with uniqueness: use Composite with collection protocol
+           and duplicate rejection. The server's own rejection limit (via
+           [many.reject]) will send StopTest when too many duplicates occur,
+           which [collection_reject] converts to [Data_exhausted]. *)
+        Composite
+          { label = Labels.list
+          ; generate_fn =
+              (fun data ->
+                let coll = new_collection ~min_size ?max_size data () in
+                let rec collect acc =
+                  if collection_more coll data
+                  then (
+                    let elem = do_draw (core_of elements) data in
+                    if List.mem acc elem ~equal:Poly.equal
+                    then (
+                      collection_reject coll data;
+                      collect acc)
+                    else collect (elem :: acc))
+                  else List.rev acc
+                in
+                collect [])
+          }
+  in
+  Printable { core; sexp_of }
 ;;

--- a/lib/generators_combinators.ml
+++ b/lib/generators_combinators.ml
@@ -6,7 +6,8 @@ open Generators_primitives
     non-empty list of values.
 
     Implemented as an integer index generator: picks an index in [0, n-1] and
-    returns [options.(index)]. *)
+    returns [options.(index)]. The output type is the caller's, so the result
+    carries no printer; use {!with_printer} to draw it with {!draw}. *)
 let sampled_from options =
   let arr = Array.of_list options in
   let n = Array.length arr in
@@ -14,23 +15,18 @@ let sampled_from options =
   map (fun i -> arr.(i)) (integers ~min_value:0 ~max_value:(n - 1) ())
 ;;
 
-(** [one_of generators] creates a generator that picks from one of the given
-    [generators].
-
-    Two code paths depending on generator types:
-    - All basic: a single [one_of] schema with the raw child schemas. The
-      server's response is [[index, value]]; the index selects which branch's
-      transform to apply.
-    - Any non-basic: compositional via [ONE_OF] span.
-
-    Requires at least one generator. *)
-let one_of (generators : 'a generator list) =
-  if List.length generators = 0 then failwith "one_of requires at least one generator";
-  let basics = List.filter_map generators ~f:as_basic in
-  if List.length basics <> List.length generators
+(** [one_of_core cores] builds the generation structure that picks among
+    [cores]. When every core is [Basic], a single [one_of] schema is used and
+    the server's [[index, value]] response selects the branch transform.
+    Otherwise an index is drawn inside a {!Labels.one_of} span and that branch
+    is generated compositionally. *)
+let one_of_core : type a. a core list -> a core =
+  fun cores ->
+  let basics = List.filter_map cores ~f:as_basic_core in
+  if List.length basics <> List.length cores
   then (
-    (* Composite path: generate index in ONE_OF span, then delegate *)
-    let gens = Array.of_list generators in
+    (* Composite path: generate index in ONE_OF span, then delegate. *)
+    let gens = Array.of_list cores in
     let n = Array.length gens in
     Composite
       { label = Labels.one_of
@@ -58,24 +54,42 @@ let one_of (generators : 'a generator list) =
       | `Array [ raw_idx; value ] -> transforms.(Cbor_helpers.extract_int raw_idx) value
       | _ -> failwith "one_of: expected [index, value] from server"
     in
+    (* Distinct raw [index, value] pairs from the server can map to the same
+       OCaml value when two branches produce overlapping outputs, so the
+       dispatch transform is not known to preserve uniqueness. *)
     Basic
       { schema =
           `Map [ `Text "type", `Text "one_of"; `Text "generators", `Array child_schemas ]
       ; transform = dispatch
-      ; (* Distinct raw [index, value] pairs from the server can map to the
-           same OCaml value when two branches produce overlapping outputs
-           (e.g. [one_of [integers 0..10; integers 5..15]] can yield 7 from
-           either branch). We can't prove disjointness, so the dispatch
-           transform is not known to preserve uniqueness. *)
-        unique_safe = false
+      ; unique_safe = false
       })
+;;
+
+(** [one_of generators] creates a generator that picks from one of the given
+    [generators], all of which must be printable. The drawn value renders with
+    the first branch's printer (branches share a type). Requires at least one
+    generator. *)
+let one_of (generators : ('a, printable) generator list) : ('a, printable) generator =
+  match generators with
+  | [] -> failwith "one_of requires at least one generator"
+  | first :: _ ->
+    Printable
+      { core = one_of_core (List.map generators ~f:core_of); sexp_of = printer first }
 ;;
 
 (** [optional element] creates a generator that produces either [None] or
     [Some value] from [element].
 
-    Equivalent to [one_of [just None; map (fun x -> Some x) element]]. *)
-let optional element = one_of [ just None; map (fun x -> Some x) element ]
+    Equivalent to [one_of [just None; map (fun x -> Some x) element]]; the
+    [None]/[(Some v)] value renders through [Option.sexp_of_t] applied to
+    [element]'s printer (the round-trippable form: [()] for [None], [(v)] for
+    [Some v]). *)
+let optional (element : ('a, printable) generator) : ('a option, printable) generator =
+  Printable
+    { core = one_of_core [ core_of (just None); core_of (map Option.some element) ]
+    ; sexp_of = Option.sexp_of_t (printer element)
+    }
+;;
 
 (** [ip_addresses ?version ()] creates a generator for IP address strings.
 
@@ -85,124 +99,148 @@ let optional element = one_of [ just None; map (fun x -> Some x) element ]
 let rec ip_addresses ?version () =
   match version with
   | Some 4 ->
-    Basic
-      { schema = `Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 4 ]
-      ; transform = Cbor_helpers.extract_string
-      ; unique_safe = true
-      }
+    basic
+      ~schema:(`Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 4 ])
+      ~transform:Cbor_helpers.extract_string
+      ~sexp_of:sexp_of_string
+      ()
   | Some 6 ->
-    Basic
-      { schema = `Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 6 ]
-      ; transform = Cbor_helpers.extract_string
-      ; unique_safe = true
-      }
+    basic
+      ~schema:(`Map [ `Text "type", `Text "ip_address"; `Text "version", `Int 6 ])
+      ~transform:Cbor_helpers.extract_string
+      ~sexp_of:sexp_of_string
+      ()
   | None -> one_of [ ip_addresses ~version:4 (); ip_addresses ~version:6 () ]
   | Some v -> failwith (sprintf "ip_addresses: invalid version %d" v)
 ;;
 
-(** [tuples2 g1 g2] creates a generator for 2-element tuples.
-
-    When both elements are basic, a single [generate] command is sent using a
-    [tuple] schema. Otherwise, elements are generated separately inside a
-    {!Labels.tuple} span. *)
-let tuples2 (type a b) (g1 : a generator) (g2 : b generator) : (a * b) generator =
-  match as_basic g1, as_basic g2 with
-  | Some (s1, t1), Some (s2, t2) ->
-    let combined =
-      `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2 ] ]
-    in
-    Basic
-      { schema = combined
-      ; transform =
-          (fun raw ->
-            match raw with
-            | `Array [ v1; v2 ] -> t1 v1, t2 v2
-            | _ -> failwith "tuples2: expected 2-element array from server")
-      ; unique_safe = basic_unique_safe g1 && basic_unique_safe g2
-      }
-  | _ ->
-    Composite
-      { label = Labels.tuple
-      ; generate_fn =
-          (fun data ->
-            let a = do_draw g1 data in
-            let b = do_draw g2 data in
-            a, b)
-      }
-;;
-
-(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples.
-
-    When all elements are basic, a single [generate] command is sent. Otherwise,
-    elements are generated separately inside a {!Labels.tuple} span. *)
-let tuples3 (type a b c) (g1 : a generator) (g2 : b generator) (g3 : c generator)
-  : (a * b * c) generator
+(** [tuples2 g1 g2] creates a generator for 2-element tuples of printable
+    components. When both are basic, a single [generate] uses a [tuple] schema;
+    otherwise elements are generated separately inside a {!Labels.tuple} span. *)
+let tuples2 (type a b) (g1 : (a, printable) generator) (g2 : (b, printable) generator)
+  : (a * b, printable) generator
   =
-  match as_basic g1, as_basic g2, as_basic g3 with
-  | Some (s1, t1), Some (s2, t2), Some (s3, t3) ->
-    let combined =
-      `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3 ] ]
-    in
-    Basic
-      { schema = combined
-      ; transform =
-          (fun raw ->
-            match raw with
-            | `Array [ v1; v2; v3 ] -> t1 v1, t2 v2, t3 v3
-            | _ -> failwith "tuples3: expected 3-element array from server")
-      ; unique_safe = basic_unique_safe g1 && basic_unique_safe g2 && basic_unique_safe g3
-      }
-  | _ ->
-    Composite
-      { label = Labels.tuple
-      ; generate_fn =
-          (fun data ->
-            let a = do_draw g1 data in
-            let b = do_draw g2 data in
-            let c = do_draw g3 data in
-            a, b, c)
-      }
+  let p1 = printer g1
+  and p2 = printer g2 in
+  let sexp_of (a, b) = Sexp.List [ p1 a; p2 b ] in
+  let core =
+    match as_basic_core (core_of g1), as_basic_core (core_of g2) with
+    | Some (s1, t1), Some (s2, t2) ->
+      Basic
+        { schema =
+            `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2 ] ]
+        ; transform =
+            (fun raw ->
+              match raw with
+              | `Array [ v1; v2 ] -> t1 v1, t2 v2
+              | _ -> failwith "tuples2: expected 2-element array from server")
+        ; unique_safe = basic_unique_safe g1 && basic_unique_safe g2
+        }
+    | _ ->
+      Composite
+        { label = Labels.tuple
+        ; generate_fn =
+            (fun data ->
+              let a = do_draw (core_of g1) data in
+              let b = do_draw (core_of g2) data in
+              a, b)
+        }
+  in
+  Printable { core; sexp_of }
 ;;
 
-(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples.
+(** [tuples3 g1 g2 g3] creates a generator for 3-element tuples of printable
+    components. *)
+let tuples3
+      (type a b c)
+      (g1 : (a, printable) generator)
+      (g2 : (b, printable) generator)
+      (g3 : (c, printable) generator)
+  : (a * b * c, printable) generator
+  =
+  let p1 = printer g1
+  and p2 = printer g2
+  and p3 = printer g3 in
+  let sexp_of (a, b, c) = Sexp.List [ p1 a; p2 b; p3 c ] in
+  let core =
+    match
+      as_basic_core (core_of g1), as_basic_core (core_of g2), as_basic_core (core_of g3)
+    with
+    | Some (s1, t1), Some (s2, t2), Some (s3, t3) ->
+      Basic
+        { schema =
+            `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3 ] ]
+        ; transform =
+            (fun raw ->
+              match raw with
+              | `Array [ v1; v2; v3 ] -> t1 v1, t2 v2, t3 v3
+              | _ -> failwith "tuples3: expected 3-element array from server")
+        ; unique_safe =
+            basic_unique_safe g1 && basic_unique_safe g2 && basic_unique_safe g3
+        }
+    | _ ->
+      Composite
+        { label = Labels.tuple
+        ; generate_fn =
+            (fun data ->
+              let a = do_draw (core_of g1) data in
+              let b = do_draw (core_of g2) data in
+              let c = do_draw (core_of g3) data in
+              a, b, c)
+        }
+  in
+  Printable { core; sexp_of }
+;;
 
-    When all elements are basic, a single [generate] command is sent. Otherwise,
-    elements are generated separately inside a {!Labels.tuple} span. *)
+(** [tuples4 g1 g2 g3 g4] creates a generator for 4-element tuples of printable
+    components. *)
 let tuples4
       (type a b c d)
-      (g1 : a generator)
-      (g2 : b generator)
-      (g3 : c generator)
-      (g4 : d generator)
-  : (a * b * c * d) generator
+      (g1 : (a, printable) generator)
+      (g2 : (b, printable) generator)
+      (g3 : (c, printable) generator)
+      (g4 : (d, printable) generator)
+  : (a * b * c * d, printable) generator
   =
-  match as_basic g1, as_basic g2, as_basic g3, as_basic g4 with
-  | Some (s1, t1), Some (s2, t2), Some (s3, t3), Some (s4, t4) ->
-    let combined =
-      `Map [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3; s4 ] ]
-    in
-    Basic
-      { schema = combined
-      ; transform =
-          (fun raw ->
-            match raw with
-            | `Array [ v1; v2; v3; v4 ] -> t1 v1, t2 v2, t3 v3, t4 v4
-            | _ -> failwith "tuples4: expected 4-element array from server")
-      ; unique_safe =
-          basic_unique_safe g1
-          && basic_unique_safe g2
-          && basic_unique_safe g3
-          && basic_unique_safe g4
-      }
-  | _ ->
-    Composite
-      { label = Labels.tuple
-      ; generate_fn =
-          (fun data ->
-            let a = do_draw g1 data in
-            let b = do_draw g2 data in
-            let c = do_draw g3 data in
-            let d = do_draw g4 data in
-            a, b, c, d)
-      }
+  let p1 = printer g1
+  and p2 = printer g2
+  and p3 = printer g3
+  and p4 = printer g4 in
+  let sexp_of (a, b, c, d) = Sexp.List [ p1 a; p2 b; p3 c; p4 d ] in
+  let core =
+    match
+      ( as_basic_core (core_of g1)
+      , as_basic_core (core_of g2)
+      , as_basic_core (core_of g3)
+      , as_basic_core (core_of g4) )
+    with
+    | Some (s1, t1), Some (s2, t2), Some (s3, t3), Some (s4, t4) ->
+      Basic
+        { schema =
+            `Map
+              [ `Text "type", `Text "tuple"; `Text "elements", `Array [ s1; s2; s3; s4 ] ]
+        ; transform =
+            (fun raw ->
+              match raw with
+              | `Array [ v1; v2; v3; v4 ] -> t1 v1, t2 v2, t3 v3, t4 v4
+              | _ -> failwith "tuples4: expected 4-element array from server")
+        ; unique_safe =
+            basic_unique_safe g1
+            && basic_unique_safe g2
+            && basic_unique_safe g3
+            && basic_unique_safe g4
+        }
+    | _ ->
+      Composite
+        { label = Labels.tuple
+        ; generate_fn =
+            (fun data ->
+              let a = do_draw (core_of g1) data in
+              let b = do_draw (core_of g2) data in
+              let c = do_draw (core_of g3) data in
+              let d = do_draw (core_of g4) data in
+              a, b, c, d)
+        }
+  in
+  Printable { core; sexp_of }
 ;;

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -20,77 +20,158 @@ module Labels = struct
   let stateful_rule = 16
 end
 
-(** The type of generators. Generators produce typed OCaml values and can be
-    combined using {!map}, {!flat_map}, and {!filter}.
+(** The pure generation structure of a generator, carrying no printer. A
+    {!generator} is a {!core} paired (or not) with a printer; see {!generator}.
 
-    - [Basic] generators hold a raw schema and a mandatory client-side
-      transform. Calling {!map} on a [Basic] generator preserves the schema and
-      composes transforms. The [unique_safe] flag tracks whether [transform] is
-      known to preserve distinctness over the schema's value space (i.e. is
-      injective); leaf generators set it to [true], and [map] sets it to
-      [false] since the user's function may collapse distinct inputs.
-    - [Mapped] generators wrap a source generator and a transform function.
-    - [FlatMapped] generators wrap a source and a function returning a
-      generator.
-    - [Filtered] generators wrap a source and a predicate.
-    - [CompositeList] generators use the collection protocol to generate lists
-      of non-basic elements, creating a fresh collection per generate call.
-    - [Composite] generators wrap a [generate_fn] thunk inside a span with the
-      given [label]. Used for tuples and one_of with non-basic elements. *)
-type 'a generator =
+    - [Basic] cores hold a raw schema and a mandatory client-side transform.
+      Mapping a [Basic] preserves the schema and composes transforms. The
+      [unique_safe] flag tracks whether [transform] is known to preserve
+      distinctness over the schema's value space (i.e. is injective); leaf
+      generators set it to [true], and [map] sets it to [false] since the
+      user's function may collapse distinct inputs.
+    - [Mapped] cores wrap a source and a transform function.
+    - [FlatMapped] cores wrap a source and a function returning a core.
+    - [Filtered] cores wrap a source and a predicate.
+    - [CompositeList] cores use the collection protocol to generate lists of
+      non-basic elements, creating a fresh collection per generate call.
+    - [Composite] cores wrap a [generate_fn] thunk inside a span with the given
+      [label]. Used for tuples and one_of with non-basic elements. *)
+type 'a core =
   | Basic :
       { schema : Cbor.t
       ; transform : Cbor.t -> 'a
       ; unique_safe : bool
       }
-      -> 'a generator
+      -> 'a core
   | Mapped :
-      { source : 'b generator
+      { source : 'b core
       ; f : 'b -> 'a
       }
-      -> 'a generator
+      -> 'a core
   | FlatMapped :
-      { source : 'b generator
-      ; f : 'b -> 'a generator
+      { source : 'b core
+      ; f : 'b -> 'a core
       }
-      -> 'a generator
+      -> 'a core
   | Filtered :
-      { source : 'a generator
+      { source : 'a core
       ; predicate : 'a -> bool
       }
-      -> 'a generator
+      -> 'a core
   | CompositeList :
-      { elements : 'a generator
+      { elements : 'a core
       ; min_size : int
       ; max_size : int option
       }
-      -> 'a list generator
+      -> 'a list core
   | Composite :
       { label : int
       ; generate_fn : Client.test_case -> 'a
       }
-      -> 'a generator
+      -> 'a core
+
+(** Phantom witness that a generator carries a printer and so may be drawn with
+    {!draw}. *)
+type printable
+
+(** Phantom witness that a generator carries no printer; such a generator can
+    only be drawn with {!draw_silent} (or upgraded with {!with_printer}). *)
+type unprintable
+
+(** A generator: a {!core} (how to generate) plus a phantom ['p] recording
+    whether a printer is present. [Printable] structurally carries the printer,
+    so {!draw} can always render its value; [Unprintable] carries none.
+
+    Generators produce typed OCaml values and can be combined using {!map},
+    {!flat_map}, and {!filter}. The phantom is what makes {!draw} require a
+    printer at compile time while {!draw_silent} accepts any generator. *)
+type ('a, 'p) generator =
+  | Printable :
+      { core : 'a core
+      ; sexp_of : 'a -> Sexp.t
+      }
+      -> ('a, printable) generator
+  | Unprintable : { core : 'a core } -> ('a, unprintable) generator
+
+(** [core_of gen] is the generation structure of [gen], discarding printability.
+*)
+let core_of : type a p. (a, p) generator -> a core = function
+  | Printable { core; _ } -> core
+  | Unprintable { core } -> core
+;;
+
+(** [basic ~schema ~transform ~sexp_of ?unique_safe ()] builds a printable
+    {!Basic} generator. [sexp_of] is the printer used to render a drawn value on
+    the final replay. [unique_safe] defaults to [true] (leaf generators preserve
+    distinctness); set it to [false] for transforms that may collapse distinct
+    inputs. *)
+let basic ~schema ~transform ~sexp_of ?(unique_safe = true) () =
+  Printable { core = Basic { schema; transform; unique_safe }; sexp_of }
+;;
+
+(** [basic_silent ~schema ~transform ()] builds an unprintable {!Basic}
+    generator, for leaves whose output type has no known printer (e.g. {!just}).
+    Its transform is treated as not distinctness-preserving ([unique_safe =
+    false]); such leaves are constants today, which collapse all inputs. *)
+let basic_silent ~schema ~transform () =
+  Unprintable { core = Basic { schema; transform; unique_safe = false } }
+;;
+
+(** [with_printer sexp_of gen] attaches (or replaces) [gen]'s printer, yielding a
+    printable generator that {!draw} accepts. This is the explicit way to make a
+    [map]/[flat_map]/[sampled_from]/[just] result printable. *)
+let with_printer : type a p. (a -> Sexp.t) -> (a, p) generator -> (a, printable) generator
+  =
+  fun sexp_of gen -> Printable { core = core_of gen; sexp_of }
+;;
+
+(** [printer gen] is the printer carried by the printable generator [gen]. *)
+let printer : type a. (a, printable) generator -> a -> Sexp.t =
+  fun (Printable { sexp_of; _ }) -> sexp_of
+;;
+
+(** [composite generate_fn] builds an unprintable generator from an imperative
+    [generate_fn] that draws sub-values from the test case and returns a value.
+    The draws run inside a span, so they are suppressed on the final replay and
+    only an outer [draw] of the whole value prints. Carries no printer (the
+    output type is the caller's); use {!with_printer} to draw it with {!draw}.
+    This is the form [@@deriving hegel] emits. *)
+let composite generate_fn =
+  Unprintable { core = Composite { label = Labels.fixed_dict; generate_fn } }
+;;
 
 (** Maximum number of filter attempts before calling [assume false]. *)
 let max_filter_attempts = 3
 
 (** [group label data f] runs [f ()] inside a span with the given [label]. The
-    span is stopped with [discard:false] regardless of whether [f] raises. *)
+    span is stopped with [discard:false] regardless of whether [f] raises.
+
+    A group also increments [draw_depth] for the duration of [f], marking [f]'s
+    draws as nested so only the outermost value prints on the final replay. (A
+    counter, not a flag, so nested groups compose.) *)
 let group label data f =
   Client.start_span ~label data;
-  Exn.protect ~finally:(fun () -> Client.stop_span data) ~f:(fun () -> f ())
+  data.Client.draw_depth <- data.Client.draw_depth + 1;
+  Exn.protect
+    ~finally:(fun () ->
+      data.Client.draw_depth <- data.Client.draw_depth - 1;
+      Client.stop_span data)
+    ~f
 ;;
 
-(** [discardable_group label data f] runs [f ()] inside a span with [label]. If
-    [f] raises, the span is stopped with [discard:true]; otherwise
-    [discard:false]. *)
+(** [discardable_group label data f] runs [f ()] inside a span with [label],
+    incrementing [draw_depth] like {!group}. If [f] raises, the span is stopped
+    with [discard:true]; otherwise [discard:false]. *)
 let discardable_group label data f =
   Client.start_span ~label data;
+  data.Client.draw_depth <- data.Client.draw_depth + 1;
   match f () with
   | v ->
+    data.Client.draw_depth <- data.Client.draw_depth - 1;
     Client.stop_span data;
     v
   | exception e ->
+    data.Client.draw_depth <- data.Client.draw_depth - 1;
     Client.stop_span ~discard:true data;
     raise e
 ;;
@@ -149,11 +230,11 @@ let collection_reject coll data =
     Client.collection_reject data ~collection_id)
 ;;
 
-(** [do_draw gen data] produces a typed value from generator [gen] using the
-    given test case [data]. *)
-let rec do_draw : type a. a generator -> Client.test_case -> a =
-  fun gen data ->
-  match gen with
+(** [do_draw core data] produces a typed value from generation structure [core]
+    using the given test case [data]. *)
+let rec do_draw : type a. a core -> Client.test_case -> a =
+  fun core data ->
+  match core with
   | Basic { schema; transform; _ } -> transform (Client.generate_from_schema schema data)
   | Mapped { source; f } ->
     group Labels.mapped data (fun () ->
@@ -162,8 +243,8 @@ let rec do_draw : type a. a generator -> Client.test_case -> a =
   | FlatMapped { source; f } ->
     discardable_group Labels.flat_map data (fun () ->
       let first = do_draw source data in
-      let second_gen = f first in
-      do_draw second_gen data)
+      let second_core = f first in
+      do_draw second_core data)
   | Filtered { source; predicate } ->
     let rec attempt i =
       if i > max_filter_attempts
@@ -192,60 +273,135 @@ let rec do_draw : type a. a generator -> Client.test_case -> a =
   | Composite { label; generate_fn } -> group label data (fun () -> generate_fn data)
 ;;
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
-let draw tc gen = do_draw gen tc
-
-(** [map f gen] transforms values from [gen] using [f].
-
-    When [gen] is a [Basic] generator, the schema is preserved and transforms
-    are composed. Otherwise, a [Mapped] generator is created. *)
-let map : type a b. (a -> b) -> a generator -> b generator =
-  fun f gen ->
-  match gen with
-  | Basic { schema; transform; _ } ->
-    (* The user's [f] may collapse distinct inputs, so the composed transform
-       is no longer known to preserve uniqueness. Consumers that rely on this
-       (e.g. [lists ~unique:true]) must fall back to a post-transform dedup
-       path when [unique_safe] is [false]. *)
-    Basic { schema; transform = (fun x -> f (transform x)); unique_safe = false }
-  | other -> Mapped { source = other; f }
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; it is not intended for direct use
+    (prefer {!draw}). On the final replay of a failing test (or on every case
+    under verbose output), an outermost draw prints its value through
+    {!Client.note} as [name = value], where [name] is [label], printed bare on
+    its sole use and numbered ([label_1], [label_2], …) when [repeatable] is set
+    — which the PPX does for a binding name that is reused or drawn in a loop.
+    Draws nested inside a span (e.g. composite elements) are suppressed so only
+    the outermost value shows. *)
+let draw_named
+  : type a.
+    label:string -> repeatable:bool -> Client.test_case -> (a, printable) generator -> a
+  =
+  fun ~label ~repeatable tc (Printable { core; sexp_of }) ->
+  let value = do_draw core tc in
+  if tc.Client.draw_depth = 0
+  then (
+    let name = Client.draw_display_name tc ~label ~repeatable in
+    let rendered = Sexp.to_string_hum (sexp_of value) in
+    Client.note tc (sprintf "%s = %s" name rendered));
+  value
 ;;
 
-(** [flat_map f gen] creates a dependent generator. The function [f] receives
-    the generated value and returns a new generator whose value is the final
-    result. *)
-let flat_map f gen = FlatMapped { source = gen; f }
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen] using test case [tc].
 
-(** [filter predicate gen] filters values from [gen] using [predicate]. Tries up
-    to {!max_filter_attempts} times; calls [assume false] if all attempts fail.
-*)
-let filter predicate gen = Filtered { source = gen; predicate }
+    On the final replay of a failing test (or on every case under verbose
+    output), an outermost draw prints its value through {!Client.note} as
+    [name = value]. The [name] is [label] when given, else ["draw"]; an
+    unlabeled draw is numbered ([draw_1], [draw_2], …) while a [label] is printed
+    bare. Draws nested inside a span (e.g. composite elements) are suppressed so
+    only the outermost value shows. To draw a generator that carries no printer,
+    use {!draw_silent}, or attach a printer with {!with_printer}. *)
+let draw ?label tc gen =
+  draw_named
+    ~label:(Option.value label ~default:"draw")
+    ~repeatable:(Option.is_none label)
+    tc
+    gen
+;;
 
-(** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
-let schema : type a. a generator -> Cbor.t option = function
+(** [draw_silent tc gen] produces a typed value from any generator [gen] without
+    recording it for the final-replay output. Use it for draws whose value is
+    not a useful part of the printed counterexample, or for generators that
+    carry no printer. *)
+let draw_silent : type a p. Client.test_case -> (a, p) generator -> a =
+  fun tc gen -> do_draw (core_of gen) tc
+;;
+
+(** [map f gen] transforms values from [gen] using [f]. The result carries no
+    printer (the output type is the user's), so it is {!unprintable}; use
+    {!with_printer} to make it drawable with {!draw}.
+
+    When [gen]'s core is [Basic], the schema is preserved and transforms are
+    composed; otherwise a [Mapped] core is created. *)
+let map : type a b p. (a -> b) -> (a, p) generator -> (b, unprintable) generator =
+  fun f gen ->
+  match core_of gen with
+  | Basic { schema; transform; _ } ->
+    (* The user's [f] may collapse distinct inputs, so the composed transform
+       is no longer known to preserve uniqueness. *)
+    Unprintable
+      { core =
+          Basic { schema; transform = (fun x -> f (transform x)); unique_safe = false }
+      }
+  | other -> Unprintable { core = Mapped { source = other; f } }
+;;
+
+(** [flat_map f gen] creates a dependent generator. [f] receives the generated
+    value and returns a generator whose value is the final result. The result
+    carries no printer; use {!with_printer} to draw it with {!draw}. *)
+let flat_map
+  : type a b p q.
+    (a -> (b, q) generator) -> (a, p) generator -> (b, unprintable) generator
+  =
+  fun f gen ->
+  Unprintable { core = FlatMapped { source = core_of gen; f = (fun x -> core_of (f x)) } }
+;;
+
+(** [filter predicate gen] filters values from [gen] using [predicate], keeping
+    [gen]'s printability. Tries up to {!max_filter_attempts} times; calls
+    [assume false] if all attempts fail. *)
+let filter : type a p. (a -> bool) -> (a, p) generator -> (a, p) generator =
+  fun predicate gen ->
+  match gen with
+  | Printable { core; sexp_of } ->
+    Printable { core = Filtered { source = core; predicate }; sexp_of }
+  | Unprintable { core } -> Unprintable { core = Filtered { source = core; predicate } }
+;;
+
+(** [schema_core core] returns the schema for a [Basic] core, or [None]. *)
+let schema_core : type a. a core -> Cbor.t option = function
   | Basic { schema; _ } -> Some schema
   | _ -> None
 ;;
 
-(** [is_basic gen] returns [true] if [gen] is a [Basic] generator. *)
-let is_basic : type a. a generator -> bool = function
+(** [schema gen] returns the schema for a [Basic] generator, or [None]. *)
+let schema : type a p. (a, p) generator -> Cbor.t option =
+  fun gen -> schema_core (core_of gen)
+;;
+
+(** [is_basic gen] returns [true] if [gen] has a [Basic] core. *)
+let is_basic : type a p. (a, p) generator -> bool =
+  fun gen ->
+  match core_of gen with
   | Basic _ -> true
   | _ -> false
 ;;
 
-(** [as_basic gen] returns [Some (schema, transform)] if [gen] is [Basic], or
-    [None] otherwise. *)
-let as_basic : type a. a generator -> (Cbor.t * (Cbor.t -> a)) option = function
+(** [as_basic_core core] returns [Some (schema, transform)] if [core] is
+    [Basic], or [None] otherwise. *)
+let as_basic_core : type a. a core -> (Cbor.t * (Cbor.t -> a)) option = function
   | Basic { schema; transform; _ } -> Some (schema, transform)
   | _ -> None
 ;;
 
-(** [basic_unique_safe gen] returns [true] iff [gen] is a [Basic] generator
-    whose transform is known to preserve distinctness (i.e. is injective over
-    the schema's value space). Used by [lists ~unique:true] to decide between
-    the server-side fast path and the client-side dedup fallback. *)
-let basic_unique_safe : type a. a generator -> bool = function
+(** [as_basic gen] returns [Some (schema, transform)] if [gen] has a [Basic]
+    core, or [None] otherwise. *)
+let as_basic : type a p. (a, p) generator -> (Cbor.t * (Cbor.t -> a)) option =
+  fun gen -> as_basic_core (core_of gen)
+;;
+
+(** [basic_unique_safe gen] returns [true] iff [gen] has a [Basic] core whose
+    transform is known to preserve distinctness (i.e. is injective over the
+    schema's value space). Used by [lists ~unique:true] to decide between the
+    server-side fast path and the client-side dedup fallback. *)
+let basic_unique_safe : type a p. (a, p) generator -> bool =
+  fun gen ->
+  match core_of gen with
   | Basic { unique_safe; _ } -> unique_safe
   | _ -> false
 ;;

--- a/lib/generators_primitives.ml
+++ b/lib/generators_primitives.ml
@@ -15,16 +15,16 @@ let integers ?min_value ?max_value () =
       ; Option.map max_value ~f:(fun v -> `Text "max_value", `Int v)
       ]
   in
-  Basic { schema = `Map pairs; transform = Cbor_helpers.extract_int; unique_safe = true }
+  basic ~schema:(`Map pairs) ~transform:Cbor_helpers.extract_int ~sexp_of:sexp_of_int ()
 ;;
 
 (** [booleans ()] creates a generator for boolean values. *)
 let booleans () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "boolean" ]
-    ; transform = Cbor_helpers.extract_bool
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "boolean" ])
+    ~transform:Cbor_helpers.extract_bool
+    ~sexp_of:sexp_of_bool
+    ()
 ;;
 
 (** [floats ?min_value ?max_value ?exclude_min ?exclude_max ?allow_nan
@@ -85,8 +85,11 @@ let floats
         ; Option.map max_value ~f:(fun v -> `Text "max_value", `Float v)
         ]
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_float; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_float
+    ~sexp_of:sexp_of_float
+    ()
 ;;
 
 (** Unicode general categories that include surrogate codepoints. OCaml strings
@@ -213,8 +216,11 @@ let text
       ]
     @ char_pairs
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_string; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [characters ?codec ?min_codepoint ?max_codepoint ?categories
@@ -250,8 +256,11 @@ let characters
     [ `Text "type", `Text "string"; `Text "min_size", `Int 1; `Text "max_size", `Int 1 ]
     @ char_pairs
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_string; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [binary ?min_size ?max_size ()] creates a generator for binary byte strings.
@@ -273,20 +282,23 @@ let binary ?(min_size = 0) ?max_size () =
       ; Option.map max_size ~f:(fun ms -> `Text "max_size", `Int ms)
       ]
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_bytes; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_bytes
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [just value] creates a generator that always produces [value].
 
     The schema uses [{"constant": null}] and the transform ignores the server
-    result, returning the constant [value]. *)
+    result, returning the constant [value]. The output type is chosen by the
+    caller, so no printer is carried. *)
 let just value =
-  Basic
-    { schema = `Map [ `Text "type", `Text "constant"; `Text "value", `Null ]
-    ; transform = (fun _ -> value)
-    ; unique_safe = false
-    }
+  basic_silent
+    ~schema:(`Map [ `Text "type", `Text "constant"; `Text "value", `Null ])
+    ~transform:(fun _ -> value)
+    ()
 ;;
 
 (** [from_regex pattern ?fullmatch ()] creates a generator for strings matching
@@ -295,34 +307,34 @@ let just value =
     When [fullmatch] is [true] (the default), the entire string must match the
     pattern. When [false], a substring match suffices. *)
 let from_regex pattern ?(fullmatch = true) () =
-  Basic
-    { schema =
-        `Map
+  basic
+    ~schema:
+      (`Map
           [ `Text "type", `Text "regex"
           ; `Text "pattern", `Text pattern
           ; `Text "fullmatch", `Bool fullmatch
-          ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+          ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [emails ()] creates a generator for valid email address strings. *)
 let emails () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "email" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "email" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [urls ()] creates a generator for valid URL strings. *)
 let urls () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "url" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "url" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [domains ?max_length ()] creates a generator for domain name strings.
@@ -340,33 +352,36 @@ let domains ?max_length () =
       ; Option.map max_length ~f:(fun ml -> `Text "max_length", `Int ml)
       ]
   in
-  Basic
-    { schema = `Map pairs; transform = Cbor_helpers.extract_string; unique_safe = true }
+  basic
+    ~schema:(`Map pairs)
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [dates ()] creates a generator for ISO 8601 date strings (YYYY-MM-DD). *)
 let dates () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "date" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "date" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [times ()] creates a generator for time strings. *)
 let times () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "time" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "time" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;
 
 (** [datetimes ()] creates a generator for ISO 8601 datetime strings. *)
 let datetimes () =
-  Basic
-    { schema = `Map [ `Text "type", `Text "datetime" ]
-    ; transform = Cbor_helpers.extract_string
-    ; unique_safe = true
-    }
+  basic
+    ~schema:(`Map [ `Text "type", `Text "datetime" ])
+    ~transform:Cbor_helpers.extract_string
+    ~sexp_of:sexp_of_string
+    ()
 ;;

--- a/lib/hegel.ml
+++ b/lib/hegel.ml
@@ -10,7 +10,7 @@ module Client = Client
 (** Generator combinators for composable test data generation. *)
 module Generators = Generators
 
-(** Runtime support for [@@deriving generator]. *)
+(** Runtime support for [@@deriving hegel]. *)
 module Derive = Derive
 
 (** Stateful property-based testing on top of {!Generators}. *)
@@ -39,9 +39,23 @@ let note = Client.note
     toward higher values. *)
 let target = Client.target
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen]. On the final replay of a failing test, an outermost draw prints its
+    value. See {!Generators.draw}. *)
 let draw = Generators.draw
+
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw}). See {!Generators.draw_named}. *)
+let draw_named = Generators.draw_named
+
+(** [draw_silent tc gen] is {!draw} without printing the value on the final
+    replay, and accepts a generator with no printer. *)
+let draw_silent = Generators.draw_silent
+
+(** [with_printer sexp_of gen] attaches [sexp_of] so [gen] can be drawn with
+    {!draw}. See {!Generators.with_printer}. *)
+let with_printer = Generators.with_printer
 
 (** [default_settings ()] creates default test settings with CI auto-detection.
 *)

--- a/lib/hegel.mli
+++ b/lib/hegel.mli
@@ -10,7 +10,7 @@ module Client = Client
 (** Generator combinators for composable test data generation. *)
 module Generators = Generators
 
-(** Runtime support for [@@deriving generator]. *)
+(** Runtime support for [@@deriving hegel]. *)
 module Derive = Derive
 
 (** Stateful property-based testing on top of {!Generators}. *)
@@ -43,9 +43,38 @@ val note : Client.test_case -> string -> unit
     toward higher values. *)
 val target : Client.test_case -> float -> string -> unit
 
-(** [draw tc gen] produces a typed value from generator [gen] using test case
-    [tc]. *)
-val draw : Client.test_case -> 'a Generators.generator -> 'a
+(** [draw ?label tc gen] produces a typed value from the printable generator
+    [gen] using test case [tc]. On the final replay of a failing test (or on
+    every case under verbose output), an outermost draw prints its value as
+    [name = value], where [name] is [label] (else ["draw"]); an unlabeled draw is
+    numbered ([draw_1], [draw_2], …) while a [label] is printed bare. See
+    {!Generators.draw}. *)
+val draw
+  :  ?label:string
+  -> Client.test_case
+  -> ('a, Generators.printable) Generators.generator
+  -> 'a
+
+(** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw}). See {!Generators.draw_named}. *)
+val draw_named
+  :  label:string
+  -> repeatable:bool
+  -> Client.test_case
+  -> ('a, Generators.printable) Generators.generator
+  -> 'a
+
+(** [draw_silent tc gen] is {!draw} without printing the value on the final
+    replay, and accepts a generator with no printer. *)
+val draw_silent : Client.test_case -> ('a, 'p) Generators.generator -> 'a
+
+(** [with_printer sexp_of gen] attaches [sexp_of] as [gen]'s printer so it can
+    be drawn with {!draw}. See {!Generators.with_printer}. *)
+val with_printer
+  :  ('a -> Core.Sexp.t)
+  -> ('a, 'p) Generators.generator
+  -> ('a, Generators.printable) Generators.generator
 
 (** [default_settings ()] creates default test settings with CI auto-detection.
 *)

--- a/lib/stateful.ml
+++ b/lib/stateful.ml
@@ -7,11 +7,12 @@ module Variables = struct
     { tc : Client.test_case
     ; pool_id : int
     ; values : (int, 'a) Hashtbl.t
+    ; sexp_of : ('a -> Sexp.t) option
     }
 
-  let create tc =
+  let create ?sexp_of tc =
     let pool_id = Client.new_pool tc in
-    { tc; pool_id; values = Hashtbl.create (module Int) }
+    { tc; pool_id; values = Hashtbl.create (module Int); sexp_of }
   ;;
 
   let add t value =
@@ -40,7 +41,10 @@ module Variables = struct
   let pick t ~consume =
     Client.assume t.tc (not (is_empty t));
     let variable_id = Client.pool_generate t.tc ~pool_id:t.pool_id ~consume () in
-    resolve_drawn t.values ~consume variable_id
+    let value = resolve_drawn t.values ~consume variable_id in
+    Option.iter t.sexp_of ~f:(fun f ->
+      Client.note t.tc (Printf.sprintf "v%d = %s" variable_id (Sexp.to_string (f value))));
+    value
   ;;
 
   let draw t = pick t ~consume:false
@@ -77,8 +81,7 @@ let run ~init ~rules ?(invariants = []) tc =
         ~invariant_names
     in
     let run_invariants state = List.iter invariants ~f:(fun inv -> inv state) in
-    run_invariants init;
-    let max_steps = tc.Client.stateful_step_count in
+    let max_steps = if is_single then Int.max_value else tc.Client.stateful_step_count in
     (* We basically always want to run the maximum number of steps, but leave a
        small probability of terminating early so the shrinker can reduce the
        step count once a failing case is found: stop with probability 2^-16
@@ -104,9 +107,7 @@ let run ~init ~rules ?(invariants = []) tc =
         let next_state, num_steps_succeeded =
           try
             let rule = rule_array.(Client.state_machine_next_rule tc ~state_machine_id) in
-            Client.note
-              tc
-              (Printf.sprintf "    Step %d: %s" (steps_run + 1) rule.Rule.name);
+            Client.note tc (Printf.sprintf "Step %d: %s" (steps_run + 1) rule.Rule.name);
             let new_state = rule.Rule.step tc state in
             run_invariants new_state;
             Client.stop_span tc;

--- a/lib/stateful.mli
+++ b/lib/stateful.mli
@@ -33,8 +33,10 @@ module Variables : sig
   type 'a t
 
   (** Creates an empty {!Variables.t}. Variables are tied to a test case; do not
-      reuse one across test cases. *)
-  val create : Client.test_case -> 'a t
+      reuse one across test cases. When [sexp_of] is given, each drawn/consumed
+      variable is printed as [v<id> = <sexp>] on the final replay of a failing
+      test; without it, variable picks print nothing. *)
+  val create : ?sexp_of:('a -> Core.Sexp.t) -> Client.test_case -> 'a t
 
   (** Records [value] in [variables] for later draws. *)
   val add : 'a t -> 'a -> unit

--- a/test/expect_tests/test_failure_blobs_record.ml
+++ b/test/expect_tests/test_failure_blobs_record.ml
@@ -98,21 +98,26 @@ let%expect_test "only the first blob is actually replayed" =
 exception A
 exception B
 
-let%expect_test "recording reports multiple distinct failures" =
+let%hegel_test multi_fail_test tc =
   let int_gen = Hegel.Generators.integers ~min_value:0 ~max_value:100 () in
-  let prop tc =
-    let v = Hegel.draw tc int_gen in
-    if v >= 60 then raise A;
-    if v <= 30 then raise B
-  in
-  let settings =
-    Hegel.settings ~test_cases:300 ~seed:9 ()
-    |> Hegel.Client.with_print_blob true
-    |> Hegel.Client.with_report_multiple_failures true
-  in
-  match Hegel.run_hegel_test ~settings prop with
+  let v = Hegel.draw tc int_gen in
+  if v >= 60 then raise A;
+  if v <= 30 then raise B
+[@@settings
+  Hegel.settings ~test_cases:300 ~seed:9 ()
+  |> Hegel.Client.with_print_blob true
+  |> Hegel.Client.with_report_multiple_failures true]
+;;
+
+let%expect_test "recording reports multiple distinct failures" =
+  match multi_fail_test () with
   | () -> assert false
   | exception Failure msg ->
     assert (contains ~needle:"Multiple failures (2)" msg);
-    assert (count ~needle:"failure blob:" msg = 2)
+    assert (count ~needle:"failure blob:" msg = 2);
+    [%expect
+      {|
+    v = 60
+    v = 0
+    |}]
 ;;

--- a/test/expect_tests/test_note_verbosity.ml
+++ b/test/expect_tests/test_note_verbosity.ml
@@ -43,14 +43,19 @@ let%expect_test "Verbose notes on every case (not just the final replay)" =
   run_passing Verbose;
   [%expect
     {|
+    draw_1 = 0
     NOTE_MARKER
     Running test case
+    draw_1 = 59
     NOTE_MARKER
     Running test case
+    draw_1 = 34
     NOTE_MARKER
     Running test case
+    draw_1 = 47
     NOTE_MARKER
     Running test case
+    draw_1 = 41
     NOTE_MARKER
     |}]
 ;;
@@ -59,13 +64,18 @@ let%expect_test "Debug notes on every case (not just the final replay)" =
   run_passing Debug;
   [%expect
     {|
+    draw_1 = 0
     NOTE_MARKER
+    draw_1 = 59
     NOTE_MARKER
     test case #2: status = Valid, choices = 1
+    draw_1 = 34
     NOTE_MARKER
     test case #3: status = Valid, choices = 1
+    draw_1 = 47
     NOTE_MARKER
     test case #4: status = Valid, choices = 1
+    draw_1 = 41
     NOTE_MARKER
     test case #5: status = Valid, choices = 1
     Test done. interesting_test_cases=0

--- a/test/test_generators_collections.ml
+++ b/test/test_generators_collections.ml
@@ -38,8 +38,9 @@ let test_lists_basic_no_max_schema () =
 (** Test: lists(basic_elem_with_transform) produces a Basic generator whose
     transform applies the element transform to every item in the result list. *)
 let test_lists_basic_with_element_transform () =
-  (* Build a basic generator with a transform (doubles the value) *)
-  let elem = map (fun v -> v * 2) (integers ()) in
+  (* Build a basic generator with a transform (doubles the value); [with_printer]
+     makes the mapped element drawable/composable while preserving its core. *)
+  let elem = with_printer Core.Int.sexp_of_t (map (fun v -> v * 2) (integers ())) in
   Alcotest.(check bool) "elem is_basic" true (is_basic elem);
   let gen = lists elem () in
   Alcotest.(check bool) "gen is_basic" true (is_basic gen);
@@ -61,13 +62,13 @@ let test_lists_non_basic_is_not_basic () =
 (** Test: lists basic transform raises on non-array input. *)
 let test_lists_basic_non_array_raises () =
   let gen = lists (integers ()) () in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42) : _) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (* ==== Validation tests ==== *)
@@ -268,7 +269,9 @@ let%hegel_test test_hashmaps_non_basic_values_e2e tc =
 let%hegel_test test_lists_unique_under_map_e2e tc =
   let gen =
     lists
-      (map (fun _ -> 0) (integers ~min_value:0 ~max_value:1 ()))
+      (with_printer
+         Core.Int.sexp_of_t
+         (map (fun _ -> 0) (integers ~min_value:0 ~max_value:1 ())))
       ~min_size:2
       ~max_size:2
       ~unique:true

--- a/test/test_generators_combinators.ml
+++ b/test/test_generators_combinators.ml
@@ -9,7 +9,9 @@ let test_one_of_empty () =
 ;;
 
 (** Test: one_of with a single generator is accepted. *)
-let test_one_of_single_accepted () = ignore (one_of [ booleans () ] : bool generator)
+let test_one_of_single_accepted () =
+  ignore (one_of [ booleans () ] : (bool, printable) generator)
+;;
 
 (** Test: sampled_from raises when given an empty list. *)
 let test_sampled_from_empty () =
@@ -23,7 +25,10 @@ let test_sampled_from_empty () =
     schemas so any partial tuple-wrapping regression would be visible. *)
 let test_one_of_basic_schema () =
   let gen =
-    one_of [ integers ~min_value:0 ~max_value:10 (); map (fun _ -> 0) (booleans ()) ]
+    one_of
+      [ integers ~min_value:0 ~max_value:10 ()
+      ; with_printer Core.Int.sexp_of_t (map (fun _ -> 0) (booleans ()))
+      ]
   in
   Alcotest.(check bool) "is_basic" true (is_basic gen);
   match schema gen with
@@ -61,17 +66,20 @@ let test_one_of_non_basic () =
 (** Test: one_of [index, value] dispatch transform. *)
 let test_one_of_dispatch () =
   let gen =
-    one_of [ map (fun x -> x * 2) (integers ()); map (fun x -> x + 100) (integers ()) ]
+    one_of
+      [ with_printer Core.Int.sexp_of_t (map (fun x -> x * 2) (integers ()))
+      ; with_printer Core.Int.sexp_of_t (map (fun x -> x + 100) (integers ()))
+      ]
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     (* index 0 → first branch, value 5 → 5 * 2 = 10 *)
     let result = transform (`Array [ `Int 0; `Int 5 ]) in
     Alcotest.(check int) "dispatched first" 10 result;
     (* index 1 → second branch, value 7 → 7 + 100 = 107 *)
     let result2 = transform (`Array [ `Int 1; `Int 7 ]) in
     Alcotest.(check int) "dispatched second" 107 result2
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: one_of dispatch bad format raises. *)
@@ -82,13 +90,13 @@ let test_one_of_dispatch_bad_format () =
       ; integers ~min_value:100 ~max_value:200 ()
       ]
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "bad format raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: optional creates one_of-based generator. *)
@@ -152,24 +160,24 @@ let test_tuples2_basic_schema () =
 (** Test: tuples2 basic transform. *)
 let test_tuples2_basic_transform () =
   let gen = tuples2 (integers ()) (booleans ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let a, b = transform (`Array [ `Int 5; `Bool true ]) in
     Alcotest.(check int) "first" 5 a;
     Alcotest.(check bool) "second" true b
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples2 basic transform bad format raises. *)
 let test_tuples2_bad_format () =
   let gen = tuples2 (integers ()) (booleans ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples2 non-basic is not basic. *)
@@ -194,25 +202,25 @@ let test_tuples3_basic_schema () =
 (** Test: tuples3 basic transform. *)
 let test_tuples3_basic_transform () =
   let gen = tuples3 (integers ()) (booleans ()) (integers ~min_value:0 ~max_value:5 ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let a, b, c = transform (`Array [ `Int 1; `Bool false; `Int 3 ]) in
     Alcotest.(check int) "first" 1 a;
     Alcotest.(check bool) "second" false b;
     Alcotest.(check int) "third" 3 c
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples3 bad format raises. *)
 let test_tuples3_bad_format () =
   let gen = tuples3 (integers ()) (booleans ()) (integers ~min_value:0 ~max_value:5 ()) in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples3 non-basic is not basic. *)
@@ -243,14 +251,14 @@ let test_tuples4_basic_transform () =
       (integers ~min_value:0 ~max_value:5 ())
       (floats ())
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let a, b, c, d = transform (`Array [ `Int 1; `Bool true; `Int 3; `Float 3.14 ]) in
     Alcotest.(check int) "first" 1 a;
     Alcotest.(check bool) "second" true b;
     Alcotest.(check int) "third" 3 c;
     Alcotest.(check (float 0.01)) "fourth" 3.14 d
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples4 bad format raises. *)
@@ -262,13 +270,13 @@ let test_tuples4_bad_format () =
       (integers ~min_value:0 ~max_value:5 ())
       (floats ())
   in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     let raised = ref false in
     (try ignore (transform (`Int 42)) with
      | Failure _ -> raised := true);
     Alcotest.(check bool) "raised" true !raised
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: tuples4 non-basic is not basic. *)
@@ -283,7 +291,12 @@ let test_tuples4_non_basic () =
 (** Test: one_of with basic generators works e2e. *)
 let test_one_of_e2e () =
   Hegel.run_hegel_test ~settings:(Client.settings ~test_cases:50 ()) (fun tc ->
-    let gen = one_of [ integers ~min_value:0 ~max_value:10 (); just 99 ] in
+    let gen =
+      one_of
+        [ integers ~min_value:0 ~max_value:10 ()
+        ; with_printer Core.Int.sexp_of_t (just 99)
+        ]
+    in
     let v = Hegel.draw tc gen in
     assert ((v >= 0 && v <= 10) || v = 99))
 ;;

--- a/test/test_generators_core.ml
+++ b/test/test_generators_core.ml
@@ -194,7 +194,7 @@ let test_map_doubles_e2e () =
   Hegel.run_hegel_test ~settings:(Client.settings ~test_cases:10 ()) (fun tc ->
     let gen = integers ~min_value:1 ~max_value:5 () |> map (fun v -> v * 2) in
     Alcotest.(check bool) "still basic" true (is_basic gen);
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (v >= 2 && v <= 10);
     assert (v mod 2 = 0))
 ;;
@@ -215,7 +215,7 @@ let test_double_map_e2e () =
        let typ = Cbor_helpers.extract_string (List.assoc (`Text "type") pairs) in
        Alcotest.(check string) "schema type" "integer" typ
      | None -> Alcotest.fail "expected schema");
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (List.mem v [ 3; 5; 7; 9; 11 ]))
 ;;
 
@@ -226,7 +226,7 @@ let test_map_on_filtered_e2e () =
       filter (fun v -> v > 5) (integers ~min_value:0 ~max_value:10 ())
       |> map (fun v -> v * 2)
     in
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (v > 10 && v <= 20))
 ;;
 
@@ -239,7 +239,7 @@ let test_flat_map_e2e () =
         (integers ~min_value:1 ~max_value:5 ())
     in
     Alcotest.(check bool) "not basic" false (is_basic gen);
-    let v = Hegel.draw tc gen in
+    let v = Hegel.draw_silent tc gen in
     assert (v >= 0))
 ;;
 
@@ -297,6 +297,145 @@ let test_discardable_group_e2e () =
     assert (n >= 0 && n <= 10))
 ;;
 
+(** [printer gen] renders [value] to [expected]. ([gen] is printable, so its
+    printer is total — no [option].) *)
+let check_printer name gen value expected =
+  Alcotest.(check string) name expected (Core.Sexp.to_string (printer gen value))
+;;
+
+let test_printer_int () = check_printer "int" (integers ()) 42 "42"
+let test_printer_bool () = check_printer "bool" (booleans ()) true "true"
+let test_printer_text () = check_printer "text" (text ()) "hi" "hi"
+
+(* [filter] is type-preserving, so it delegates to the source's printer. *)
+let test_printer_filter_delegates () =
+  check_printer "filter" (filter (fun _ -> true) (integers ())) 5 "5"
+;;
+
+(* [with_printer] upgrades an unprintable generator (here [map] over a [Basic])
+   to printable using the supplied printer. *)
+let test_with_printer () =
+  check_printer
+    "with_printer"
+    (with_printer Core.Int.sexp_of_t (map (fun v -> v * 2) (integers ())))
+    21
+    "21"
+;;
+
+(* [filter] over an unprintable generator stays unprintable; it can still be
+   drawn via [draw_silent] and reports a non-basic core. *)
+let test_filter_on_unprintable () =
+  let gen = filter (fun _ -> true) (sampled_from [ 1; 2; 3 ]) in
+  Alcotest.(check bool) "not basic" false (is_basic gen)
+;;
+
+(* Lists render via both the server-side path (basic elements) and the
+   collection path (non-basic but printable elements). *)
+let test_printer_list_basic () =
+  check_printer "list" (lists (integers ()) ()) [ 1; 2; 3 ] "(1 2 3)"
+;;
+
+let test_printer_list_composite () =
+  check_printer
+    "list composite"
+    (lists (filter (fun _ -> true) (integers ())) ())
+    [ 1; 2 ]
+    "(1 2)"
+;;
+
+let test_printer_list_unique_composite () =
+  check_printer
+    "list unique"
+    (lists (filter (fun _ -> true) (integers ())) ~unique:true ())
+    [ 1; 2 ]
+    "(1 2)"
+;;
+
+(* Tuples render via both the all-basic (single schema) and composite paths. *)
+let test_printer_tuple2 () =
+  check_printer "tuple2" (tuples2 (integers ()) (integers ())) (1, 2) "(1 2)"
+;;
+
+let test_printer_tuple2_composite () =
+  check_printer
+    "tuple2 composite"
+    (tuples2 (filter (fun _ -> true) (integers ())) (integers ()))
+    (1, 2)
+    "(1 2)"
+;;
+
+let test_printer_tuple3 () =
+  check_printer
+    "tuple3"
+    (tuples3 (integers ()) (integers ()) (integers ()))
+    (1, 2, 3)
+    "(1 2 3)"
+;;
+
+let test_printer_tuple4 () =
+  check_printer
+    "tuple4"
+    (tuples4 (integers ()) (integers ()) (integers ()) (integers ()))
+    (1, 2, 3, 4)
+    "(1 2 3 4)"
+;;
+
+(* one_of branches share a type, so any branch's printer renders the result. *)
+let test_printer_one_of_basic () =
+  check_printer
+    "one_of basic"
+    (one_of
+       [ integers ~min_value:0 ~max_value:5 (); integers ~min_value:6 ~max_value:9 () ])
+    3
+    "3"
+;;
+
+let test_printer_one_of_composite () =
+  check_printer
+    "one_of composite"
+    (one_of [ filter (fun _ -> true) (integers ()); integers () ])
+    3
+    "3"
+;;
+
+(* Hashmaps render via both the dict-schema (basic) and collection paths. *)
+let test_printer_hashmap_basic () =
+  check_printer
+    "hashmap"
+    (hashmaps (integers ()) (integers ()) ())
+    [ 1, 2; 3, 4 ]
+    "((1 2)(3 4))"
+;;
+
+let test_printer_hashmap_composite () =
+  check_printer
+    "hashmap composite"
+    (hashmaps (filter (fun _ -> true) (integers ())) (integers ()) ())
+    [ 1, 2 ]
+    "((1 2))"
+;;
+
+(* optional composes an ['a option] printer from the element's, rendering
+   [None] / [(Some v)] via [Option.sexp_of_t]. The element being non-basic
+   (here filtered) exercises optional's composite [one_of] path. *)
+(* [Option.sexp_of_t]'s round-trippable form: [(v)] for [Some v], [()] for
+   [None]. *)
+let test_printer_optional_some () =
+  check_printer "optional some" (optional (integers ())) (Some 5) "(5)"
+;;
+
+let test_printer_optional_none () =
+  check_printer "optional none" (optional (integers ())) None "()"
+;;
+
+let test_printer_optional_composite () =
+  check_printer
+    "optional composite"
+    (optional (filter (fun _ -> true) (integers ())))
+    (Some 7)
+    "(7)"
+;;
+
 let tests =
   [ Alcotest.test_case "span label constants" `Quick test_span_label_constants
   ; Alcotest.test_case "basic generator schema" `Quick test_basic_generator_schema
@@ -351,5 +490,28 @@ let tests =
   ; Alcotest.test_case "filter exhaustion e2e" `Quick test_filter_exhaustion_e2e
   ; Alcotest.test_case "group e2e" `Quick test_group_e2e
   ; Alcotest.test_case "discardable_group e2e" `Quick test_discardable_group_e2e
+  ; Alcotest.test_case "printer int" `Quick test_printer_int
+  ; Alcotest.test_case "printer bool" `Quick test_printer_bool
+  ; Alcotest.test_case "printer text" `Quick test_printer_text
+  ; Alcotest.test_case "printer filter delegates" `Quick test_printer_filter_delegates
+  ; Alcotest.test_case "with_printer" `Quick test_with_printer
+  ; Alcotest.test_case "filter on unprintable" `Quick test_filter_on_unprintable
+  ; Alcotest.test_case "printer list basic" `Quick test_printer_list_basic
+  ; Alcotest.test_case "printer list composite" `Quick test_printer_list_composite
+  ; Alcotest.test_case
+      "printer list unique composite"
+      `Quick
+      test_printer_list_unique_composite
+  ; Alcotest.test_case "printer tuple2" `Quick test_printer_tuple2
+  ; Alcotest.test_case "printer tuple2 composite" `Quick test_printer_tuple2_composite
+  ; Alcotest.test_case "printer tuple3" `Quick test_printer_tuple3
+  ; Alcotest.test_case "printer tuple4" `Quick test_printer_tuple4
+  ; Alcotest.test_case "printer one_of basic" `Quick test_printer_one_of_basic
+  ; Alcotest.test_case "printer one_of composite" `Quick test_printer_one_of_composite
+  ; Alcotest.test_case "printer hashmap basic" `Quick test_printer_hashmap_basic
+  ; Alcotest.test_case "printer hashmap composite" `Quick test_printer_hashmap_composite
+  ; Alcotest.test_case "printer optional some" `Quick test_printer_optional_some
+  ; Alcotest.test_case "printer optional none" `Quick test_printer_optional_none
+  ; Alcotest.test_case "printer optional composite" `Quick test_printer_optional_composite
   ]
 ;;

--- a/test/test_generators_primitives.ml
+++ b/test/test_generators_primitives.ml
@@ -43,10 +43,10 @@ let test_just_schema () =
 (** Test: just transform ignores server value. *)
 let test_just_transform () =
   let gen = just "hello" in
-  match gen with
-  | Basic { transform; _ } ->
+  match as_basic gen with
+  | Some (_, transform) ->
     Alcotest.(check string) "ignores server" "hello" (transform (`Int 999))
-  | _ -> Alcotest.fail "expected Basic"
+  | None -> Alcotest.fail "expected Basic"
 ;;
 
 (** Test: from_regex schema with default fullmatch. *)
@@ -458,7 +458,7 @@ let test_characters_with_categories () =
 (** Test: just always returns the constant. *)
 let test_just_e2e () =
   Hegel.run_hegel_test ~settings:(Client.settings ~test_cases:10 ()) (fun tc ->
-    let v = Hegel.draw tc (just 42) in
+    let v = Hegel.draw_silent tc (just 42) in
     Alcotest.(check int) "always 42" 42 v)
 ;;
 

--- a/test/test_generators_schema.ml
+++ b/test/test_generators_schema.ml
@@ -311,7 +311,7 @@ let%hegel_test test_binary_e2e tc =
 (** Test: sampled_from() E2E — values come from the options list. *)
 let%hegel_test test_sampled_from_e2e tc =
   let options = [ 10; 20; 30 ] in
-  let n = Hegel.draw tc (sampled_from options) in
+  let n = Hegel.draw_silent tc (sampled_from options) in
   assert (List.mem n [ 10; 20; 30 ])
 [@@settings Client.settings ~test_cases:10 ()]
 ;;


### PR DESCRIPTION
> (#78) and (#79) are stacked on this branch. #79 is independently CI-green (tree-identical to `better-printing`); these commits are review slices that apply in order.

### Core draw-printing mechanism
Printable/unprintable generator GADT and the final-replay printing path:
- `generators_core.ml`: `('a,'p) generator` GADT over a pure `'a core`, with `draw` / `draw_silent` / `with_printer` / `basic` / `basic_silent` and a total printer on `Printable`.
- `client.ml/.mli`: `draw_depth` gate
- `generators_primitives.ml`: every primitive/format generator carries a `Core.sexp_of_*` printer.
- `hegel.ml/.mli`, `generators.mli`: exposed surface.

### Combinator & collection printer propagation
`lists` / `tuples` / `one_of` / `hashmaps` / `optional` now require printable components and compose a total printer, so a drawn composite self-prints as one sexp on the failing replay. `filter` preserves printability across both arms.
- `generators_combinators.ml`: `tuples2/3/4` and `one_of` compute the printer from component printers; `optional` composes a round-trippable option printer.
- `generators_collections.ml`: `lists` / `hashmaps` propagate printers across basic / `CompositeList` / unique-`Composite` paths.

### Stateful / Variables printing on the failing replay
Stateful counterexamples print argument draws within a step and variable-pool bindings on the failing replay.
- `stateful.ml/.mli`: `Variables.create ?sexp_of`; `Variables.pick` prints `v<id> = <sexp>` on the final replay only when a printer was supplied. 

Tests: core/primitives/schema/stateful unit checks; `note_verbosity` and `failure_blobs_record` expect snapshots; `examples/collections.ml` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code), checked and edited by a human
