### PR TITLE
Replace hashmaps with hash_tables and association_lists

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 The `hashmaps` generator is replaced by two generators that say what they
 mean: `association_lists`, which produces what `hashmaps` actually

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 RELEASE_TYPE: minor
 
 The `hashmaps` generator is replaced by two generators that say what they
-mean: `association_lists`, which produces what `hashmaps` actually
+mean: `assoc_lists`, which produces what `hashmaps` actually
 produced — a `(key * value) list` in generation order with unique keys —
 and `hash_tables`, which produces a real polymorphic `Hashtbl.t` with the
 same entry generation. Existing uses of `hashmaps` translate directly to
-`association_lists`.
+`assoc_lists`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: major
+
+The `hashmaps` generator is replaced by two generators that say what they
+mean: `association_lists`, which produces what `hashmaps` actually
+produced — a `(key * value) list` in generation order with unique keys —
+and `hash_tables`, which produces a real polymorphic `Hashtbl.t` with the
+same entry generation. Existing uses of `hashmaps` translate directly to
+`association_lists`.

--- a/examples/collections.ml
+++ b/examples/collections.ml
@@ -1,6 +1,6 @@
 (** Collection and combinator examples.
 
-    Demonstrates: lists, association_lists, hash_tables, sampled_from, map,
+    Demonstrates: lists, assoc_lists, hash_tables, sampled_from, map,
     flat_map, filter. *)
 
 open Hegel.Generators
@@ -72,11 +72,11 @@ let%hegel_test test_sampled_from tc =
 
 (** Property: association lists generated with a min_size have at least that
     many entries. *)
-let%hegel_test test_association_list_size tc =
+let%hegel_test test_assoc_list_size tc =
   let pairs =
     Hegel.draw
       tc
