### PR TITLE
Fix concurrent cold-cache libhegel downloads clobbering each other

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This patch fixes a crash when several test binaries start at the same time
+with a cold libhegel cache. Every process downloaded the library to the same
+temporary file and renamed it into place, so the first process to finish
+pulled the file out from under the others, which then failed with checksum or
+missing-file errors (and could corrupt the cached library). Each process now
+downloads to its own temporary file and atomically renames it into place, so
+concurrent first runs all succeed. Partial downloads left behind by a killed
+process no longer interfere with later downloads.

--- a/lib/ffi/loader.ml
+++ b/lib/ffi/loader.ml
@@ -175,6 +175,37 @@ let from_sibling ext =
   List.find_opt is_file [ candidate "release"; candidate "debug" ]
 ;;
 
+(* Download [url] into [cache_path], failing unless the payload's SHA-256 is
+   [expected]. The payload is fetched to a temporary file in the cache
+   directory, verified, and then renamed into place. Exposed (rather than
+   inlined in [from_cache_or_download]) so the test suite can exercise the
+   download protocol against a stubbed [curl] and its own checksum. *)
+let download_verified ~url ~expected ~cache_path =
+  mkdir_p (Filename.dirname cache_path);
+  let tmp = cache_path ^ ".tmp" in
+  let rc =
+    Sys.command
+      (Printf.sprintf "curl -fsSL %s -o %s" (Filename.quote url) (Filename.quote tmp))
+  in
+  if rc <> 0
+  then (
+    (try Sys.remove tmp with
+     | _ -> ());
+    failwith (Printf.sprintf "hegel: failed to download %s (curl exit %d)" url rc));
+  let actual = sha256_of_file tmp in
+  if not (String.equal actual expected)
+  then (
+    (try Sys.remove tmp with
+     | _ -> ());
+    failwith
+      (Printf.sprintf
+         "hegel: SHA-256 mismatch for downloaded libhegel (expected %s, got %s)"
+         expected
+         actual));
+  Sys.rename tmp cache_path;
+  cache_path
+;;
+
 (* 4. Cached download (fetching + verifying on first use). *)
 let from_cache_or_download os_id ext =
   let key = os_id ^ "-" ^ arch_id () in
@@ -206,29 +237,7 @@ let from_cache_or_download os_id ext =
             cache_path)
      | None -> ());
     let url = Printf.sprintf "%s/%s" release_base (release_artifact key ext) in
-    mkdir_p (cache_dir ());
-    let tmp = cache_path ^ ".tmp" in
-    let rc =
-      Sys.command
-        (Printf.sprintf "curl -fsSL %s -o %s" (Filename.quote url) (Filename.quote tmp))
-    in
-    if rc <> 0
-    then (
-      (try Sys.remove tmp with
-       | _ -> ());
-      failwith (Printf.sprintf "hegel: failed to download %s (curl exit %d)" url rc));
-    let actual = sha256_of_file tmp in
-    if not (String.equal actual expected)
-    then (
-      (try Sys.remove tmp with
-       | _ -> ());
-      failwith
-        (Printf.sprintf
-           "hegel: SHA-256 mismatch for downloaded libhegel (expected %s, got %s)"
-           expected
-           actual));
-    Sys.rename tmp cache_path;
-    cache_path)
+    download_verified ~url ~expected ~cache_path)
 ;;
 
 (** [locate ()] returns the path to a usable libhegel shared library, downloading

--- a/lib/ffi/loader.ml
+++ b/lib/ffi/loader.ml
@@ -182,27 +182,52 @@ let from_sibling ext =
    download protocol against a stubbed [curl] and its own checksum. *)
 let download_verified ~url ~expected ~cache_path =
   mkdir_p (Filename.dirname cache_path);
