### PR TITLE
label-injecting PPX + docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,7 +20,7 @@ just check       # Run lint + docs + test (the full CI check)
 - **Formatter**: OCamlFormat 0.28.1 (version pinned in .ocamlformat)
 - **Documentation**: odoc 3.1.0
 - **Package manager**: opam 2.1.5
-- **PPX derivation**: ppxlib 0.35.0 (for `[@@deriving generator]`)
+- **PPX derivation**: ppxlib 0.35.0 (for `[@@deriving hegel]`)
 
 ## Project Structure
 
@@ -34,7 +34,7 @@ lib/                         # Library source
   cbor_helpers.ml            # CBOR encoding/decoding with type-safe extractors
   client.ml                  # Test runner + run lifecycle on top of Hegel_ffi.Ffi
   generators.ml              # Generator combinators (booleans, integers, lists, …)
-  derive.ml                  # Runtime support for [@@deriving generator]
+  derive.ml                  # Runtime support for [@@deriving hegel]
   test_runtime/              # Inline-test registry + runner for [let%hegel_test]
     hegel_test_runtime.ml    # Registry, run_all, test_main (called by dune-generated runner)
 
@@ -62,7 +62,7 @@ examples/                    # Example programs demonstrating the library
   basic_properties.ml        # Primitive generators: integers, booleans, floats
   collections.ml             # Collections and combinators: lists, filter, map
   real_world.ml              # Real-world scenario: sorted-merge property test
-  derived_types.ml           # Derived generators via [@@deriving generator]
+  derived_types.ml           # Derived generators via [@@deriving hegel]
 
 scripts/
   check-coverage.py          # Parses bisect-ppx-report, enforces 100%
@@ -133,20 +133,22 @@ binary directly.
 
 ### Type-Directed Derivation (ppx/ + lib/derive.ml)
 
-The `ppx_hegel_generator` PPX deriver synthesizes `unit -> 'a` generator functions
-from type declarations annotated with `[@@deriving generator]`. The generated code:
+The `ppx_hegel_generator` PPX deriver synthesizes a `(<t>, unprintable) generator`
+value named `<t>_generator` from type declarations annotated with
+`[@@deriving hegel]`. The generated code:
 
 1. For **records**: generates each field by calling the appropriate primitive
    generator, then constructs the record value.
 2. For **variants**: picks a constructor index uniformly at random via
    `sampled_from`, then generates arguments for the chosen constructor.
 3. For **type aliases**: delegates to the generator for the aliased type.
-4. For **nested types**: calls `<type>_generator ()` (user-defined generators
-   must exist in scope).
+4. For **nested types**: draws `<type>_generator` via `draw_silent` (user-defined
+   generators must exist in scope).
 
-The PPX emits code that calls `Hegel.Generators.generate` directly — no
-intermediate `generator` value is produced. The `Hegel.Derive` module provides
-runtime helpers for option and list types.
+The PPX emits a `test_case -> t` field-drawing thunk and wraps it with
+`Hegel.Generators.composite`, producing an `(t, unprintable) generator` value —
+no printer is attached, so a bare `[@@deriving hegel]` always compiles. The
+`Hegel.Derive` module provides runtime helpers for option and list types.
 
 **Usage example:**
 
@@ -155,20 +157,25 @@ runtime helpers for option and list types.
      (inline_tests (backend ppx_hegel_test))
      (preprocess (pps ppx_hegel_generator ppx_hegel_test)) *)
 
-type point = { x : int; y : int } [@@deriving generator]
-type color = Red | Green | Blue [@@deriving generator]
+type point = { x : int; y : int } [@@deriving hegel]
+type color = Red | Green | Blue [@@deriving hegel]
 type entity = { name : string; tag : int option; active : bool }
-[@@deriving generator]
+[@@deriving hegel]
 
