### PR TITLE
claude: sync zerover release-type guidance in docs

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -5,11 +5,11 @@ description: "Changelog style guide for writing RELEASE.md files. Use when creat
 
 # Changelog Style Guide
 
-This guide describes the style for writing `RELEASE.md` files for hegel-rust. The style is modeled on the [Hypothesis changelog](https://hypothesis.readthedocs.io/en/latest/changes.html).
+This guide describes the style for writing `RELEASE.md` files for hegel-ocaml. The style is modeled on the [Hypothesis changelog](https://hypothesis.readthedocs.io/en/latest/changes.html).
 
 ## Choosing `RELEASE_TYPE`
 
-hegel-rust is currently zerover (`0.x.y`), so the usual semver mapping does **not** apply. While we are pre-1.0:
+hegel-ocaml is currently zerover (`0.x.y`), so the usual semver mapping does **not** apply. While we are pre-1.0:
 
 - **`patch`** — Bug fixes, internal changes, **and new features / non-breaking API additions**. The default choice.
 - **`minor`** — **Breaking changes only.** Any change that requires users to update their code (renamed/removed APIs, changed signatures, behavior changes that could break downstream tests) is a minor bump.

--- a/RELEASE-sample.md
+++ b/RELEASE-sample.md
@@ -6,7 +6,7 @@ This patch adds support for setting `seed` to the protocol.
 
 Every pull request which modifies the source code must include a `RELEASE.md` file. This `RELEASE-sample.md` file is an example of that file.
 
-In the example above, "patch" on the first line should be replaced by "minor" if changes are visible in the public API, or "major" if there are breaking changes.  Note that only maintainers should ever make a major release.
+While we are on a `0.x` major version the semver levels are shifted: **breaking changes are "minor"** and **everything else (bug fixes, internal changes, and new non-breaking features / API additions) is "patch"**. So in the example above, "patch" on the first line should be replaced by "minor" only for a breaking change. "major" is reserved for the eventual 1.0 and beyond, and only maintainers should ever make a major release.
 
 The remaining lines are the actual changelog text for this release, which should:
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Syncs the zerover (`0.x.y`) release-type guidance into this repo's docs, part of a cross-repo pass over all seven Hegel libraries (a breaking change was recently mislabeled `RELEASE_TYPE: major` due to stale classic-semver guidance):

- `RELEASE-sample.md`: replaced the stale "minor if visible in the public API, major if breaking" paragraph with the canonical zerover mapping — breaking changes are `minor`, everything else (bug fixes, internals, non-breaking additions) is `patch`, and `major` is reserved for the eventual 1.0.
- `.claude/skills/changelog/SKILL.md`: fixed two leftover "hegel-rust" references (the skill was copied from hegel-rust) to say "hegel-ocaml". The zerover guidance in that file was already correct and is unchanged.

Docs-only change, so no `RELEASE.md` is included.

Self-review note: the reviewer pass flagged that the illustrative sample entry in `RELEASE-sample.md` ("adds support for setting `seed` to the protocol") is stale post-FFI-migration (there is no protocol anymore). Left as-is since this PR's scope is strictly the release-type guidance sync; worth a reword in a follow-up.

</details>