-  let tmp = cache_path ^ ".tmp" in
+  (* Concurrent processes (e.g. several test binaries starting with a cold
+     cache) may all reach this point at once, so each must download to its
+     OWN temporary file: a shared temporary path would let one process rename
+     (or delete) a file another is still writing. The PID makes the name
+     unique across live processes on this host; the random salt guards
+     against PID reuse colliding with a stale file left by a killed process
+     (such leftovers are otherwise inert: nothing else ever reads them). The
+     temporary file stays in the cache directory so the rename below cannot
+     cross filesystems. *)
+  let tmp =
+    Printf.sprintf
+      "%s.%d.%06x.tmp"
+      cache_path
+      (Unix.getpid ())
+      (Random.State.bits (Random.State.make_self_init ()) land 0xFFFFFF)
+  in
+  let remove_tmp () =
+    try Sys.remove tmp with
+    | _ -> ()
+  in
   let rc =
     Sys.command
       (Printf.sprintf "curl -fsSL %s -o %s" (Filename.quote url) (Filename.quote tmp))
   in
   if rc <> 0
   then (
-    (try Sys.remove tmp with
-     | _ -> ());
+    remove_tmp ();
     failwith (Printf.sprintf "hegel: failed to download %s (curl exit %d)" url rc));
   let actual = sha256_of_file tmp in
   if not (String.equal actual expected)
   then (
-    (try Sys.remove tmp with
-     | _ -> ());
+    remove_tmp ();
     failwith
       (Printf.sprintf
          "hegel: SHA-256 mismatch for downloaded libhegel (expected %s, got %s)"
          expected
          actual));
-  Sys.rename tmp cache_path;
+  (* Atomic publish. If a concurrent process won the race, POSIX [rename]
+     silently (and atomically) replaces its identical, verified copy. On
+     platforms where replacing an in-use file can fail (e.g. Windows), fall
+     back to the winner's copy when it verifies. *)
+  (try Sys.rename tmp cache_path with
+   | Sys_error _ as e ->
+     remove_tmp ();
+     if not (is_file cache_path && String.equal (sha256_of_file cache_path) expected)
+     then raise e);
   cache_path
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -13,8 +13,9 @@
   test_derive
   test_stateful
   test_single_test_case
-  test_antithesis)
- (libraries hegel alcotest core core_unix threads.posix yojson)
+  test_antithesis
+  test_loader)
+ (libraries hegel hegel_ffi alcotest core core_unix threads.posix yojson)
  (preprocess
   (pps ppx_js_style -- -allow-unannotated-ignores))
  (foreign_stubs

--- a/test/test_hegel.ml
+++ b/test/test_hegel.ml
@@ -11,5 +11,6 @@ let () =
     ; "stateful", Test_stateful.tests
     ; "single_test_case", Test_single_test_case.tests
     ; "antithesis", Test_antithesis.tests
+    ; "loader", Test_loader.tests
     ]
 ;;