-(* Use inside a let%hegel_test body: *)
-let%hegel_test derived_types_smoke _tc =
-  let p = point_generator () in
-  let c = color_generator () in
-  let e = entity_generator () in
+(* Use inside a let%hegel_test body. The derived generators are
+   (t, unprintable) generator values, drawn with draw_silent: *)
+let%hegel_test derived_types_smoke tc =
+  let p = Hegel.draw_silent tc point_generator in
+  let c = Hegel.draw_silent tc color_generator in
+  let e = Hegel.draw_silent tc entity_generator in
   (* p.x, p.y are ints; c is Red|Green|Blue; e has typed fields *)
   ignore (p, c, e)
 ;;
 ```
+
+To print a derived value on a failing replay, add `[@@deriving sexp_of]` and draw
+through `with_printer`:
+`Hegel.draw tc (Hegel.with_printer sexp_of_point point_generator)`.
 
 **Supported field types:**
 - `int` — bounded integers (±1073741823 to fit OCaml native int)
@@ -177,7 +184,7 @@ let%hegel_test derived_types_smoke _tc =
 - `string` — text strings
 - `t list` — lists of derived elements (max size 20)
 - `t option` — `Some v` or `None`
-- Named types `t` — calls `t_generator ()` (must be in scope)
+- Named types `t` — draws `t_generator` via `draw_silent` (must be in scope)
 - Tuples `(t1 * t2 * ...)` — generates each component
 
 ### Collection Protocol
@@ -266,11 +273,15 @@ The Hegel server speaks CBOR. Generator schemas are CBOR maps:
 
 ### PPX Deriver Implementation
 
-1. **PPX generates `unit -> 'a` functions, not `generator` values**: The Hegel generator
-   system operates at the CBOR level — `generate gen` returns `Cbor.t`. For
-   type-directed derivation to be ergonomic, the PPX generates functions that call
-   `generate` internally and extract typed OCaml values. This means derived generators
-   are `unit -> my_type` thunks, not `Hegel.Generators.generator` values.
+1. **PPX generates `(t, unprintable) generator` values**: The deriver builds a
+   `test_case -> t` field-drawing thunk and wraps it with
+   `Hegel.Generators.composite`, yielding a `(t, unprintable) generator` value
+   named `<t>_generator`. It carries no printer (the output type is the user's),
+   so a bare `[@@deriving hegel]` always compiles; draw it with `draw_silent`, or
+   pair it with `[@@deriving sexp_of]` and `with_printer` to print on a failing
+   replay. (Earlier revisions emitted a `test_case -> t` thunk drawn by calling
+   it directly; the `composite` wrapper replaced that so derived generators
+   compose with the other combinators.)
 
 2. **Unbounded integers cause CBOR bigint issues**: `integers()` without bounds can
    generate numbers too large for OCaml's native int. The CBOR library encodes these
@@ -279,7 +290,7 @@ The Hegel server speaks CBOR. Generator schemas are CBOR maps:
    the manual `Generators.integers ~min_value ~max_value ()` API.
 
 3. **PPX tests need a separate executable**: Because the PPX needs
-   `(preprocess (pps ppx_hegel_generator))`, the test file using `[@@deriving generator]`
+   `(preprocess (pps ppx_hegel_generator))`, the test file using `[@@deriving hegel]`
    must be in a separate `(test ...)` stanza from the main test suite. Both test
    executables are run by `dune runtest`.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ let%hegel_test commutative_addition tc =
 ```
 
 Run `dune runtest`. Hegel generates 100 random input pairs and reports the
-minimal counterexample if it finds one.
+minimal counterexample if it finds one. When a test fails, Hegel prints each
+value you drew from the failing case, named after the `let` binding it was
+bound to (`a = …`, `b = …`). See [Debugging failures](docs/getting-started.md#debug-your-failing-test-cases)
+for details.
 
 To override the default settings, attach a `[@@settings ...]` attribute:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,73 @@
+RELEASE_TYPE: minor
+
+This release makes Hegel print the values it drew as s-expressions when a test fails. 
+On the final replay of a failing property, each draw is reported as`name = value`. 
+Inside a `let%hegel_test`, each draw is labeled with the variable it was bound to:
+
+```ocaml
+let%hegel_test sorted_after_insert tc =
+  let xs = Hegel.draw tc (lists (integers ()) ()) in
+  let x = Hegel.draw tc (integers ()) in
+  assert (is_sorted (insert x (List.sort compare xs)))
+;;
+
+(* On failure, prints:
+     xs = (3 1)
+     x = 0  *)
+```
+
+A named draw that is shadowed or inside a loop is numbered
+(`x_1`, `x_2`, …). An unnamed `draw` or a draw outside of a `let%hegel_test` 
+binding is named `draw_1`, `draw_2`, …. The label can also be passed explicitly.
+
+**Generators are now `('a, 'p) generator`.** The phantom `'p` is `printable`
+when the generator carries a printer and `unprintable` otherwise. 
+
+**`map`, `flat_map`, `sampled_from`, and `just` are unprintable by default.** 
+Draw from them with `draw_silent` (no printing).
+```ocaml
+(* before *)
+let v = Hegel.draw tc (sampled_from [ 10; 20; 30 ])
+
+(* after — not printed *)
+let v = Hegel.draw_silent tc (sampled_from [ 10; 20; 30 ])
+```
+
+Attach a printer with the new `with_printer` to make a printable generator.
+Draw from them with `draw`. `with_printer` takes any `'a -> Sexp.t`.
+
+```ocaml
+(* after — printed on failure *)
+let sexp_of_int n = ...
+
+let v =
+  Hegel.draw tc (with_printer sexp_of_int (sampled_from [ 10; 20; 30 ]))
+```
+
+**`[@@deriving generator]` is now `[@@deriving hegel]`, and emits a generator
+value.** The deriver previously produced a `test_case -> t` function; it now
+produces a `(t, unprintable) generator` value named `<t>_generator`.
+
+```ocaml
+type point = { x : int; y : int } [@@deriving hegel]
+
+(* before: let p = point_generator tc *)
+let p = Hegel.draw_silent tc point_generator
+```
+
+To print a value from a derived generator:
+
+```ocaml
+type point = { x : int; y : int } [@@deriving hegel]
+
+let sexp_of_point p = ...
+
+let p = Hegel.draw tc (Hegel.with_printer sexp_of_point point_generator)
+```
+                                                      
+For a given type `t`, [`ppx_sexp_conv`](https://github.com/janestreet/ppx_sexp_conv) can be used to automatically 
+derive `sexp_of_<t>`.
+
+Stateful tests gain a `?sexp_of` argument on `Variables.create`; when given, each
+variable that is drawn or consumed prints as `v<id> = <sexp>` on a failing
+replay.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,10 +2,6 @@
 
 This guide walks you through the basics of installing Hegel and writing your first tests.
 
-## Prerequisites
-
-You will need [`uv`](https://docs.astral.sh/uv/) installed and on your PATH.
-
 ## Install Hegel
 
 Add `hegel` to your opam environment:
@@ -13,6 +9,11 @@ Add `hegel` to your opam environment:
 ```bash
 opam pin add hegel "git+ssh://git@github.com/hegeldev/hegel-ocaml.git"
 ```
+
+Hegel calls the native `libhegel` shared library and locates (or downloads and
+caches) it automatically at runtime, so there is no separate install step. See
+the [README](../README.md#install-hegel) for how the library is resolved and the
+supported platforms.
 
 ## Write your first test
 
@@ -59,7 +60,8 @@ let%hegel_test integer_under_fifty tc =
 This test asserts that any integer is less than 50, which is obviously incorrect.
 Hegel will find a test case that makes this assertion fail, and then shrink it
 to find the smallest counterexample — in this case, `n = 50`. `dune runtest`
-will print a `FAIL` line and exit non-zero.
+will print a `FAIL` line, report the drawn value as `n = 50` (named after the
+`let` binding), and exit non-zero.
 
 To fix this test, you can constrain the integers you generate with `min_value`
 and `max_value`:
@@ -123,7 +125,45 @@ let generate_person tc =
 
 ## Debug your failing test cases
 
-Use `note` to attach debug information:
+When a test fails, Hegel replays the minimal failing example and prints each
+value you drew as an s-expression, named after the `let` binding it was bound
+to:
+
+```ocaml
+let%hegel_test addition_commutes tc =
+  let x = draw tc (integers ()) in
+  let y = draw tc (integers ()) in
+  assert (x + y = y + x)
+;;
+
+(* On failure, prints:
+     x = …
+     y = …  *)
+```
+
+A value that is shadowed or drawn inside a loop is numbered (`x_1`, `x_2`, …),
+and you can override the name with `~label`: `draw ~label:"seed" tc (integers ())`.
+
+Some combinators hand the result type to your own code and so carry no printer —
+`map`, `flat_map`, `sampled_from`, `just`, and generators from `[@@deriving
+hegel]`. Either draw it with `draw_silent` (which prints nothing):
+
+```ocaml
+let parity = draw_silent tc (map (fun n -> n mod 2) (integers ())) 
+```
+or attach a printer with `with_printer`. The printer is any `'a -> Sexp.t`:
+```ocaml
+let parity =
+  draw tc (with_printer (fun n -> Sexp.Atom (Int.to_string n))
+             (map (fun n -> n mod 2) (integers ())))
+```
+If you have [`ppx_sexp_conv`](https://github.com/janestreet/ppx_sexp_conv) in your
+`(preprocess (pps ...))`, `[%sexp_of: int]` is a shorthand for that printer:
+```ocaml
+let parity = draw tc (with_printer [%sexp_of: int] (map (fun n -> n mod 2) (integers ())))
+```
+
+You can also attach your own debug information with `note`:
 
 ```ocaml
 let%hegel_test addition_commutes tc =
@@ -134,7 +174,8 @@ let%hegel_test addition_commutes tc =
 ;;
 ```
 
-Notes only appear when Hegel replays the minimal failing example.
+Notes, like drawn values, only appear when Hegel replays the minimal failing
+example.
 
 ## Change the number of test cases
 

--- a/ppx/ppx_hegel_test.ml
+++ b/ppx/ppx_hegel_test.ml
@@ -169,6 +169,175 @@ let build_items ~loc ~function_name ~settings_expr ~failure_blobs ~body_fn
   [ definition; registration ]
 ;;
 
+(** [is_draw_lident lid] is [true] when [lid]'s final component is [draw],
+    whether unqualified ([draw]) or qualified ([Hegel.draw], [Generators.draw],
+    a module alias [G.draw], …). Precision comes from the receiver check in
+    {!draw_binding_name} (the draw must be applied to the test's own [tc]), so
+    this only needs to recognize the name; [draw_silent] is a different name and
+    is excluded. *)
+let is_draw_lident : longident -> bool = function
+  | Lident "draw" | Ldot (_, "draw") -> true
+  | _ -> false
+;;
+
+(** [draw_named_lident lid] is [lid] with its final [draw] component replaced by
+    [draw_named], preserving the module prefix the user wrote, so the rewrite
+    targets the same module's internal entry point (e.g. [Hegel.draw] becomes
+    [Hegel.draw_named]). *)
+let draw_named_lident : longident -> longident = function
+  | Lident "draw" -> Lident "draw_named"
+  | Ldot (prefix, "draw") -> Ldot (prefix, "draw_named")
+  | other -> other
+;;
+
+(** [has_label_arg args] is [true] when an application already passes [~label]
+    (or [?label]) explicitly, in which case the hand-written label wins. *)
+let has_label_arg (args : (arg_label * expression) list) : bool =
+  List.exists
+    (fun (lbl, _) ->
+       match lbl with
+       | Labelled "label" | Optional "label" -> true
+       | _ -> false)
+    args
+;;
+
+(** [param_name pat] is the variable bound by [pat], if it is a simple variable
+    (possibly type-annotated), else [None]. *)
+let rec param_name (pat : pattern) : string option =
+  match pat.ppat_desc with
+  | Ppat_var { txt; _ } -> Some txt
+  | _ ->
+    (* [Ppat_constraint] arity differs between standard OCaml and OxCaml, so
+       unwrap a type-annotated pattern through the compat shim. *)
+    (match Ppx_compat.unwrap_pattern_constraint pat with
+     | Some p -> param_name p
+     | None -> None)
+;;
+
+(** [test_case_name e] is the name of the test function's first parameter (its
+    [tc]), used as the receiver the rewrite keys off. [None] when the binding is
+    not a function or its parameter is not a simple variable. *)
+let test_case_name (e : expression) : string option =
+  match Ppx_compat.expr_first_param_pat e with
+  | Some pat -> param_name pat
+  | None -> None
+;;
+
+(** [tc_arg_is ~tc_name args] is [true] when the first positional argument of an
+    application is exactly the identifier [tc_name]. *)
+let tc_arg_is ~tc_name (args : (arg_label * expression) list) : bool =
+  match List.find_map (fun (lbl, e) -> if lbl = Nolabel then Some e else None) args with
+  | Some { pexp_desc = Pexp_ident { txt = Lident n; _ }; _ } -> String.equal n tc_name
+  | _ -> false
+;;
+
+(** [draw_binding_name ~tc_name vb] returns [Some name] when [vb] is
+    [let <name> = draw tc …] — a simple-variable binding whose right-hand side is
+    a [draw] application on the test's own [tc] — and [None] otherwise. *)
+let draw_binding_name ~tc_name (vb : value_binding) : string option =
+  match vb.pvb_pat.ppat_desc, vb.pvb_expr.pexp_desc with
+  | ( Ppat_var { txt = name; _ }
+    , Pexp_apply ({ pexp_desc = Pexp_ident { txt = lid; _ }; _ }, args) )
+    when is_draw_lident lid && tc_arg_is ~tc_name args -> Some name
+  | _ -> None
+;;
+
+(** [collect_repeatable body] maps each draw-bound name to whether its draws
+    should be numbered. A name is repeatable
+    if it is drawn more than once, or drawn anywhere at block depth > 0 (inside a
+    function, [for], or [while] body, where it may run repeatedly). *)
+let collect_repeatable ~tc_name (body : expression) : (string, bool) Stdlib.Hashtbl.t =
+  let flags : (string, bool) Stdlib.Hashtbl.t = Stdlib.Hashtbl.create 8 in
+  let depth = ref 0 in
+  let record name =
+    let seen = Stdlib.Hashtbl.mem flags name in
+    if not seen then Stdlib.Hashtbl.replace flags name false;
+    if !depth > 0 || seen then Stdlib.Hashtbl.replace flags name true
+  in
+  let collector =
+    object
+      inherit Ast_traverse.iter as super
+
+      method! expression e =
+        (* [Pexp_let]/[Pexp_fun]/[Pexp_function] arities differ between OCaml
+           flavors, so go through the compat shim. *)
+        match Ppx_compat.extract_let_bindings e with
+        | Some vbs ->
+          List.iter
+            (fun vb ->
+               match draw_binding_name ~tc_name vb with
+               | Some name -> record name
+               | None -> ())
+            vbs;
+          super#expression e
+        | None ->
+          (match e.pexp_desc with
+           | Pexp_for _ | Pexp_while _ ->
+             incr depth;
+             super#expression e;
+             decr depth
+           | _ when Ppx_compat.is_function_expr e ->
+             incr depth;
+             super#expression e;
+             decr depth
+           | _ -> super#expression e)
+    end
+  in
+  collector#expression body;
+  flags
+;;
+
+(** [inject_draw ~tc_name flags vb] rewrites [let x = M.draw tc gen] into
+    [let x = M.draw_named ~label:"x" ~repeatable:b tc gen], so the drawn value
+    prints as [x = value] (numbered when [x] is flagged repeatable in [flags] —
+    reused name or drawn in a loop). It targets the internal [draw_named] rather
+    than the public [draw] (so [repeatable] stays off the public API), keeping
+    the module prefix [M] the user wrote. It fires only for a simple-variable
+    binding whose right-hand side is a [draw] application on [tc] with no
+    explicit [~label]; every other binding is unchanged. *)
+let inject_draw ~tc_name (flags : (string, bool) Stdlib.Hashtbl.t) (vb : value_binding)
+  : value_binding
+  =
+  match draw_binding_name ~tc_name vb, vb.pvb_expr.pexp_desc with
+  | ( Some name
+    , Pexp_apply (({ pexp_desc = Pexp_ident ({ txt = lid; _ } as ident); _ } as fn), args)
+    )
+    when not (has_label_arg args) ->
+    let loc = vb.pvb_expr.pexp_loc in
+    let repeatable =
+      match Stdlib.Hashtbl.find_opt flags name with
+      | Some b -> b
+      | None -> false
+    in
+    let named_fn =
+      { fn with pexp_desc = Pexp_ident { ident with txt = draw_named_lident lid } }
+    in
+    let named_args =
+      [ Labelled "label", Ast_builder.Default.estring ~loc name
+      ; Labelled "repeatable", Ast_builder.Default.ebool ~loc repeatable
+      ]
+    in
+    { vb with
+      pvb_expr = Ast_builder.Default.pexp_apply ~loc named_fn (named_args @ args)
+    }
+  | _ -> vb
+;;
+
+(** A traversal that applies {!inject_draw} to every [let]-binding in an
+    expression, threading the precomputed [flags], so labels are injected
+    throughout the test body (nested [let]s, helper functions, match arms, …).
+    Draws nested inside a generation span are still suppressed at runtime by the
+    depth gate, so labeling them is harmless. *)
+let label_injector ~tc_name flags =
+  object
+    inherit Ast_traverse.map as super
+
+    method! expression e =
+      let e = super#expression e in
+      Ppx_compat.map_let_value_bindings (List.map (inject_draw ~tc_name flags)) e
+  end
+;;
+
 (** Expander for a single [let%hegel_test ...] structure item. *)
 let expand_value_binding ~loc (vb : value_binding) : structure_item list =
   let function_name = extract_function_name vb.pvb_pat in
@@ -176,8 +345,18 @@ let expand_value_binding ~loc (vb : value_binding) : structure_item list =
   let failure_blobs = extract_failure_blobs_attr vb.pvb_attributes in
   (* The body of [let%hegel_test name <args> = expr] is parsed as
      [let name = <args -> expr>]. We pass that lambda as the [test_fn] to
-     [Hegel.run_hegel_test]. *)
-  build_items ~loc ~function_name ~settings_expr ~failure_blobs ~body_fn:vb.pvb_expr
+     [Hegel.run_hegel_test], first injecting [~label]/[~repeatable] from the
+     binding names — for draws on the test's own [tc] — so the counterexample
+     replay prints [name = value]. With no recognizable [tc] parameter, the body
+     is passed through unchanged. *)
+  let body_fn =
+    match test_case_name vb.pvb_expr with
+    | None -> vb.pvb_expr
+    | Some tc_name ->
+      let flags = collect_repeatable ~tc_name (Ppx_compat.peel_fun_params vb.pvb_expr) in
+      (label_injector ~tc_name flags)#expression vb.pvb_expr
+  in
+  build_items ~loc ~function_name ~settings_expr ~failure_blobs ~body_fn
 ;;
 
 (** The [hegel_test] extension is attached to [structure_item] (top-level

--- a/test/expect_tests/test_draw_printing.ml
+++ b/test/expect_tests/test_draw_printing.ml
@@ -1,0 +1,378 @@
+(** On the final replay of a failing test ([is_final = true]) an outermost
+    [draw] prints its value through the [note] channel (stderr, captured here by
+    ppx_expect). [draw_silent] never prints, and draws nested inside a span
+    (depth > 0) are suppressed so only the outermost value shows. The printer is
+    carried on primitive generators; combinators that hand the output type to
+    user code ([map], [sampled_from]) carry none, and [with_printer] attaches
+    one (and is what [draw] requires). *)
+
+open! Core
+open Hegel
+open Generators
+
+(* ---- draw / draw_silent through the engine ---- *)
+
+(* Quiet, deterministic run; swallow the failure the property raises so the
+   expect block only sees what we printed. *)
+let run_failing
+      ?(settings = Client.(settings ~test_cases:20 ~seed:0 () |> with_verbosity Normal))
+      body
+  =
+  try Hegel.run_hegel_test ~settings body with
+  | _ -> ()
+;;
+
+let%expect_test "draw_silent returns the value and prints nothing" =
+  Hegel.run_hegel_test
+    ~settings:Client.(settings ~test_cases:1 () |> with_verbosity Normal)
+    (fun tc ->
+       let v = Hegel.draw_silent tc (integers ~min_value:3 ~max_value:3 ()) in
+       printf "got=%d" v);
+  [%expect {| got=3 |}]
+;;
+
+let%expect_test "labeled draw prints name = value on final replay" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw ~label:"x" tc (integers ~min_value:7 ~max_value:7 ()) in
+    assert false);
+  [%expect
+    {|
+    x = 7
+    |}]
+;;
+
+let%expect_test "unlabeled draw is auto-named draw_N on final replay" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw tc (integers ~min_value:123456 ~max_value:123456 ()) in
+    assert false);
+  [%expect
+    {|
+    draw_1 = 123456
+    |}]
+;;
+
+let%expect_test "successive unlabeled draws number draw_1, draw_2" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw tc (integers ~min_value:1 ~max_value:1 ()) in
+    let _ = Hegel.draw tc (integers ~min_value:2 ~max_value:2 ()) in
+    assert false);
+  [%expect
+    {|
+    draw_1 = 1
+    draw_2 = 2
+    |}]
+;;
+
+let%expect_test "with_printer supplies the printer draw renders with" =
+  run_failing (fun tc ->
+    let _ =
+      Hegel.draw
+        ~label:"h"
+        tc
+        (with_printer
+           (fun n -> Sexp.Atom (sprintf "0x%x" n))
+           (integers ~min_value:255 ~max_value:255 ()))
+    in
+    assert false);
+  [%expect
+    {|
+    h = 0xff
+    |}]
+;;
+
+let%expect_test "with_printer makes an unprintable sampled_from drawable" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw ~label:"c" tc (with_printer Int.sexp_of_t (sampled_from [ 9 ])) in
+    assert false);
+  [%expect
+    {|
+    c = 9
+    |}]
+;;
+
+let%expect_test "draw nested in a span (depth > 0) is suppressed" =
+  run_failing (fun tc ->
+    let _ =
+      group Labels.list tc (fun () ->
+        Hegel.draw ~label:"n" tc (integers ~min_value:7 ~max_value:7 ()))
+    in
+    Hegel.note tc "ran";
+    assert false);
+  (* Only the outermost draw should print; the nested one is suppressed. *)
+  [%expect
+    {|
+    ran
+    |}]
+;;
+
+let%expect_test "a tuple draw prints as one sexp" =
+  run_failing (fun tc ->
+    let _ =
+      Hegel.draw
+        ~label:"pair"
+        tc
+        (tuples2
+           (integers ~min_value:7 ~max_value:7 ())
+           (integers ~min_value:8 ~max_value:8 ()))
+    in
+    assert false);
+  [%expect
+    {|
+    pair = (7 8)
+    |}]
+;;
+
+let%expect_test "a list draw prints as one sexp" =
+  run_failing (fun tc ->
+    let _ =
+      Hegel.draw
+        ~label:"xs"
+        tc
+        (lists (integers ~min_value:7 ~max_value:7 ()) ~min_size:2 ~max_size:2 ())
+    in
+    assert false);
+  [%expect
+    {|
+    xs = (7 7)
+    |}]
+;;
+
+let%expect_test "Variables.draw prints the binding (with ~sexp_of)" =
+  run_failing (fun tc ->
+    let vars = Stateful.Variables.create ~sexp_of:Int.sexp_of_t tc in
+    Stateful.Variables.add vars 42;
+    let _ = Stateful.Variables.draw vars in
+    assert false);
+  [%expect
+    {|
+    v1 = 42
+    |}]
+;;
+
+let%expect_test "Variables.draw without ~sexp_of prints no binding" =
+  run_failing (fun tc ->
+    let vars = Stateful.Variables.create tc in
+    Stateful.Variables.add vars 42;
+    let _ = Stateful.Variables.draw vars in
+    assert false);
+  (* Header only — no [v<id>] line, since no printer was supplied. *)
+  [%expect {|  |}]
+;;
+
+let%expect_test "a stateful rule's args print; the step-cap draw stays silent" =
+  let rule =
+    Stateful.Rule.create ~name:"push" ~step:(fun tc _state ->
+      let _ = Hegel.draw ~label:"n" tc (integers ~min_value:7 ~max_value:7 ()) in
+      assert false)
+  in
+  run_failing (fun tc -> Stateful.run ~init:() ~rules:[ rule ] tc);
+  [%expect
+    {|
+    Step 1: push
+    n = 7 
+    |}]
+;;
+
+let%expect_test
+    "stateful tests prints drawn data across all test cases when verbosity is verbose"
+  =
+  let rule =
+    Stateful.Rule.create ~name:"push" ~step:(fun tc _state ->
+      let _ = Hegel.draw ~label:"n" tc (integers ~min_value:7 ~max_value:7 ()) in
+      assert false)
+  in
+  run_failing
+    ~settings:
+      Client.(
+        settings ~test_cases:1 ~seed:0 ()
+        |> with_verbosity Verbose
+        |> with_phases [ Client.Generate ])
+    (fun tc ->
+       let vars = Stateful.Variables.create ~sexp_of:Int.sexp_of_t tc in
+       Stateful.Variables.add vars 42;
+       let _ = Stateful.Variables.draw vars in
+       Stateful.run ~init:() ~rules:[ rule ] tc);
+  [%expect
+    {|
+    v1 = 42
+    Step 1: push
+    n = 7
+    v1 = 42
+    Step 1: push
+    n = 7
+    |}]
+;;
+
+(* indent inner draws in a step *)
+
+(* [@@deriving hegel] emits an unprintable generator value. Adding
+   [@@deriving sexp_of] and drawing through [with_printer] prints the whole value
+   as one sexp; a bare [@@deriving hegel] drawn with [draw_silent] prints
+   nothing. *)
+
+type only = Only [@@deriving sexp_of, hegel]
+type wrap = { tag : only } [@@deriving sexp_of, hegel]
+type bare = Bare [@@deriving hegel]
+
+let%expect_test "a derived value prints as one sexp via with_printer" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw tc (with_printer sexp_of_only only_generator) in
+    assert false);
+  [%expect
+    {|
+    draw_1 = Only
+    |}]
+;;
+
+let%expect_test "a nested derived record prints as one sexp via with_printer" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw tc (with_printer sexp_of_wrap wrap_generator) in
+    assert false);
+  [%expect
+    {|
+    draw_1 = ((tag Only))
+    |}]
+;;
+
+let%expect_test "a bare [@@deriving hegel] drawn with draw_silent prints nothing" =
+  run_failing (fun tc ->
+    let _ = Hegel.draw_silent tc bare_generator in
+    assert false);
+  (* Header only — no [@@deriving sexp_of], so nothing to print. *)
+  [%expect {|  |}]
+;;
+
+(* ---- ppx_hegel_test label injection (end-to-end) ----
+
+   Inside a [let%hegel_test] body, a draw bound to a simple variable —
+   [let x = draw tc g] — is rewritten by the PPX to [draw ~label:"x" tc g], so
+   the value prints as [x = value] (not a bare value) on the failing replay.
+   This file enables the [ppx_hegel_test] rewriter, so the test below exercises
+   a real expansion. *)
+
+let%hegel_test label_injection_from_binding (tc : Hegel.Client.test_case) =
+  let x = Hegel.draw tc (integers ~min_value:7 ~max_value:7 ()) in
+  ignore (x : int);
+  assert false
+[@@settings Client.(settings ~test_cases:20 ~seed:0 () |> with_verbosity Normal)]
+;;
+
+let%expect_test "ppx injects ~label from the binding name" =
+  (try label_injection_from_binding () with
+   | _ -> ());
+  [%expect
+    {| 
+    x = 7
+    |}]
+;;
+
+(* The receiver decides what is rewritten, not the module path: a draw on [tc]
+   qualified by any Hegel-exporting module (here [Generators]) is labeled, and
+   the rewrite keeps that prefix (targeting [Generators.draw_named]). *)
+
+let%hegel_test qualified_generators_draw (tc : Hegel.Client.test_case) =
+  let g = Generators.draw tc (integers ~min_value:9 ~max_value:9 ()) in
+  ignore (g : int);
+  assert false
+[@@settings Client.(settings ~test_cases:20 ~seed:0 () |> with_verbosity Normal)]
+;;
+
+let%expect_test "a Generators-qualified draw is labeled (prefix preserved)" =
+  (try qualified_generators_draw () with
+   | _ -> ());
+  [%expect
+    {|   
+    g = 9
+    |}]
+;;
+
+(* A local function also named [draw] that is not Hegel's is left untouched,
+   because the rewrite keys off the receiver (the draw must be applied to the
+   test's own [tc]). Here [draw 5] is not applied to [tc], so it gets no
+   label and the user's own [draw] runs; only the genuine [Hegel.draw tc] is
+   labeled. *)
+
+let%hegel_test local_draw_not_on_tc_untouched (tc : Hegel.Client.test_case) =
+  let draw n = n + 100 in
+  let y = draw 5 in
+  ignore (y : int);
+  let z = Hegel.draw tc (integers ~min_value:1 ~max_value:1 ()) in
+  ignore (z : int);
+  assert false
+[@@settings Client.(settings ~test_cases:20 ~seed:0 () |> with_verbosity Normal)]
+;;
+
+let%expect_test "a local non-Hegel draw (not on tc) is not rewritten" =
+  (try local_draw_not_on_tc_untouched () with
+   | _ -> ());
+  (* No [y = …] line: [draw 5] was left alone; only [z], a real Hegel draw on
+     [tc], is labeled. *)
+  [%expect
+    {|
+    z = 1
+    |}]
+;;
+
+(* When a binding name is drawn more than once, the PPX flags it repeatable, so
+   every occurrence is numbered ([x_1], [x_2], …) — including the first — rather
+   than the lone-binding bare [x]. *)
+
+let%hegel_test repeated_binding_numbers (tc : Hegel.Client.test_case) =
+  let x = Hegel.draw tc (integers ~min_value:1 ~max_value:1 ()) in
+  ignore (x : int);
+  let x = Hegel.draw tc (integers ~min_value:2 ~max_value:2 ()) in
+  ignore (x : int);
+  let x = Hegel.draw tc (integers ~min_value:3 ~max_value:3 ()) in
+  ignore (x : int);
+  assert false
+[@@settings Client.(settings ~test_cases:20 ~seed:0 () |> with_verbosity Normal)]
+;;
+
+let%expect_test "a reused binding name numbers x_1, x_2, x_3" =
+  (try repeated_binding_numbers () with
+   | _ -> ());
+  [%expect
+    {|
+    x_1 = 1
+    x_2 = 2
+    x_3 = 3
+    |}]
+;;
+
+(* A draw inside a loop (block depth > 0) is flagged repeatable even though the
+   name appears once syntactically, so its per-iteration values are numbered. *)
+
+let%hegel_test looped_binding_numbers (tc : Hegel.Client.test_case) =
+  for i = 1 to 2 do
+    let x = Hegel.draw tc (integers ~min_value:i ~max_value:i ()) in
+    ignore (x : int)
+  done;
+  assert false
+[@@settings Client.(settings ~test_cases:20 ~seed:0 () |> with_verbosity Normal)]
+;;
+
+let%expect_test "a draw inside a loop numbers x_1, x_2" =
+  (try looped_binding_numbers () with
+   | _ -> ());
+  [%expect
+    {|
+    x_1 = 1
+    x_2 = 2
+    |}]
+;;
+
+(* ---- verbose verbosity prints draws on a non-final case ----
+
+   At [Normal]/[Quiet] verbosity a passing test prints nothing, since printing
+   is gated on the failing final replay. A single case keeps the snapshot clean: 
+   the engine emits its own [Running test case] lines between cases under verbose, 
+   which a multi-case run would capture. *)
+
+let%expect_test "verbose prints draws on a passing run" =
+  Hegel.run_hegel_test
+    ~settings:Client.(settings ~test_cases:1 ~seed:0 () |> with_verbosity Verbose)
+    (fun tc ->
+       let _ = Hegel.draw tc (integers ~min_value:5 ~max_value:5 ()) in
+       ());
+  [%expect {| draw_1 = 5 |}]
+;;


### PR DESCRIPTION
This branch is **tree-identical to `better-printing`**

In `ppx_hegel_test.ml`, rewrite `let x = draw tc g` inside `let%hegel_test` bodies to `draw ~label:"x" tc g`, which prints `name = value`.

- `ppx_hegel_test.ml`: label injection over `draw` bindings.
- `test/expect_tests/test_draw_printing.ml`: end-to-end snapshots across the whole printing surface (primitives, combinators, stateful, derived, labeled draws).
- `README` / `getting-started` / `RELEASE` / `CLAUDE.md`: document the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code), checked and edited by a human