-      (association_lists
+      (assoc_lists
          (text ~min_size:1 ~max_size:8 ())
          (integers ~min_value:0 ~max_value:100 ())
          ~min_size:2
@@ -117,8 +117,8 @@ let () =
   Printf.printf "  flat_map_combinator: OK\n%!";
   test_sampled_from ();
   Printf.printf "  sampled_from: OK\n%!";
-  test_association_list_size ();
-  Printf.printf "  association_list_size: OK\n%!";
+  test_assoc_list_size ();
+  Printf.printf "  assoc_list_size: OK\n%!";
   test_hash_table_size ();
   Printf.printf "  hash_table_size: OK\n%!";
   Printf.printf "All tests passed.\n%!"

--- a/examples/collections.ml
+++ b/examples/collections.ml
@@ -1,6 +1,7 @@
 (** Collection and combinator examples.
 
-    Demonstrates: lists, hashmaps, sampled_from, map, flat_map, filter. *)
+    Demonstrates: lists, association_lists, hash_tables, sampled_from, map,
+    flat_map, filter. *)
 
 open Hegel.Generators
 
@@ -69,13 +70,13 @@ let%hegel_test test_sampled_from tc =
 [@@settings Hegel.settings ~test_cases:100 ()]
 ;;
 
-(** Property: hashmaps generated with a min_size have at least that many
-    entries. *)
-let%hegel_test test_hashmap_size tc =
+(** Property: association lists generated with a min_size have at least that
+    many entries. *)
+let%hegel_test test_association_list_size tc =
   let pairs =
     Hegel.draw
       tc
-      (hashmaps
+      (association_lists
          (text ~min_size:1 ~max_size:8 ())
          (integers ~min_value:0 ~max_value:100 ())
          ~min_size:2
@@ -83,6 +84,24 @@ let%hegel_test test_hashmap_size tc =
          ())
   in
   assert (List.length pairs >= 2)
+[@@settings Hegel.settings ~test_cases:50 ()]
+;;
+
+(** Property: hash tables respect their size bounds and hold unique keys by
+    construction. *)
+let%hegel_test test_hash_table_size tc =
+  let table =
+    Hegel.draw
+      tc
+      (hash_tables
+         (text ~min_size:1 ~max_size:8 ())
+         (integers ~min_value:0 ~max_value:100 ())
+         ~min_size:2
+         ~max_size:6
+         ())
+  in
+  let n = Core.Hashtbl.length table in
+  assert (n >= 2 && n <= 6)
 [@@settings Hegel.settings ~test_cases:50 ()]
 ;;
 
@@ -98,7 +117,9 @@ let () =
   Printf.printf "  flat_map_combinator: OK\n%!";
   test_sampled_from ();
   Printf.printf "  sampled_from: OK\n%!";
-  test_hashmap_size ();
-  Printf.printf "  hashmap_size: OK\n%!";
+  test_association_list_size ();
+  Printf.printf "  association_list_size: OK\n%!";
+  test_hash_table_size ();
+  Printf.printf "  hash_table_size: OK\n%!";
   Printf.printf "All tests passed.\n%!"
 ;;

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -483,25 +483,55 @@ val lists
   -> unit
   -> ('a list, printable) generator
 
-(** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
-    dictionaries (hash maps) over printable [keys] and [values].
+(** [association_lists keys values ?min_size ?max_size ()] creates a
+    generator for association lists over printable [keys] and [values]:
+    [(key, value)] pairs, in generation order, whose keys are unique.
 
     {[
-      let%hegel_test hashmaps_example tc =
+      let%hegel_test association_lists_example tc =
         let m =
           draw tc
-            (hashmaps (text ~max_size:4 ()) (integers ~min_value:0 ~max_value:9 ()) ~max_size:5 ())
+            (association_lists
+               (text ~max_size:4 ())
+               (integers ~min_value:0 ~max_value:9 ())
+               ~max_size:5
+               ())
         in
         assert (List.length m <= 5)
       ;;
     ]} *)
-val hashmaps
+val association_lists
   :  ('a, printable) generator
   -> ('b, printable) generator
   -> ?min_size:int
   -> ?max_size:int
   -> unit
   -> (('a * 'b) list, printable) generator
+
+(** [hash_tables keys values ?min_size ?max_size ()] creates a generator for
+    polymorphic hash tables over printable [keys] and [values], with entries
+    generated exactly as {!association_lists} generates its pairs.
+
+    {[
+      let%hegel_test hash_tables_example tc =
+        let m =
+          draw tc
+            (hash_tables
+               (text ~max_size:4 ())
+               (integers ~min_value:0 ~max_value:9 ())
+               ~max_size:5
+               ())
+        in
+        assert (Core.Hashtbl.length m <= 5)
+      ;;
+    ]} *)
+val hash_tables
+  :  ('a, printable) generator
+  -> ('b, printable) generator
+  -> ?min_size:int
+  -> ?max_size:int
+  -> unit
+  -> (('a, 'b) Core.Hashtbl.t, printable) generator
 
 (** [sampled_from options] creates a generator that samples uniformly from a
     non-empty list of values. The output type is the caller's, so the result

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -483,15 +483,15 @@ val lists
   -> unit
   -> ('a list, printable) generator
 
-(** [association_lists keys values ?min_size ?max_size ()] creates a
+(** [assoc_lists keys values ?min_size ?max_size ()] creates a
     generator for association lists over printable [keys] and [values]:
     [(key, value)] pairs, in generation order, whose keys are unique.
 
     {[
-      let%hegel_test association_lists_example tc =
+      let%hegel_test assoc_lists_example tc =
         let m =
           draw tc
-            (association_lists
+            (assoc_lists
                (text ~max_size:4 ())
                (integers ~min_value:0 ~max_value:9 ())
                ~max_size:5
@@ -500,7 +500,7 @@ val lists
         assert (List.length m <= 5)
       ;;
     ]} *)
-val association_lists
+val assoc_lists
   :  ('a, printable) generator
   -> ('b, printable) generator
   -> ?min_size:int
@@ -510,7 +510,7 @@ val association_lists
 
 (** [hash_tables keys values ?min_size ?max_size ()] creates a generator for
     polymorphic hash tables over printable [keys] and [values], with entries
-    generated exactly as {!association_lists} generates its pairs.
+    generated exactly as {!assoc_lists} generates its pairs.
 
     {[
       let%hegel_test hash_tables_example tc =

--- a/lib/generators_collections.ml
+++ b/lib/generators_collections.ml
@@ -1,13 +1,48 @@
 open! Core
 open Generators_core
 
-(** [hashmaps keys values ?min_size ?max_size ()] creates a generator for
-    dictionaries (hash maps) over printable [keys] and [values].
+(* [validate_size_bounds ~min_size ~max_size] rejects negative or crossed
+   collection size bounds. *)
+let validate_size_bounds ~min_size ~max_size =
+  if min_size < 0
+  then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
+  match max_size with
+  | Some ms when ms < 0 ->
+    raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
+  | Some ms when min_size > ms ->
+    raise (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
+  | _ -> ()
+;;
 
-    Key-value pairs are generated one at a time via the collection protocol.
-    Dict semantics require unique keys, so duplicate keys are rejected
-    client-side. *)
-let hashmaps
+(* [draw_association_pairs keys values ~min_size ~max_size data] drives the
+   collection protocol to produce unique-keyed [(key, value)] pairs in draw
+   order: the shared generation of {!association_lists} and {!hash_tables}.
+   Duplicate keys are rejected client-side. *)
+let draw_association_pairs keys values ~min_size ~max_size data =
+  let coll = new_collection ~min_size ?max_size data () in
+  let rec collect acc =
+    if collection_more coll data
+    then (
+      let k = do_draw (core_of keys) data in
+      if List.exists acc ~f:(fun (k', _) -> Poly.equal k' k)
+      then (
+        collection_reject coll data;
+        collect acc)
+      else (
+        let v = do_draw (core_of values) data in
+        collect ((k, v) :: acc)))
+    else List.rev acc
+  in
+  collect []
+;;
+
+(** [association_lists keys values ?min_size ?max_size ()] creates a generator
+    for association lists over printable [keys] and [values]: [(key, value)]
+    pairs, in generation order, whose keys are unique.
+
+    Key-value pairs are generated one at a time via the collection protocol,
+    with duplicate keys rejected client-side. *)
+let association_lists
       (keys : ('a, printable) generator)
       (values : ('b, printable) generator)
       ?(min_size = 0)
@@ -15,15 +50,7 @@ let hashmaps
       ()
   : (('a * 'b) list, printable) generator
   =
-  if min_size < 0
-  then raise (Invalid_argument (sprintf "min_size=%d must be non-negative" min_size));
-  (match max_size with
-   | Some ms when ms < 0 ->
-     raise (Invalid_argument (sprintf "max_size=%d must be non-negative" ms))
-   | Some ms when min_size > ms ->
-     raise
-       (Invalid_argument (sprintf "Cannot have max_size=%d < min_size=%d" ms min_size))
-   | _ -> ());
+  validate_size_bounds ~min_size ~max_size;
   let pk = printer keys
   and pv = printer values in
   let sexp_of kvs =
@@ -32,23 +59,37 @@ let hashmaps
   let core =
     Composite
       { label = Labels.map
+      ; generate_fn = draw_association_pairs keys values ~min_size ~max_size
+      }
+  in
+  Printable { core; sexp_of }
+;;
+
+(** [hash_tables keys values ?min_size ?max_size ()] creates a generator for
+    polymorphic hash tables over printable [keys] and [values].
+
+    The entries are generated exactly as {!association_lists} generates its
+    pairs — one at a time via the collection protocol, duplicate keys
+    rejected client-side — and loaded into a [Hashtbl.Poly.t]. *)
+let hash_tables
+      (keys : ('a, printable) generator)
+      (values : ('b, printable) generator)
+      ?(min_size = 0)
+      ?max_size
+      ()
+  : (('a, 'b) Hashtbl.t, printable) generator
+  =
+  validate_size_bounds ~min_size ~max_size;
+  let pk = printer keys
+  and pv = printer values in
+  let sexp_of table = Hashtbl.Poly.sexp_of_t pk pv table in
+  let core =
+    Composite
+      { label = Labels.map
       ; generate_fn =
           (fun data ->
-            let coll = new_collection ~min_size ?max_size data () in
-            let rec collect acc =
-              if collection_more coll data
-              then (
-                let k = do_draw (core_of keys) data in
-                if List.exists acc ~f:(fun (k', _) -> Poly.equal k' k)
-                then (
-                  collection_reject coll data;
-                  collect acc)
-                else (
-                  let v = do_draw (core_of values) data in
-                  collect ((k, v) :: acc)))
-              else List.rev acc
-            in
-            collect [])
+            Hashtbl.Poly.of_alist_exn
+              (draw_association_pairs keys values ~min_size ~max_size data))
       }
   in
   Printable { core; sexp_of }

--- a/lib/generators_collections.ml
+++ b/lib/generators_collections.ml
@@ -16,7 +16,7 @@ let validate_size_bounds ~min_size ~max_size =
 
 (* [draw_association_pairs keys values ~min_size ~max_size data] drives the
    collection protocol to produce unique-keyed [(key, value)] pairs in draw
-   order: the shared generation of {!association_lists} and {!hash_tables}.
+   order: the shared generation of {!assoc_lists} and {!hash_tables}.
    Duplicate keys are rejected client-side. *)
 let draw_association_pairs keys values ~min_size ~max_size data =
   let coll = new_collection ~min_size ?max_size data () in
@@ -36,13 +36,13 @@ let draw_association_pairs keys values ~min_size ~max_size data =
   collect []
 ;;
 
-(** [association_lists keys values ?min_size ?max_size ()] creates a generator
+(** [assoc_lists keys values ?min_size ?max_size ()] creates a generator
     for association lists over printable [keys] and [values]: [(key, value)]
     pairs, in generation order, whose keys are unique.
 
     Key-value pairs are generated one at a time via the collection protocol,
     with duplicate keys rejected client-side. *)
-let association_lists
+let assoc_lists
       (keys : ('a, printable) generator)
       (values : ('b, printable) generator)
       ?(min_size = 0)
@@ -68,7 +68,7 @@ let association_lists
 (** [hash_tables keys values ?min_size ?max_size ()] creates a generator for
     polymorphic hash tables over printable [keys] and [values].
 
-    The entries are generated exactly as {!association_lists} generates its
+    The entries are generated exactly as {!assoc_lists} generates its
     pairs — one at a time via the collection protocol, duplicate keys
     rejected client-side — and loaded into a [Hashtbl.Poly.t]. *)
 let hash_tables

--- a/test/test_generators_collections.ml
+++ b/test/test_generators_collections.ml
@@ -24,23 +24,23 @@ let test_lists_min_greater_than_max () =
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Test: association_lists raises when min_size is negative. *)
-let test_association_lists_negative_min_size () =
-  match association_lists (integers ()) (booleans ()) ~min_size:(-1) () with
+(** Test: assoc_lists raises when min_size is negative. *)
+let test_assoc_lists_negative_min_size () =
+  match assoc_lists (integers ()) (booleans ()) ~min_size:(-1) () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Test: association_lists raises when max_size is negative. *)
-let test_association_lists_negative_max_size () =
-  match association_lists (integers ()) (booleans ()) ~max_size:(-1) () with
+(** Test: assoc_lists raises when max_size is negative. *)
+let test_assoc_lists_negative_max_size () =
+  match assoc_lists (integers ()) (booleans ()) ~max_size:(-1) () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Test: association_lists raises when min_size > max_size. *)
-let test_association_lists_min_greater_than_max () =
-  match association_lists (integers ()) (booleans ()) ~min_size:5 ~max_size:3 () with
+(** Test: assoc_lists raises when min_size > max_size. *)
+let test_assoc_lists_min_greater_than_max () =
+  match assoc_lists (integers ()) (booleans ()) ~min_size:5 ~max_size:3 () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
@@ -142,22 +142,22 @@ let test_lists_non_basic_unique_exhaustion_e2e () =
        ignore (Hegel.draw tc gen))
 ;;
 
-(** Test: association_lists(non-basic keys) E2E — generates pairs. *)
-let test_association_lists_non_basic_keys_e2e () =
+(** Test: assoc_lists(non-basic keys) E2E — generates pairs. *)
+let test_assoc_lists_non_basic_keys_e2e () =
   Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:10 ()) (fun tc ->
     let key_gen = filter (fun _ -> true) (integers ~min_value:0 ~max_value:100 ()) in
     let val_gen = integers ~min_value:0 ~max_value:100 () in
-    let gen = association_lists key_gen val_gen ~min_size:0 ~max_size:5 () in
+    let gen = assoc_lists key_gen val_gen ~min_size:0 ~max_size:5 () in
     let pairs = Hegel.draw tc gen in
     assert (List.length pairs <= 5))
 ;;
 
-(** Test: association_lists(non-basic values) E2E — generates pairs. *)
-let test_association_lists_non_basic_values_e2e () =
+(** Test: assoc_lists(non-basic values) E2E — generates pairs. *)
+let test_assoc_lists_non_basic_values_e2e () =
   Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:10 ()) (fun tc ->
     let key_gen = integers ~min_value:0 ~max_value:100 () in
     let val_gen = filter (fun _ -> true) (integers ~min_value:0 ~max_value:100 ()) in
-    let gen = association_lists key_gen val_gen ~min_size:0 ~max_size:5 () in
+    let gen = assoc_lists key_gen val_gen ~min_size:0 ~max_size:5 () in
     let pairs = Hegel.draw tc gen in
     assert (List.length pairs <= 5))
 ;;
@@ -207,24 +207,24 @@ let test_hash_tables_e2e () =
     Core.Hashtbl.iteri table ~f:(fun ~key ~data:_ -> assert (key >= 0 && key <= 100)))
 ;;
 
-(** Test: hash_tables rejects crossed size bounds like association_lists. *)
+(** Test: hash_tables rejects crossed size bounds like assoc_lists. *)
 let test_hash_tables_min_greater_than_max () =
   match hash_tables (integers ()) (booleans ()) ~min_size:5 ~max_size:3 () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Regression: [association_lists] with a non-basic key generator must still enforce
+(** Regression: [assoc_lists] with a non-basic key generator must still enforce
     key uniqueness. With keys constrained to a single value, the dedup loop
     rejects every duplicate; the engine's reject limit eventually fires
     StopTest, which is caught by the test runner and skips the case.*)
-let test_association_lists_unique_keys_under_filter_e2e () =
+let test_assoc_lists_unique_keys_under_filter_e2e () =
   Hegel.run_hegel_test
     ~settings:
       (Hegel.settings ~test_cases:5 () |> with_suppress_health_check [ Filter_too_much ])
     (fun tc ->
        let gen =
-         association_lists
+         assoc_lists
            (filter (fun _ -> true) (integers ~min_value:0 ~max_value:0 ()))
            (booleans ())
            ~min_size:2
@@ -242,17 +242,17 @@ let tests =
   ; Alcotest.test_case "lists negative max_size" `Quick test_lists_negative_max_size
   ; Alcotest.test_case "lists min > max" `Quick test_lists_min_greater_than_max
   ; Alcotest.test_case
-      "association_lists negative min_size"
+      "assoc_lists negative min_size"
       `Quick
-      test_association_lists_negative_min_size
+      test_assoc_lists_negative_min_size
   ; Alcotest.test_case
-      "association_lists negative max_size"
+      "assoc_lists negative max_size"
       `Quick
-      test_association_lists_negative_max_size
+      test_assoc_lists_negative_max_size
   ; Alcotest.test_case
-      "association_lists min > max"
+      "assoc_lists min > max"
       `Quick
-      test_association_lists_min_greater_than_max
+      test_assoc_lists_min_greater_than_max
   ; Alcotest.test_case "lists of integers e2e" `Quick test_lists_of_integers_e2e
   ; Alcotest.test_case "lists booleans bounds e2e" `Quick test_lists_booleans_bounds_e2e
   ; Alcotest.test_case "lists non-basic e2e" `Quick test_lists_non_basic_e2e
@@ -270,20 +270,20 @@ let tests =
       `Quick
       test_hash_tables_min_greater_than_max
   ; Alcotest.test_case
-      "association_lists non-basic keys e2e"
+      "assoc_lists non-basic keys e2e"
       `Quick
-      test_association_lists_non_basic_keys_e2e
+      test_assoc_lists_non_basic_keys_e2e
   ; Alcotest.test_case
-      "association_lists non-basic values e2e"
+      "assoc_lists non-basic values e2e"
       `Quick
-      test_association_lists_non_basic_values_e2e
+      test_assoc_lists_non_basic_values_e2e
   ; Alcotest.test_case
       "lists unique under non-injective map e2e (regression)"
       `Quick
       test_lists_unique_under_map_e2e
   ; Alcotest.test_case
-      "association_lists unique keys under filter e2e (regression)"
+      "assoc_lists unique keys under filter e2e (regression)"
       `Quick
-      test_association_lists_unique_keys_under_filter_e2e
+      test_assoc_lists_unique_keys_under_filter_e2e
   ]
 ;;

--- a/test/test_generators_collections.ml
+++ b/test/test_generators_collections.ml
@@ -24,23 +24,23 @@ let test_lists_min_greater_than_max () =
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Test: hashmaps raises when min_size is negative. *)
-let test_hashmaps_negative_min_size () =
-  match hashmaps (integers ()) (booleans ()) ~min_size:(-1) () with
+(** Test: association_lists raises when min_size is negative. *)
+let test_association_lists_negative_min_size () =
+  match association_lists (integers ()) (booleans ()) ~min_size:(-1) () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Test: hashmaps raises when max_size is negative. *)
-let test_hashmaps_negative_max_size () =
-  match hashmaps (integers ()) (booleans ()) ~max_size:(-1) () with
+(** Test: association_lists raises when max_size is negative. *)
+let test_association_lists_negative_max_size () =
+  match association_lists (integers ()) (booleans ()) ~max_size:(-1) () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
 
-(** Test: hashmaps raises when min_size > max_size. *)
-let test_hashmaps_min_greater_than_max () =
-  match hashmaps (integers ()) (booleans ()) ~min_size:5 ~max_size:3 () with
+(** Test: association_lists raises when min_size > max_size. *)
+let test_association_lists_min_greater_than_max () =
+  match association_lists (integers ()) (booleans ()) ~min_size:5 ~max_size:3 () with
   | exception Invalid_argument _ -> ()
   | _ -> Alcotest.fail "expected Invalid_argument"
 ;;
@@ -142,22 +142,22 @@ let test_lists_non_basic_unique_exhaustion_e2e () =
        ignore (Hegel.draw tc gen))
 ;;
 
-(** Test: hashmaps(non-basic keys) E2E — generates pairs. *)
-let test_hashmaps_non_basic_keys_e2e () =
+(** Test: association_lists(non-basic keys) E2E — generates pairs. *)
+let test_association_lists_non_basic_keys_e2e () =
   Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:10 ()) (fun tc ->
     let key_gen = filter (fun _ -> true) (integers ~min_value:0 ~max_value:100 ()) in
     let val_gen = integers ~min_value:0 ~max_value:100 () in
-    let gen = hashmaps key_gen val_gen ~min_size:0 ~max_size:5 () in
+    let gen = association_lists key_gen val_gen ~min_size:0 ~max_size:5 () in
     let pairs = Hegel.draw tc gen in
     assert (List.length pairs <= 5))
 ;;
 
-(** Test: hashmaps(non-basic values) E2E — generates pairs. *)
-let test_hashmaps_non_basic_values_e2e () =
+(** Test: association_lists(non-basic values) E2E — generates pairs. *)
+let test_association_lists_non_basic_values_e2e () =
   Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:10 ()) (fun tc ->
     let key_gen = integers ~min_value:0 ~max_value:100 () in
     let val_gen = filter (fun _ -> true) (integers ~min_value:0 ~max_value:100 ()) in
-    let gen = hashmaps key_gen val_gen ~min_size:0 ~max_size:5 () in
+    let gen = association_lists key_gen val_gen ~min_size:0 ~max_size:5 () in
     let pairs = Hegel.draw tc gen in
     assert (List.length pairs <= 5))
 ;;
@@ -189,17 +189,42 @@ let test_lists_unique_under_map_e2e () =
        Alcotest.(check int) "all unique" n uniq)
 ;;
 
-(** Regression: [hashmaps] with a non-basic key generator must still enforce
+(** Test: hash_tables produces a [Hashtbl.t] within the size bounds, holding
+    the generated entries. *)
+let test_hash_tables_e2e () =
+  Hegel.run_hegel_test ~settings:(Hegel.settings ~test_cases:50 ()) (fun tc ->
+    let gen =
+      hash_tables
+        (integers ~min_value:0 ~max_value:100 ())
+        (booleans ())
+        ~min_size:1
+        ~max_size:5
+        ()
+    in
+    let table = Hegel.draw tc gen in
+    let n = Core.Hashtbl.length table in
+    assert (n >= 1 && n <= 5);
+    Core.Hashtbl.iteri table ~f:(fun ~key ~data:_ -> assert (key >= 0 && key <= 100)))
+;;
+
+(** Test: hash_tables rejects crossed size bounds like association_lists. *)
+let test_hash_tables_min_greater_than_max () =
+  match hash_tables (integers ()) (booleans ()) ~min_size:5 ~max_size:3 () with
+  | exception Invalid_argument _ -> ()
+  | _ -> Alcotest.fail "expected Invalid_argument"
+;;
+
+(** Regression: [association_lists] with a non-basic key generator must still enforce
     key uniqueness. With keys constrained to a single value, the dedup loop
     rejects every duplicate; the engine's reject limit eventually fires
     StopTest, which is caught by the test runner and skips the case.*)
-let test_hashmaps_unique_keys_under_filter_e2e () =
+let test_association_lists_unique_keys_under_filter_e2e () =
   Hegel.run_hegel_test
     ~settings:
       (Hegel.settings ~test_cases:5 () |> with_suppress_health_check [ Filter_too_much ])
     (fun tc ->
        let gen =
-         hashmaps
+         association_lists
            (filter (fun _ -> true) (integers ~min_value:0 ~max_value:0 ()))
            (booleans ())
            ~min_size:2
@@ -216,9 +241,18 @@ let tests =
   [ Alcotest.test_case "lists negative min_size" `Quick test_lists_negative_min_size
   ; Alcotest.test_case "lists negative max_size" `Quick test_lists_negative_max_size
   ; Alcotest.test_case "lists min > max" `Quick test_lists_min_greater_than_max
-  ; Alcotest.test_case "hashmaps negative min_size" `Quick test_hashmaps_negative_min_size
-  ; Alcotest.test_case "hashmaps negative max_size" `Quick test_hashmaps_negative_max_size
-  ; Alcotest.test_case "hashmaps min > max" `Quick test_hashmaps_min_greater_than_max
+  ; Alcotest.test_case
+      "association_lists negative min_size"
+      `Quick
+      test_association_lists_negative_min_size
+  ; Alcotest.test_case
+      "association_lists negative max_size"
+      `Quick
+      test_association_lists_negative_max_size
+  ; Alcotest.test_case
+      "association_lists min > max"
+      `Quick
+      test_association_lists_min_greater_than_max
   ; Alcotest.test_case "lists of integers e2e" `Quick test_lists_of_integers_e2e
   ; Alcotest.test_case "lists booleans bounds e2e" `Quick test_lists_booleans_bounds_e2e
   ; Alcotest.test_case "lists non-basic e2e" `Quick test_lists_non_basic_e2e
@@ -230,21 +264,26 @@ let tests =
       "lists non-basic unique exhaustion e2e"
       `Quick
       test_lists_non_basic_unique_exhaustion_e2e
+  ; Alcotest.test_case "hash_tables e2e" `Quick test_hash_tables_e2e
   ; Alcotest.test_case
-      "hashmaps non-basic keys e2e"
+      "hash_tables min > max"
       `Quick
-      test_hashmaps_non_basic_keys_e2e
+      test_hash_tables_min_greater_than_max
   ; Alcotest.test_case
-      "hashmaps non-basic values e2e"
+      "association_lists non-basic keys e2e"
       `Quick
-      test_hashmaps_non_basic_values_e2e
+      test_association_lists_non_basic_keys_e2e
+  ; Alcotest.test_case
+      "association_lists non-basic values e2e"
+      `Quick
+      test_association_lists_non_basic_values_e2e
   ; Alcotest.test_case
       "lists unique under non-injective map e2e (regression)"
       `Quick
       test_lists_unique_under_map_e2e
   ; Alcotest.test_case
-      "hashmaps unique keys under filter e2e (regression)"
+      "association_lists unique keys under filter e2e (regression)"
       `Quick
-      test_hashmaps_unique_keys_under_filter_e2e
+      test_association_lists_unique_keys_under_filter_e2e
   ]
 ;;

--- a/test/test_generators_core.ml
+++ b/test/test_generators_core.ml
@@ -258,20 +258,31 @@ let test_printer_one_of_composite () =
     "3"
 ;;
 
-(* Hashmaps render via both the dict-schema (basic) and collection paths. *)
-let test_printer_hashmap_basic () =
+(* Association lists render via both the dict-schema (basic) and collection
+   paths. *)
+let test_printer_association_list_basic () =
   check_printer
-    "hashmap"
-    (hashmaps (integers ()) (integers ()) ())
+    "association list"
+    (association_lists (integers ()) (integers ()) ())
     [ 1, 2; 3, 4 ]
     "((1 2)(3 4))"
 ;;
 
-let test_printer_hashmap_composite () =
+let test_printer_association_list_composite () =
   check_printer
-    "hashmap composite"
-    (hashmaps (filter (fun _ -> true) (integers ())) (integers ()) ())
+    "association list composite"
+    (association_lists (filter (fun _ -> true) (integers ())) (integers ()) ())
     [ 1, 2 ]
+    "((1 2))"
+;;
+
+(* Hash tables render through [Hashtbl.Poly.sexp_of_t]; a single entry keeps
+   the iteration order deterministic. *)
+let test_printer_hash_table () =
+  check_printer
+    "hash table"
+    (hash_tables (integers ()) (integers ()) ())
+    (Core.Hashtbl.Poly.of_alist_exn [ 1, 2 ])
     "((1 2))"
 ;;
 
@@ -360,8 +371,15 @@ let tests =
   ; Alcotest.test_case "printer tuple4" `Quick test_printer_tuple4
   ; Alcotest.test_case "printer one_of basic" `Quick test_printer_one_of_basic
   ; Alcotest.test_case "printer one_of composite" `Quick test_printer_one_of_composite
-  ; Alcotest.test_case "printer hashmap basic" `Quick test_printer_hashmap_basic
-  ; Alcotest.test_case "printer hashmap composite" `Quick test_printer_hashmap_composite
+  ; Alcotest.test_case
+      "printer association list basic"
+      `Quick
+      test_printer_association_list_basic
+  ; Alcotest.test_case
+      "printer association list composite"
+      `Quick
+      test_printer_association_list_composite
+  ; Alcotest.test_case "printer hash table" `Quick test_printer_hash_table
   ; Alcotest.test_case "printer optional some" `Quick test_printer_optional_some
   ; Alcotest.test_case "printer optional none" `Quick test_printer_optional_none
   ; Alcotest.test_case "printer optional composite" `Quick test_printer_optional_composite

--- a/test/test_generators_core.ml
+++ b/test/test_generators_core.ml
@@ -260,18 +260,18 @@ let test_printer_one_of_composite () =
 
 (* Association lists render via both the dict-schema (basic) and collection
    paths. *)
-let test_printer_association_list_basic () =
+let test_printer_assoc_list_basic () =
   check_printer
     "association list"
-    (association_lists (integers ()) (integers ()) ())
+    (assoc_lists (integers ()) (integers ()) ())
     [ 1, 2; 3, 4 ]
     "((1 2)(3 4))"
 ;;
 
-let test_printer_association_list_composite () =
+let test_printer_assoc_list_composite () =
   check_printer
     "association list composite"
-    (association_lists (filter (fun _ -> true) (integers ())) (integers ()) ())
+    (assoc_lists (filter (fun _ -> true) (integers ())) (integers ()) ())
     [ 1, 2 ]
     "((1 2))"
 ;;
@@ -374,11 +374,11 @@ let tests =
   ; Alcotest.test_case
       "printer association list basic"
       `Quick
-      test_printer_association_list_basic
+      test_printer_assoc_list_basic
   ; Alcotest.test_case
       "printer association list composite"
       `Quick
-      test_printer_association_list_composite
+      test_printer_assoc_list_composite
   ; Alcotest.test_case "printer hash table" `Quick test_printer_hash_table
   ; Alcotest.test_case "printer optional some" `Quick test_printer_optional_some
   ; Alcotest.test_case "printer optional none" `Quick test_printer_optional_none


### PR DESCRIPTION
<details>
<summary>Details (AI-generated)</summary>

`hashmaps` documented itself as generating "dictionaries (hash maps)" but its return type was `('a * 'b) list` — an association list with unique keys. This PR removes it and adds two generators that say what they mean:

- `association_lists keys values ?min_size ?max_size ()` — exactly what `hashmaps` produced: `(key, value)` pairs in generation order with unique keys (duplicates rejected client-side through the collection protocol). Existing `hashmaps` uses translate directly to this.
- `hash_tables keys values ?min_size ?max_size ()` — a real `('a, 'b) Hashtbl.t` (polymorphic hashing), generated as the same pair stream loaded via `Hashtbl.Poly.of_alist_exn`, printing through `Hashtbl.Poly.sexp_of_t`.

Both share the pair-generation loop (`draw_association_pairs`) and size validation. Tests: the existing `hashmaps` validation/e2e/printer/unique-keys-under-filter tests carry over to `association_lists`, plus new `hash_tables` e2e, validation, and printer tests; the `examples/collections.ml` example is split to demonstrate both. `RELEASE_TYPE: major` since removing `hashmaps` is a breaking change — downgrade if you'd rather ship it differently.

Full `just check` (format, docs, tests, 100% bisect coverage) passes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)