--- a/test/test_loader.ml
+++ b/test/test_loader.ml
@@ -1,0 +1,210 @@
+(** Tests for the libhegel download protocol ([Hegel_ffi.Loader]).
+
+    The protocol is exercised against a stubbed [curl] (a shell script placed
+    first on [PATH]) that writes a fixed payload in two chunks with a pause
+    between them, widening the window of any race between concurrent
+    downloaders. The tests supply their own expected checksum, so no network
+    access or real libhegel artifact is involved. *)
+
+open! Core
+module Loader = Hegel_ffi.Loader
+
+let payload = "first half of the payload second half of the payload"
+
+(* A [curl] stand-in: honors [-o <dest>] and writes {!payload} to it in two
+   chunks with a pause in between. [FAKE_CURL_EXIT] forces a failure exit
+   code (simulating a network error) without writing anything. *)
+let fake_curl_script =
+  {|#!/bin/sh
+if [ -n "${FAKE_CURL_EXIT:-}" ]; then exit "$FAKE_CURL_EXIT"; fi
+out=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then out=$2; shift 2; else shift 1; fi
+done
+printf 'first half of the payload ' > "$out"
+sleep 0.4
+printf 'second half of the payload' >> "$out"
+|}
+;;
+
+(* Set up a tempdir containing the stubbed [curl] and pass its path, the
+   PATH value that puts the stub first, and the payload's checksum to [f].
+   The checksum is computed with the loader's own [sha256_of_file] so the
+   test agrees with the implementation about hashing. *)
+let with_download_fixture ~f =
+  Test_helpers.with_tempdir ~prefix:"hegel-loader-test-" ~f:(fun dir ->
+    let curl_path = Filename.concat dir "curl" in
+    Out_channel.write_all curl_path ~data:fake_curl_script;
+    Core_unix.chmod curl_path ~perm:0o755;
+    let reference = Filename.concat dir "reference-payload" in
+    Out_channel.write_all reference ~data:payload;
+    let expected = Loader.sha256_of_file reference in
+    let stub_path =
+      dir ^ ":" ^ Option.value (Sys.getenv "PATH") ~default:"/usr/bin:/bin"
+    in
+    f ~dir ~stub_path ~expected)
+;;
+
+(* Run [f] with PATH set to [path], restoring the previous value on exit. *)
+let with_path path ~f =
+  let prev = Sys.getenv "PATH" in
+  Core_unix.putenv ~key:"PATH" ~data:path;
+  Exn.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Core_unix.putenv ~key:"PATH" ~data:v
+      | None -> Test_helpers.unsetenv "PATH")
+    ~f
+;;
+
+let leftover_tmp_files dir =
+  Stdlib.Sys.readdir dir
+  |> Array.to_list
+  |> List.filter ~f:(fun name -> Test_helpers.contains_substring name ".tmp")
+;;
+
+(* Regression test for the cold-cache download race: multiple processes (e.g.
+   several test binaries starting concurrently on a fresh machine) download
+   libhegel at the same time. Every downloader must end up with a verified
+   library, and the cache file must not be corrupted. Before the fix all
+   processes shared a single temporary path ([<cache>.tmp]), so the first
+   process to finish renamed the file the others were still writing out from
+   under them and the losers crashed. *)
+let test_concurrent_downloads_all_succeed () =
+  with_download_fixture ~f:(fun ~dir ~stub_path ~expected ->
+    let cache_path = Filename.concat dir "libhegel.so" in
+    let n = 4 in
+    let children =
+      List.init n ~f:(fun i ->
+        match Core_unix.fork () with
+        | `In_the_parent pid -> pid
+        | `In_the_child ->
+          let status =
+            try
+              Core_unix.putenv ~key:"PATH" ~data:stub_path;
+              (* Stagger the children so their downloads overlap at
+                 different phases rather than starting in lockstep. *)
+              ignore (Core_unix.nanosleep (Float.of_int i *. 0.15));
+              let got =
+                Loader.download_verified
+                  ~url:"http://example.invalid/libhegel.so"
+                  ~expected
+                  ~cache_path
+              in
+              if String.equal (In_channel.read_all got) payload then 0 else 1
+            with
+            | _ -> 1
+          in
+          Core_unix.exit_immediately status)
+    in
+    let failures =
+      List.count children ~f:(fun pid -> Result.is_error (Core_unix.waitpid pid))
+    in
+    Alcotest.(check int) "all concurrent downloaders succeed" 0 failures;
+    Alcotest.(check string)
+      "cache file holds the verified payload"
+      payload
+      (In_channel.read_all cache_path);
+    Alcotest.(check (list string))
+      "no leftover temporary files"
+      []
+      (leftover_tmp_files dir))
+;;
+
+(* A stale temporary file left by a killed downloader (partial download) must
+   not break, or leak into, a later download. *)
+let test_stale_tmp_file_is_harmless () =
+  with_download_fixture ~f:(fun ~dir ~stub_path ~expected ->
+    let cache_path = Filename.concat dir "libhegel.so" in
+    Out_channel.write_all (cache_path ^ ".tmp") ~data:"partial garbage";
+    Out_channel.write_all (cache_path ^ ".12345.abc123.tmp") ~data:"more garbage";
+    let got =
+      with_path stub_path ~f:(fun () ->
+        Loader.download_verified
+          ~url:"http://example.invalid/libhegel.so"
+          ~expected
+          ~cache_path)
+    in
+    Alcotest.(check string) "returns the cache path" cache_path got;
+    Alcotest.(check string)
+      "cache file holds the verified payload"
+      payload
+      (In_channel.read_all cache_path))
+;;
+
+let test_checksum_mismatch_fails_and_cleans_up () =
+  with_download_fixture ~f:(fun ~dir ~stub_path ~expected:_ ->
+    let cache_path = Filename.concat dir "libhegel.so" in
+    let raised =
+      with_path stub_path ~f:(fun () ->
+        try
+          ignore
+            (Loader.download_verified
+               ~url:"http://example.invalid/libhegel.so"
+               ~expected:(String.make 64 '0')
+               ~cache_path);
+          false
+        with
+        | Failure msg -> Test_helpers.contains_substring msg "SHA-256 mismatch")
+    in
+    Alcotest.(check bool) "raises a SHA-256 mismatch failure" true raised;
+    Alcotest.(check bool)
+      "does not install the corrupt file"
+      false
+      (Stdlib.Sys.file_exists cache_path);
+    Alcotest.(check (list string))
+      "no leftover temporary files"
+      []
+      (leftover_tmp_files dir))
+;;
+
+let test_download_failure_fails_and_cleans_up () =
+  with_download_fixture ~f:(fun ~dir ~stub_path ~expected ->
+    let cache_path = Filename.concat dir "libhegel.so" in
+    let prev = Sys.getenv "FAKE_CURL_EXIT" in
+    let raised =
+      Exn.protect
+        ~finally:(fun () ->
+          match prev with
+          | Some v -> Core_unix.putenv ~key:"FAKE_CURL_EXIT" ~data:v
+          | None -> Test_helpers.unsetenv "FAKE_CURL_EXIT")
+        ~f:(fun () ->
+          Core_unix.putenv ~key:"FAKE_CURL_EXIT" ~data:"9";
+          with_path stub_path ~f:(fun () ->
+            try
+              ignore
+                (Loader.download_verified
+                   ~url:"http://example.invalid/libhegel.so"
+                   ~expected
+                   ~cache_path);
+              false
+            with
+            | Failure msg -> Test_helpers.contains_substring msg "curl exit 9"))
+    in
+    Alcotest.(check bool) "raises a download failure" true raised;
+    Alcotest.(check bool)
+      "does not install anything"
+      false
+      (Stdlib.Sys.file_exists cache_path);
+    Alcotest.(check (list string))
+      "no leftover temporary files"
+      []
+      (leftover_tmp_files dir))
+;;
+
+let tests =
+  [ Alcotest.test_case
+      "concurrent cold-cache downloads all succeed"
+      `Quick
+      test_concurrent_downloads_all_succeed
+  ; Alcotest.test_case "stale tmp file is harmless" `Quick test_stale_tmp_file_is_harmless
+  ; Alcotest.test_case
+      "checksum mismatch fails and cleans up"
+      `Quick
+      test_checksum_mismatch_fails_and_cleans_up
+  ; Alcotest.test_case
+      "download failure fails and cleans up"
+      `Quick
+      test_download_failure_fails_and_cleans_up
+  ]
+;;


### PR DESCRIPTION
<details><summary>Implementation details (AI-generated)</summary>

**Bug.** When several test binaries started concurrently with a cold cache, every process in `lib/ffi/loader.ml` downloaded libhegel to the same temporary path (`libhegel.<ext>.tmp`) and renamed it into place. Concurrent `curl` writes corrupted each other's partial downloads, and the first process to finish renamed the shared file out from under the rest, so the losers crashed with SHA-256 mismatch or missing-file errors.

**Fix.** The fetch/verify/rename sequence is extracted into `Loader.download_verified ~url ~expected ~cache_path` (behavior-preserving refactor in the first commit). Each process now downloads to its own temporary file in the cache directory — `<cache>.<pid>.<random>.tmp` — verifies it, and atomically renames it into place. POSIX rename-over-existing means losers simply replace the winner's identical verified copy; if the rename fails (e.g. Windows keeping the winner's in-use file locked), the loser removes its temp file and falls back to the winner's copy after re-verifying its checksum. Stale temp files left by a killed process are inert because nothing ever reads another process's uniquely-named temp file.

**Regression test (written first, TDD).** `test/test_loader.ml` drives `download_verified` through a stubbed `curl` placed first on `PATH`, which writes a fixed payload in two chunks with a 0.4s pause to widen the race window; the expected checksum is computed with the loader's own `sha256_of_file`, so no network or real artifact is involved. The main test forks four staggered processes downloading into one cache path and requires all four to succeed, the final cache file to hold the verified payload, and no leftover `*.tmp` files. Before the fix it failed with 2 of 4 downloaders crashing. Additional tests pin: a stale shared-name or unique-name temp file from a killed process does not break or leak into a later download; checksum-mismatch and curl-failure paths fail cleanly without installing anything or leaving temp files.

**Verification.** Full `just check` passes from a clean build: formatting, zero-warning docs, 100% coverage (615/615), all test binaries including the 4 new loader tests. Includes a `RELEASE.md` (`RELEASE_TYPE: patch`) for the release automation.

**Note (pre-existing, unrelated).** While verifying, `just check-docs` was found to fail (`odoc: no page-index.odoc`) when run against an existing `_build` after any source change since the last doc build; it reproduces on unmodified `origin/main` plus a comment-only edit. CI is unaffected (always cold builds); a `dune clean` works around it locally.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
