### PR TITLE
Generate functions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,6 +88,7 @@ examples/                    # Example programs demonstrating the library
   collections.ml             # Collections and combinators: lists, filter, map
   real_world.ml              # Real-world scenario: sorted-merge property test
   derived_types.ml           # Derived generators via [@@deriving hegel_generator]
+  higher_order.ml            # Function generators: functions/functions2/functions3
 
 scripts/
   check-coverage.py          # Parses bisect-ppx-report, enforces 100%
@@ -137,7 +138,7 @@ Generators are a discriminated union:
 - **Filtered** — wraps source + predicate. Up to `max_filter_attempts` retries before `assume false`.
 - **CompositeList** — lists of any element core. Uses the collection protocol (new_collection / collection_more) to generate elements one at a time.
 - **Composite** — a `generate_fn` thunk run inside a labeled span; used by tuples, one_of, `lists ~unique`, and hashmaps (all of which now always drive the collection protocol / draw sub-values directly — there is no schema fast path).
-- **Function** — a generated function (`functions`/`functions2`/`functions3`). `build ~name` returns a fresh per-test-case memoized function that draws each result from `returns` on first application (keyed by `sexp_of_arg`) and shows applied pairs as `name arg = result` via `note` on the final replay. A distinct core so `draw_silent_named` / `draw_named` can thread the draw-site binding name into the function (see the PPX note below); nested result draws are wrapped in a `Labels.function_result` span.
+- **Function** — a generated function (`functions`/`functions2`/`functions3`). `build ~name` returns a fresh per-test-case memoized function that draws each result from `returns` on first application (memoized on the argument via structural hash/equality — a `Hashtbl.Poly` — so `sexp_of_arg` is display-only and an omitted one shows `<opaque>` without collapsing the key) and shows applied pairs as `name arg = result` via `note` on the final replay. Only *top-level* applications print — a pair applied at draw depth > 0 (inside a span) is suppressed, like a nested draw. A distinct core so `draw_silent_named` / `draw_named` can thread the draw-site binding name into the function (see the PPX note below); the name threads even when the function is drawn nested. Result draws are wrapped in a `Labels.function_result` span.
 
 ### Inline Test Integration (ppx/ppx_hegel_test.ml + lib/test_runtime/)
 
@@ -153,11 +154,13 @@ becomes `draw_silent_named ~name:"x" tc g`. Both target hidden entry points, kee
 `~repeatable`/`~name` off the public `draw`/`draw_silent` (the `draw`→`draw_named`
 precedent). The `~name` is only meaningful for a function generator (`Function` core),
 where it labels the shown `x arg = result` pairs; it is ignored for every other
-generator, attaches at the draw site (so it works through an intermediate
-`let g = functions ..; let f = draw_silent tc g` binding), and overrides the
-generator's own `?name`. A function made printable (via `with_printer`) is drawn with
-`draw`; `draw_named` threads the label the same way and also prints the usual
-`x = value` line (the function renders as `<fun>` through its printer).
+generator, and attaches at the draw site (so it works through an intermediate
+`let g = functions ..; let f = draw_silent tc g` binding). Precedence: an explicit
+`?name` on `functions` always wins, else the draw-site binding name, else `"function"`.
+A function made printable (via `with_printer`) is drawn with
+`draw`; `draw_named` threads the label the same way (even when nested) and prints
+the usual `x = value` line — the function renders as `<fun>` through its printer —
+only at the top level, suppressing it when nested like any other draw.
 
 `ppx_hegel_test`'s dune stanza declares `(inline_tests.backend ...)` with a
 generated runner that calls `Hegel_test_runtime.test_main ()`, and
@@ -394,10 +397,11 @@ draw, and always freed (`Internal.with_string_generator`).
     Reference it from README.md. Translate all Python library examples to idiomatic OCaml, adding
     short notes where the OCaml API differs (no decorator, no `.generate()` method, etc.).
 
-11. **Four example programs covers the full surface area**: `basic_properties.ml` (primitives,
+11. **Five example programs cover the full surface area**: `basic_properties.ml` (primitives,
     assume, note), `collections.ml` (lists, map, flat_map, filter, sampled_from, hashmaps),
-    `real_world.ml` (sorted-merge property test), `derived_types.ml` (PPX deriver). Each has a
-    standalone `main`; derived_types needs a separate dune stanza with PPX preprocessing.
+    `real_world.ml` (sorted-merge property test), `derived_types.ml` (PPX deriver),
+    `higher_order.ml` (function generators). Each has a standalone `main`; derived_types needs
+    a separate dune stanza with PPX preprocessing.
 
 12. **opam not on PATH in shell spawned by `just`**: The `just` tool starts a fresh shell that
     does not source `.bashrc` or `.profile`. Fix: add

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,6 +40,9 @@ lib/                         # Library source
   generators_primitives.ml   # integers, booleans, floats, text, binary, just, formats
   generators_collections.ml  # lists, hashmaps, sets, and the collection protocol
   generators_combinators.ml  # sampled_from, one_of, tuples2/3/4
+  generators_functions.ml    # functions/functions2/functions3: memoized
+                             #   function generators (Claessen's show/shrink,
+                             #   but no trie — the engine shrinks results)
   derive.ml                  # Runtime support for [@@deriving hegel_generator]
   stateful.ml                # Stateful testing: Rule.create + run over action sequences
   antithesis.ml              # Antithesis integration (emits an always-typed assertion)
@@ -134,6 +137,7 @@ Generators are a discriminated union:
 - **Filtered** — wraps source + predicate. Up to `max_filter_attempts` retries before `assume false`.
 - **CompositeList** — lists of any element core. Uses the collection protocol (new_collection / collection_more) to generate elements one at a time.
 - **Composite** — a `generate_fn` thunk run inside a labeled span; used by tuples, one_of, `lists ~unique`, and hashmaps (all of which now always drive the collection protocol / draw sub-values directly — there is no schema fast path).
+- **Function** — a generated function (`functions`/`functions2`/`functions3`). `build ~name` returns a fresh per-test-case memoized function that draws each result from `returns` on first application (keyed by `sexp_of_arg`) and shows applied pairs as `name arg = result` via `note` on the final replay. A distinct core so `draw_silent_named` / `draw_named` can thread the draw-site binding name into the function (see the PPX note below); nested result draws are wrapped in a `Labels.function_result` span.
 
 ### Inline Test Integration (ppx/ppx_hegel_test.ml + lib/test_runtime/)
 
@@ -142,6 +146,18 @@ top-level items: (1) `let name = fun () -> Hegel.run_hegel_test ...
 (fun tc -> body)`, and (2) `let () = Hegel_test_runtime.register ~name ~file
 ~line name`. The function remains directly callable; the registration is a
 side effect run at module init.
+
+Within the body the PPX also injects binding names into draws: `let x = draw tc g`
+becomes `draw_named ~label:"x" ~repeatable:.. tc g`, and `let x = draw_silent tc g`
+becomes `draw_silent_named ~name:"x" tc g`. Both target hidden entry points, keeping
+`~repeatable`/`~name` off the public `draw`/`draw_silent` (the `draw`→`draw_named`
+precedent). The `~name` is only meaningful for a function generator (`Function` core),
+where it labels the shown `x arg = result` pairs; it is ignored for every other
+generator, attaches at the draw site (so it works through an intermediate
+`let g = functions ..; let f = draw_silent tc g` binding), and overrides the
+generator's own `?name`. A function made printable (via `with_printer`) is drawn with
+`draw`; `draw_named` threads the label the same way and also prints the usual
+`x = value` line (the function renders as `<fun>` through its printer).
 
 `ppx_hegel_test`'s dune stanza declares `(inline_tests.backend ...)` with a
 generated runner that calls `Hegel_test_runtime.test_main ()`, and

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+This patch adds generators for functions `functions`, `functions2`, and `functions3` 
+in `Hegel.Generators`. A generated function draws each result lazily
+from a `returns` generator, memoized per argument.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,24 @@
 RELEASE_TYPE: patch
 
-This patch adds generators for functions `functions`, `functions2`, and `functions3` 
-in `Hegel.Generators`. A generated function draws each result lazily
-from a `returns` generator, memoized per argument.
+This patch adds `functions`, `functions2`, and `functions3` in `Hegel.Generators` for 
+generating functions. `functions2` and `functions3` generate curried two and three 
+argument functions. Function generators are unprintable.
+
+When a property over a generated function fails, Hegel prints the function application(s)
+and its result(s). For example, a property that wrongly assumes applying a function twice 
+returns the original value:
+
+```ocaml
+let%hegel_test involution tc =
+  let f = draw_silent tc (functions ~sexp_of_arg:Int.sexp_of_t ~returns:(integers ()) ()) in
+  let x = draw tc (integers ()) in
+  assert (f (f x) = x)
+```
+
+fails with a concrete counterexample:
+
+```
+x = 0
+f 0 = 1
+f 1 = 1
+```

--- a/examples/dune
+++ b/examples/dune
@@ -1,6 +1,6 @@
 (executables
- (names basic_properties collections real_world)
- (modules basic_properties collections real_world)
+ (names basic_properties collections real_world higher_order)
+ (modules basic_properties collections real_world higher_order)
  (libraries hegel core)
  (preprocess
   (pps ppx_js_style ppx_hegel_test -- -allow-unannotated-ignores)))

--- a/examples/higher_order.ml
+++ b/examples/higher_order.ml
@@ -1,0 +1,93 @@
+(** Higher-order examples: generating functions as test inputs.
+
+    Demonstrates: functions, functions2, functions3. A generated function draws
+    each result lazily from its [returns] generator, memoized per argument, so it
+    behaves as a genuine function within a test case. On a failing replay it
+    prints only the argument/result pairs the property actually applied (e.g.
+    [f 3 = 7]) rather than an opaque [<function>]. *)
+
+open Hegel.Generators
+
+let small_int = integers ~min_value:(-100) ~max_value:100 ()
+
+(** Property (map fusion): mapping [f] then [g] over a list equals mapping their
+    composition. Both [f] and [g] are generated [int -> int] functions, drawn
+    with [draw_silent] (a function carries no printer). *)
+let%hegel_test map_fusion tc =
+  let int_fn () =
+    Hegel.draw_silent tc (functions ~sexp_of_arg:Core.Int.sexp_of_t ~returns:small_int ())
+  in
+  let f = int_fn () in
+  let g = int_fn () in
+  let xs = Hegel.draw tc (lists small_int ~max_size:10 ()) in
+  assert (List.map g (List.map f xs) = List.map (fun x -> g (f x)) xs)
+[@@settings Hegel.settings ~test_cases:100 ()]
+;;
+
+(** Property (filter keeps matches): every element [List.filter p] keeps does
+    satisfy the generated predicate [p], an [int -> bool] function. *)
+let%hegel_test filter_keeps_matching tc =
+  let p =
+    Hegel.draw_silent
+      tc
+      (functions ~sexp_of_arg:Core.Int.sexp_of_t ~returns:(booleans ()) ())
+  in
+  let xs =
+    Hegel.draw tc (lists (integers ~min_value:0 ~max_value:20 ()) ~max_size:10 ())
+  in
+  List.iter (fun x -> assert (p x)) (List.filter p xs)
+[@@settings Hegel.settings ~test_cases:100 ()]
+;;
+
+(** Property (flip is involutive): flipping a generated two-argument function
+    twice recovers the original. Uses [functions2]. *)
+let%hegel_test flip_flip_is_identity tc =
+  let f =
+    Hegel.draw_silent
+      tc
+      (functions2
+         ~sexp_of_arg1:Core.Int.sexp_of_t
+         ~sexp_of_arg2:Core.Int.sexp_of_t
+         ~returns:small_int
+         ())
+  in
+  let a = Hegel.draw tc small_int in
+  let b = Hegel.draw tc small_int in
+  let flip g x y = g y x in
+  assert (flip (flip f) a b = f a b)
+[@@settings Hegel.settings ~test_cases:100 ()]
+;;
+
+(** Property (a generated function is a genuine function): a generated
+    three-argument function returns the same result for the same arguments. Uses
+    [functions3]. *)
+let%hegel_test functions_are_deterministic tc =
+  let f =
+    Hegel.draw_silent
+      tc
+      (functions3
+         ~sexp_of_arg1:Core.Int.sexp_of_t
+         ~sexp_of_arg2:Core.Bool.sexp_of_t
+         ~sexp_of_arg3:Core.Int.sexp_of_t
+         ~returns:small_int
+         ())
+  in
+  let a = Hegel.draw tc small_int in
+  let b = Hegel.draw tc (booleans ()) in
+  let c = Hegel.draw tc small_int in
+  assert (f a b c = f a b c)
+[@@settings Hegel.settings ~test_cases:100 ()]
+;;
+
+let () =
+  Printf.printf "Running higher-order (function generator) examples...\n%!";
+  map_fusion ();
+  Printf.printf "  map_fusion: OK\n%!";
+  filter_keeps_matching ();
+  Printf.printf "  filter_keeps_matching: OK\n%!";
+  flip_flip_is_identity ();
+  Printf.printf "  flip_flip_is_identity: OK\n%!";
+  functions_are_deterministic ();
+  Printf.printf "  functions_are_deterministic: OK\n%!";
+  Printf.printf "All tests passed.\n%!"
+;;

--- a/lib/dune
+++ b/lib/dune
@@ -6,7 +6,8 @@
   generators_core
   generators_primitives
   generators_collections
-  generators_combinators)
+  generators_combinators
+  generators_functions)
  (preprocess
   (pps ppx_js_style))
  (instrumentation

--- a/lib/generators.ml
+++ b/lib/generators.ml
@@ -2,3 +2,4 @@ include Generators_core
 include Generators_primitives
 include Generators_collections
 include Generators_combinators
+include Generators_functions

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -536,7 +536,7 @@ val tuples4
 
 (** {2 Function generators} *)
 
-(** [functions ?name ~sexp_of_arg ~returns ()] creates a generator for functions
+(** [functions ?name ?sexp_of_arg ~returns ()] creates a generator for functions
     ['a -> 'b] whose results are drawn from [returns].
 
     The result carries no printer (its output type is a function), so draw it
@@ -555,7 +555,7 @@ val tuples4
 
     {[
       let%hegel_test map_length_preserved tc =
-        let f_gen = functions ~sexp_of_arg:Int.sexp_of_t ~returns:(integers ()) () in
+        let f_gen = functions ~sexp_of_arg:Core.Int.sexp_of_t ~returns:(integers ()) () in
         let f = draw_silent tc f_gen in
         let xs = draw tc (lists (integers ()) ()) in
         assert (List.length (List.map ~f xs) = List.length xs)
@@ -568,7 +568,7 @@ val functions
   -> unit
   -> ('a -> 'b, unprintable) generator
 
-(** [functions2 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~returns ()] creates a
+(** [functions2 ?name ?sexp_of_arg1 ?sexp_of_arg2 ~returns ()] creates a
     generator for curried two-argument functions ['a -> 'b -> 'c].
 
     Sugar over {!functions} keyed on the argument pair: the two arguments form
@@ -582,7 +582,7 @@ val functions2
   -> unit
   -> ('a -> 'b -> 'c, unprintable) generator
 
-(** [functions3 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~sexp_of_arg3 ~returns ()]
+(** [functions3 ?name ?sexp_of_arg1 ?sexp_of_arg2 ?sexp_of_arg3 ~returns ()]
     creates a generator for curried three-argument functions
     ['a -> 'b -> 'c -> 'd].
 

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -175,6 +175,11 @@ val draw_named
     ]} *)
 val draw_silent : Internal.test_case -> ('a, 'p) generator -> 'a
 
+(** [draw_silent_named ~name tc gen] is {!draw_silent} threading the draw-site
+    [name] into a function generator ({!Generators.functions}). Not intended for 
+    direct use (prefer {!draw_silent}). *)
+val draw_silent_named : name:string -> Internal.test_case -> ('a, 'p) generator -> 'a
+
 (** [with_printer sexp_of gen] attaches (or replaces) [gen]'s printer, yielding
     a printable generator that {!draw} accepts. This is how a [map]/[flat_map]/
     [sampled_from]/[just] result is made drawable with {!draw}.
@@ -528,6 +533,65 @@ val tuples4
   -> ('c, printable) generator
   -> ('d, printable) generator
   -> ('a * 'b * 'c * 'd, printable) generator
+
+(** {2 Function generators} *)
+
+(** [functions ?name ~sexp_of_arg ~returns ()] creates a generator for functions
+    ['a -> 'b] whose results are drawn from [returns].
+
+    The result carries no printer (its output type is a function), so draw it
+    with {!Hegel.draw_silent}. Applying the drawn function to an argument draws a
+    result from [returns] the first time that argument is seen and memoizes it.
+
+    On the failing final replay each function application prints as [name arg = result].
+    [name] defaults to ["function"] and is overridden by the draw-site name (the
+    binding name inside a [let%hegel_test]). Pass [?name] to set a fallback when
+    drawing without the PPX. [sexp_of_arg] both keys the memo table and renders
+    arguments; [returns] must be printable so results can be shown.
+
+    {[
+      let%hegel_test map_length_preserved tc =
+        let f_gen = functions ~sexp_of_arg:Int.sexp_of_t ~returns:(integers ()) () in
+        let f = draw_silent tc f_gen in
+        let xs = draw tc (lists (integers ()) ()) in
+        assert (List.length (List.map ~f xs) = List.length xs)
+      ;;
+    ]} *)
+val functions
+  :  ?name:string
+  -> sexp_of_arg:('a -> Core.Sexp.t)
+  -> returns:('b, printable) generator
+  -> unit
+  -> ('a -> 'b, unprintable) generator
+
+(** [functions2 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~returns ()] creates a
+    generator for curried two-argument functions ['a -> 'b -> 'c].
+
+    Sugar over {!functions} keyed on the argument pair: the two arguments form
+    one memo key and are shown uncurried as [name (arg1 arg2) = result]. Draw it
+    with {!draw_silent}. *)
+val functions2
+  :  ?name:string
+  -> sexp_of_arg1:('a -> Core.Sexp.t)
+  -> sexp_of_arg2:('b -> Core.Sexp.t)
+  -> returns:('c, printable) generator
+  -> unit
+  -> ('a -> 'b -> 'c, unprintable) generator
+
+(** [functions3 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~sexp_of_arg3 ~returns ()]
+    creates a generator for curried three-argument functions
+    ['a -> 'b -> 'c -> 'd].
+
+    Like {!functions2}, keyed on the argument triple and shown uncurried as
+    [name (arg1 arg2 arg3) = result]. Draw it with {!draw_silent}. *)
+val functions3
+  :  ?name:string
+  -> sexp_of_arg1:('a -> Core.Sexp.t)
+  -> sexp_of_arg2:('b -> Core.Sexp.t)
+  -> sexp_of_arg3:('c -> Core.Sexp.t)
+  -> returns:('d, printable) generator
+  -> unit
+  -> ('a -> 'b -> 'c -> 'd, unprintable) generator
 
 (** {2 Format generators} *)
 

--- a/lib/generators.mli
+++ b/lib/generators.mli
@@ -543,11 +543,15 @@ val tuples4
     with {!Hegel.draw_silent}. Applying the drawn function to an argument draws a
     result from [returns] the first time that argument is seen and memoizes it.
 
-    On the failing final replay each function application prints as [name arg = result].
-    [name] defaults to ["function"] and is overridden by the draw-site name (the
-    binding name inside a [let%hegel_test]). Pass [?name] to set a fallback when
-    drawing without the PPX. [sexp_of_arg] both keys the memo table and renders
-    arguments; [returns] must be printable so results can be shown.
+    On the failing final replay each top-level application prints as
+    [name arg = result] (applications nested inside a span are suppressed).
+    [name] is [?name] when you pass it — an explicit label always wins — else the
+    draw-site binding name inside a [let%hegel_test], else ["function"].
+
+    The memo table keys on the argument itself (structural hash/equality), so
+    distinct arguments always get independent results. [sexp_of_arg] only renders
+    the argument in the shown pair. An omitted [sexp_of_arg] or a non-printable
+    [returns] shows [<opaque>].
 
     {[
       let%hegel_test map_length_preserved tc =
@@ -559,8 +563,8 @@ val tuples4
     ]} *)
 val functions
   :  ?name:string
-  -> sexp_of_arg:('a -> Core.Sexp.t)
-  -> returns:('b, printable) generator
+  -> ?sexp_of_arg:('a -> Core.Sexp.t)
+  -> returns:('b, _) generator
   -> unit
   -> ('a -> 'b, unprintable) generator
 
@@ -572,9 +576,9 @@ val functions
     with {!draw_silent}. *)
 val functions2
   :  ?name:string
-  -> sexp_of_arg1:('a -> Core.Sexp.t)
-  -> sexp_of_arg2:('b -> Core.Sexp.t)
-  -> returns:('c, printable) generator
+  -> ?sexp_of_arg1:('a -> Core.Sexp.t)
+  -> ?sexp_of_arg2:('b -> Core.Sexp.t)
+  -> returns:('c, _) generator
   -> unit
   -> ('a -> 'b -> 'c, unprintable) generator
 
@@ -586,10 +590,10 @@ val functions2
     [name (arg1 arg2 arg3) = result]. Draw it with {!draw_silent}. *)
 val functions3
   :  ?name:string
-  -> sexp_of_arg1:('a -> Core.Sexp.t)
-  -> sexp_of_arg2:('b -> Core.Sexp.t)
-  -> sexp_of_arg3:('c -> Core.Sexp.t)
-  -> returns:('d, printable) generator
+  -> ?sexp_of_arg1:('a -> Core.Sexp.t)
+  -> ?sexp_of_arg2:('b -> Core.Sexp.t)
+  -> ?sexp_of_arg3:('c -> Core.Sexp.t)
+  -> returns:('d, _) generator
   -> unit
   -> ('a -> 'b -> 'c -> 'd, unprintable) generator
 

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -329,9 +329,9 @@ let rec do_draw : type a. a core -> Internal.test_case -> a =
     Draws nested inside a span (e.g. composite elements) are suppressed so only
     the outermost value shows.
 
-    A function generator ({!Generators.functions}) still prints the usual 
-    [name = value] line. The function renders through its printer, typically 
-    [<fun>], and threads [label] into the function's own per-application print *)
+    A function generator ({!Generators.functions}) made printable always threads
+    [label] into the function's own per-application showing, so its
+    [name arg = result] pairs are labeled. *)
 let draw_named
   : type a.
     label:string -> repeatable:bool -> Internal.test_case -> (a, printable) generator -> a
@@ -339,13 +339,11 @@ let draw_named
   fun ~label ~repeatable tc gen ->
   match gen with
   | Printable { core = Function { build }; sexp_of } ->
+    let name = Internal.draw_display_name tc ~label ~repeatable in
+    let value = build ~name:(Some name) tc in
     if Internal.draw_depth tc = 0
-    then (
-      let name = Internal.draw_display_name tc ~label ~repeatable in
-      let value = build ~name:(Some name) tc in
-      Internal.note tc (sprintf "%s = %s" name (Sexp.to_string_hum (sexp_of value)));
-      value)
-    else build ~name:None tc
+    then Internal.note tc (sprintf "%s = %s" name (Sexp.to_string_hum (sexp_of value)));
+    value
   | Printable { core; sexp_of } ->
     let value = do_draw core tc in
     if Internal.draw_depth tc = 0

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -27,6 +27,7 @@ module Labels = struct
      label past the engine's range. *)
   let _feature_flag = 16
   let stateful_rule = 17
+  let function_result = 18
 end
 
 (** The pure generation structure of a generator, carrying no printer. A
@@ -78,6 +79,7 @@ type 'a core =
       ; consume : bool
       }
       -> 'a core
+  | Function : { build : name:string option -> Internal.test_case -> 'a } -> 'a core
 
 (** Phantom witness that a generator carries a printer and so may be drawn with
     {!draw}. Defined as a private polymorphic variant (not left abstract) so
@@ -314,6 +316,7 @@ let rec do_draw : type a. a core -> Internal.test_case -> a =
       collect [])
   | Composite { label; generate_fn } -> group label data (fun () -> generate_fn data)
   | Values { pool_id; values; consume } -> pick data values pool_id ~consume
+  | Function { build } -> build ~name:None data
 ;;
 
 (** [draw_named ~label ~repeatable tc gen] is the naming-aware draw the
@@ -324,13 +327,25 @@ let rec do_draw : type a. a core -> Internal.test_case -> a =
     its sole use and numbered ([label_1], [label_2], …) when [repeatable] is set
     — which the PPX does for a binding name that is reused or drawn in a loop.
     Draws nested inside a span (e.g. composite elements) are suppressed so only
-    the outermost value shows. *)
+    the outermost value shows.
+
+    A function generator ({!Generators.functions}) still prints the usual 
+    [name = value] line. The function renders through its printer, typically 
+    [<fun>], and threads [label] into the function's own per-application print *)
 let draw_named
   : type a.
     label:string -> repeatable:bool -> Internal.test_case -> (a, printable) generator -> a
   =
   fun ~label ~repeatable tc gen ->
   match gen with
+  | Printable { core = Function { build }; sexp_of } ->
+    if Internal.draw_depth tc = 0
+    then (
+      let name = Internal.draw_display_name tc ~label ~repeatable in
+      let value = build ~name:(Some name) tc in
+      Internal.note tc (sprintf "%s = %s" name (Sexp.to_string_hum (sexp_of value)));
+      value)
+    else build ~name:None tc
   | Printable { core; sexp_of } ->
     let value = do_draw core tc in
     if Internal.draw_depth tc = 0
@@ -366,6 +381,18 @@ let draw ?label tc gen =
     carry no printer. *)
 let draw_silent : type a p. Internal.test_case -> (a, p) generator -> a =
   fun tc gen -> do_draw (core_of gen) tc
+;;
+
+(** [draw_silent_named ~name tc gen] is {!draw_silent} threading the draw-site
+    [name] into a function generator ({!Generators.functions}). Not intended for 
+    direct use (prefer {!draw_silent}). *)
+let draw_silent_named
+  : type a p. name:string -> Internal.test_case -> (a, p) generator -> a
+  =
+  fun ~name tc gen ->
+  match core_of gen with
+  | Function { build } -> build ~name:(Some name) tc
+  | core -> do_draw core tc
 ;;
 
 (** [map f gen] transforms values from [gen] using [f]. The result carries no

--- a/lib/generators_core.ml
+++ b/lib/generators_core.ml
@@ -327,11 +327,7 @@ let rec do_draw : type a. a core -> Internal.test_case -> a =
     its sole use and numbered ([label_1], [label_2], …) when [repeatable] is set
     — which the PPX does for a binding name that is reused or drawn in a loop.
     Draws nested inside a span (e.g. composite elements) are suppressed so only
-    the outermost value shows.
-
-    A function generator ({!Generators.functions}) made printable always threads
-    [label] into the function's own per-application showing, so its
-    [name arg = result] pairs are labeled. *)
+    the outermost value shows. *)
 let draw_named
   : type a.
     label:string -> repeatable:bool -> Internal.test_case -> (a, printable) generator -> a

--- a/lib/generators_functions.ml
+++ b/lib/generators_functions.ml
@@ -6,44 +6,72 @@
     stores, so repeated applications to the same argument return the same
     value. 
 
-    On the failing final replay each application of the generated function is 
-    printed through {!Hegel.note} as [name arg = result] (see {!functions}). 
-    [name] is the supplied to the generator, the draw site under in by 
-    [let%hegel_test], or [function] by default *)
+    On the failing final replay each top-level application of the generated
+    function is printed through {!Hegel.note} as [name arg = result] (see
+    {!functions}). Applications nested inside a span (draw depth > 0) are
+    suppressed, like any nested draw. [name] is the [?name] passed to the
+    generator, else the draw-site binding name (via [let%hegel_test]), else
+    ["function"]. *)
 
 open! Core
 open Generators_core
 
-(* [make ~default_name ~sexp_of_arg ~returns ~adapt] builds the shared function
-   core behind {!functions}/{!functions2}/{!functions3}. [adapt] is the identity function,
-   or currying for the multi-argument variants. [sexp_of_arg] both keys the memo
-   table and renders the argument when a pair is shown. [name] is the draw-site 
-   label, falling back to [default_name]. *)
-let make ~default_name ~sexp_of_arg ~returns ~adapt =
+(* [make ~explicit_name ~sexp_of_arg ~returns ~adapt] builds the shared function
+   core behind {!functions}/{!functions2}/{!functions3}. [adapt] is the identity
+   function, or currying for the multi-argument variants. [sexp_of_arg] renders
+   the argument when a pair is shown. The memo table keys on the argument itself
+   via structural hash/equality (a [Hashtbl.Poly]). The shown
+   label is [explicit_name] when the caller passed [~name], else
+   the draw-site [name] (the binding, via the PPX), else ["function"]. *)
+let make
+  : type a b c p.
+    string option
+    -> (a -> Core.Sexp.t)
+    -> (b, p) generator
+    -> ((a -> b) -> c)
+    -> (c, unprintable) generator
+  =
+  fun explicit_name sexp_of_arg returns adapt ->
+  let show_ret =
+    match returns with
+    | Printable { sexp_of; _ } -> sexp_of
+    | _ -> fun _ -> Sexp.Atom "<opaque>"
+  in
   let ret = core_of returns in
-  let show_ret = printer returns in
   let build ~name tc =
-    let display = Option.value name ~default:default_name in
-    let table = Hashtbl.create (module String) in
+    let display =
+      match explicit_name with
+      | Some n -> n
+      | None -> Option.value name ~default:"function"
+    in
+    let table = Hashtbl.Poly.create () in
     let base arg =
-      let key = Sexp.to_string (sexp_of_arg arg) in
-      match Hashtbl.find table key with
-      | Some v -> v
-      | None ->
-        let v = group Labels.function_result tc (fun () -> do_draw ret tc) in
-        Hashtbl.set table ~key ~data:v;
+      let ret =
+        match Hashtbl.find table arg with
+        | Some v -> v
+        | None ->
+          let v = group Labels.function_result tc (fun () -> do_draw ret tc) in
+          Hashtbl.set table ~key:arg ~data:v;
+          v
+      in
+      if Internal.draw_depth tc = 0
+      then
         Internal.note
           tc
           (sprintf
              "%s %s = %s"
              display
              (Sexp.to_string_hum (sexp_of_arg arg))
-             (Sexp.to_string_hum (show_ret v)));
-        v
+             (Sexp.to_string_hum (show_ret ret)));
+      ret
     in
     adapt base
   in
   Unprintable { core = Function { build } }
+;;
+
+let sexp_or sexp_of_arg =
+  Option.value sexp_of_arg ~default:(fun _ -> Sexp.Atom "<opaque>")
 ;;
 
 (** [functions ?name ~sexp_of_arg ~returns ()] creates a generator for functions
@@ -53,13 +81,15 @@ let make ~default_name ~sexp_of_arg ~returns ~adapt =
     with {!Hegel.draw_silent}. Applying the drawn function to an argument draws a
     result from [returns] the first time that argument is seen and memoizes it.
 
-    On the failing final replay each function application prints as [name arg = result].
-    [name] defaults to ["function"] and is overridden by the draw-site name (the
-    binding name inside a [let%hegel_test]). Pass [?name] to set a fallback when
-    drawing without the PPX. [sexp_of_arg] both keys the memo table and renders
-    arguments; [returns] must be printable so results can be shown. *)
-let functions ?(name = "function") ~sexp_of_arg ~returns () =
-  make ~default_name:name ~sexp_of_arg ~returns ~adapt:(fun f -> f)
+    On the failing final replay each top-level application prints as
+    [name arg = result] (applications nested inside a span are suppressed).
+    [name] is [?name] when you pass it — an explicit label always wins — else the
+    draw-site binding name inside a [let%hegel_test], else ["function"].
+
+    [sexp_of_arg] only renders the argument in the shown pair. An omitted 
+    [sexp_of_arg] or an unprintable [returns], shows [<opaque>]. *)
+let functions ?name ?sexp_of_arg ~returns () =
+  make name (sexp_or sexp_of_arg) returns (fun f -> f)
 ;;
 
 (** [functions2 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~returns ()] creates a
@@ -68,20 +98,23 @@ let functions ?(name = "function") ~sexp_of_arg ~returns () =
     Sugar over {!functions} keyed on the argument pair: the two arguments form
     one memo key and are shown uncurried as [name (arg1 arg2) = result] (more
     compact than a curried table). Draw it with {!Hegel.draw_silent}. *)
-let functions2 ?(name = "function") ~sexp_of_arg1 ~sexp_of_arg2 ~returns () =
-  let sexp_of_arg (a, b) = Sexp.List [ sexp_of_arg1 a; sexp_of_arg2 b ] in
-  make ~default_name:name ~sexp_of_arg ~returns ~adapt:(fun f a b -> f (a, b))
+let functions2 ?name ?sexp_of_arg1 ?sexp_of_arg2 ~returns () =
+  let sexp_of_arg (a, b) =
+    Sexp.List [ (sexp_or sexp_of_arg1) a; (sexp_or sexp_of_arg2) b ]
+  in
+  make name sexp_of_arg returns (fun f a b -> f (a, b))
 ;;
 
-(** [functions3 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~sexp_of_arg3 ~returns ()]
+(** [functions3 ?name ?sexp_of_arg1 ?sexp_of_arg2 ?sexp_of_arg3 ~returns ()]
     creates a generator for curried three-argument functions
     ['a -> 'b -> 'c -> 'd].
 
     Like {!functions2}, keyed on the argument triple and shown uncurried as
     [name (arg1 arg2 arg3) = result]. Draw it with {!Hegel.draw_silent}. *)
-let functions3 ?(name = "function") ~sexp_of_arg1 ~sexp_of_arg2 ~sexp_of_arg3 ~returns () =
+let functions3 ?name ?sexp_of_arg1 ?sexp_of_arg2 ?sexp_of_arg3 ~returns () =
   let sexp_of_arg (a, b, c) =
-    Sexp.List [ sexp_of_arg1 a; sexp_of_arg2 b; sexp_of_arg3 c ]
+    Sexp.List
+      [ (sexp_or sexp_of_arg1) a; (sexp_or sexp_of_arg2) b; (sexp_or sexp_of_arg3) c ]
   in
-  make ~default_name:name ~sexp_of_arg ~returns ~adapt:(fun f a b c -> f (a, b, c))
+  make name sexp_of_arg returns (fun f a b c -> f (a, b, c))
 ;;

--- a/lib/generators_functions.ml
+++ b/lib/generators_functions.ml
@@ -3,8 +3,8 @@
 
     A drawn function is backed by a per-test-case memo table. The first time it
     is applied to a given argument it draws a fresh result from [returns] and
-    stores, so repeated applications to the same argument return the same
-    value. 
+    stores it, so repeated applications to the same argument return the same
+    value.
 
     On the failing final replay each top-level application of the generated
     function is printed through {!Hegel.note} as [name arg = result] (see
@@ -74,7 +74,7 @@ let sexp_or sexp_of_arg =
   Option.value sexp_of_arg ~default:(fun _ -> Sexp.Atom "<opaque>")
 ;;
 
-(** [functions ?name ~sexp_of_arg ~returns ()] creates a generator for functions
+(** [functions ?name ?sexp_of_arg ~returns ()] creates a generator for functions
     ['a -> 'b] whose results are drawn from [returns].
 
     The result carries no printer (its output type is a function), so draw it
@@ -86,13 +86,14 @@ let sexp_or sexp_of_arg =
     [name] is [?name] when you pass it — an explicit label always wins — else the
     draw-site binding name inside a [let%hegel_test], else ["function"].
 
-    [sexp_of_arg] only renders the argument in the shown pair. An omitted 
-    [sexp_of_arg] or an unprintable [returns], shows [<opaque>]. *)
+    The memo table keys on the argument itself, so distinct arguments always get
+    independent results. [sexp_of_arg] only renders the argument in the shown
+    pair; an omitted [sexp_of_arg] or an unprintable [returns] shows [<opaque>]. *)
 let functions ?name ?sexp_of_arg ~returns () =
   make name (sexp_or sexp_of_arg) returns (fun f -> f)
 ;;
 
-(** [functions2 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~returns ()] creates a
+(** [functions2 ?name ?sexp_of_arg1 ?sexp_of_arg2 ~returns ()] creates a
     generator for curried two-argument functions ['a -> 'b -> 'c].
 
     Sugar over {!functions} keyed on the argument pair: the two arguments form

--- a/lib/generators_functions.ml
+++ b/lib/generators_functions.ml
@@ -1,0 +1,87 @@
+(** Generators for functions as test inputs, after Koen Claessen's {i Shrinking 
+    and Showing Functions}.
+
+    A drawn function is backed by a per-test-case memo table. The first time it
+    is applied to a given argument it draws a fresh result from [returns] and
+    stores, so repeated applications to the same argument return the same
+    value. 
+
+    On the failing final replay each application of the generated function is 
+    printed through {!Hegel.note} as [name arg = result] (see {!functions}). 
+    [name] is the supplied to the generator, the draw site under in by 
+    [let%hegel_test], or [function] by default *)
+
+open! Core
+open Generators_core
+
+(* [make ~default_name ~sexp_of_arg ~returns ~adapt] builds the shared function
+   core behind {!functions}/{!functions2}/{!functions3}. [adapt] is the identity function,
+   or currying for the multi-argument variants. [sexp_of_arg] both keys the memo
+   table and renders the argument when a pair is shown. [name] is the draw-site 
+   label, falling back to [default_name]. *)
+let make ~default_name ~sexp_of_arg ~returns ~adapt =
+  let ret = core_of returns in
+  let show_ret = printer returns in
+  let build ~name tc =
+    let display = Option.value name ~default:default_name in
+    let table = Hashtbl.create (module String) in
+    let base arg =
+      let key = Sexp.to_string (sexp_of_arg arg) in
+      match Hashtbl.find table key with
+      | Some v -> v
+      | None ->
+        let v = group Labels.function_result tc (fun () -> do_draw ret tc) in
+        Hashtbl.set table ~key ~data:v;
+        Internal.note
+          tc
+          (sprintf
+             "%s %s = %s"
+             display
+             (Sexp.to_string_hum (sexp_of_arg arg))
+             (Sexp.to_string_hum (show_ret v)));
+        v
+    in
+    adapt base
+  in
+  Unprintable { core = Function { build } }
+;;
+
+(** [functions ?name ~sexp_of_arg ~returns ()] creates a generator for functions
+    ['a -> 'b] whose results are drawn from [returns].
+
+    The result carries no printer (its output type is a function), so draw it
+    with {!Hegel.draw_silent}. Applying the drawn function to an argument draws a
+    result from [returns] the first time that argument is seen and memoizes it.
+
+    On the failing final replay each function application prints as [name arg = result].
+    [name] defaults to ["function"] and is overridden by the draw-site name (the
+    binding name inside a [let%hegel_test]). Pass [?name] to set a fallback when
+    drawing without the PPX. [sexp_of_arg] both keys the memo table and renders
+    arguments; [returns] must be printable so results can be shown. *)
+let functions ?(name = "function") ~sexp_of_arg ~returns () =
+  make ~default_name:name ~sexp_of_arg ~returns ~adapt:(fun f -> f)
+;;
+
+(** [functions2 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~returns ()] creates a
+    generator for curried two-argument functions ['a -> 'b -> 'c].
+
+    Sugar over {!functions} keyed on the argument pair: the two arguments form
+    one memo key and are shown uncurried as [name (arg1 arg2) = result] (more
+    compact than a curried table). Draw it with {!Hegel.draw_silent}. *)
+let functions2 ?(name = "function") ~sexp_of_arg1 ~sexp_of_arg2 ~returns () =
+  let sexp_of_arg (a, b) = Sexp.List [ sexp_of_arg1 a; sexp_of_arg2 b ] in
+  make ~default_name:name ~sexp_of_arg ~returns ~adapt:(fun f a b -> f (a, b))
+;;
+
+(** [functions3 ?name ~sexp_of_arg1 ~sexp_of_arg2 ~sexp_of_arg3 ~returns ()]
+    creates a generator for curried three-argument functions
+    ['a -> 'b -> 'c -> 'd].
+
+    Like {!functions2}, keyed on the argument triple and shown uncurried as
+    [name (arg1 arg2 arg3) = result]. Draw it with {!Hegel.draw_silent}. *)
+let functions3 ?(name = "function") ~sexp_of_arg1 ~sexp_of_arg2 ~sexp_of_arg3 ~returns () =
+  let sexp_of_arg (a, b, c) =
+    Sexp.List [ sexp_of_arg1 a; sexp_of_arg2 b; sexp_of_arg3 c ]
+  in
+  make ~default_name:name ~sexp_of_arg ~returns ~adapt:(fun f a b c -> f (a, b, c))
+;;

--- a/lib/hegel.ml
+++ b/lib/hegel.ml
@@ -110,6 +110,11 @@ let draw_named = Generators.draw_named
     replay, and accepts a generator with no printer. *)
 let draw_silent = Generators.draw_silent
 
+(** [draw_silent_named ~name tc gen] is the naming-aware {!draw_silent} the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw_silent}). See {!Generators.draw_silent_named}. *)
+let draw_silent_named = Generators.draw_silent_named
+
 (** [with_printer sexp_of gen] attaches [sexp_of] so [gen] can be drawn with
     {!draw}. See {!Generators.with_printer}. *)
 let with_printer = Generators.with_printer

--- a/lib/hegel.mli
+++ b/lib/hegel.mli
@@ -484,6 +484,15 @@ val draw_named
     ]} *)
 val draw_silent : test_case -> ('a, 'p) Generators.generator -> 'a
 
+(**/**)
+
+(** [draw_silent_named ~name tc gen] is the naming-aware {!draw_silent} the
+    [let%hegel_test] PPX rewrites bindings to; not intended for direct use
+    (prefer {!draw_silent}). See {!Generators.draw_silent_named}. *)
+val draw_silent_named : name:string -> test_case -> ('a, 'p) Generators.generator -> 'a
+
+(**/**)
+
 (** {3 Guiding generation} *)
 
 (** Raised by {!assume} when its condition is [false] (rejecting the current test

--- a/ppx/ppx_hegel_test.ml
+++ b/ppx/ppx_hegel_test.ml
@@ -322,9 +322,78 @@ let inject_draw ~tc_name (flags : (string, bool) Stdlib.Hashtbl.t) (vb : value_b
   | _ -> vb
 ;;
 
-(** A traversal that applies {!inject_draw} to every [let]-binding in an
-    expression, threading the precomputed [flags], so labels are injected
-    throughout the test body (nested [let]s, helper functions, match arms, …).
+(** [is_draw_silent_lident lid] is [true] when [lid]'s final component is
+    [draw_silent], qualified or not. Distinct from {!is_draw_lident}, which keys
+    on the [draw] component; [draw_silent] is its own name. *)
+let is_draw_silent_lident : longident -> bool = function
+  | Lident "draw_silent" | Ldot (_, "draw_silent") -> true
+  | _ -> false
+;;
+
+(** [draw_silent_named_lident lid] is [lid] with its final [draw_silent]
+    component replaced by [draw_silent_named], preserving the module prefix, so
+    the rewrite targets the same module's internal entry point (e.g.
+    [Hegel.draw_silent] becomes [Hegel.draw_silent_named]). *)
+let draw_silent_named_lident : longident -> longident = function
+  | Lident "draw_silent" -> Lident "draw_silent_named"
+  | Ldot (prefix, "draw_silent") -> Ldot (prefix, "draw_silent_named")
+  | other -> other
+;;
+
+(** [has_name_arg args] is [true] when an application already passes [~name] (or
+    [?name]) explicitly, in which case the hand-written name wins. *)
+let has_name_arg (args : (arg_label * expression) list) : bool =
+  List.exists
+    (fun (lbl, _) ->
+       match lbl with
+       | Labelled "name" | Optional "name" -> true
+       | _ -> false)
+    args
+;;
+
+(** [draw_silent_binding_name ~tc_name vb] returns [Some name] when [vb] is
+    [let <name> = draw_silent tc …] — a simple-variable binding whose right-hand
+    side is a [draw_silent] application on the test's own [tc] — and [None]
+    otherwise. *)
+let draw_silent_binding_name ~tc_name (vb : value_binding) : string option =
+  match vb.pvb_pat.ppat_desc, vb.pvb_expr.pexp_desc with
+  | ( Ppat_var { txt = name; _ }
+    , Pexp_apply ({ pexp_desc = Pexp_ident { txt = lid; _ }; _ }, args) )
+    when is_draw_silent_lident lid && tc_arg_is ~tc_name args -> Some name
+  | _ -> None
+;;
+
+(** [inject_draw_silent ~tc_name vb] rewrites [let x = draw_silent tc gen] into
+    [let x = draw_silent_named ~name:"x" tc gen], so a function generator
+    ({!Hegel.Generators.functions}) drawn there labels its shown pairs
+    [x arg = result]. [~name] is ignored for every other generator, so the
+    rewrite is harmless. Like {!inject_draw} it targets the internal
+    [draw_silent_named] (keeping [~name] off the public [draw_silent]) and keeps
+    the module prefix the user wrote. It fires only for a simple-variable binding
+    whose right-hand side is a [draw_silent] application on [tc] with no explicit
+    [~name]. *)
+let inject_draw_silent ~tc_name (vb : value_binding) : value_binding =
+  match draw_silent_binding_name ~tc_name vb, vb.pvb_expr.pexp_desc with
+  | ( Some name
+    , Pexp_apply (({ pexp_desc = Pexp_ident ({ txt = lid; _ } as ident); _ } as fn), args)
+    )
+    when not (has_name_arg args) ->
+    let loc = vb.pvb_expr.pexp_loc in
+    let named_fn =
+      { fn with pexp_desc = Pexp_ident { ident with txt = draw_silent_named_lident lid } }
+    in
+    let named_args = [ Labelled "name", Ast_builder.Default.estring ~loc name ] in
+    { vb with
+      pvb_expr = Ast_builder.Default.pexp_apply ~loc named_fn (named_args @ args)
+    }
+  | _ -> vb
+;;
+
+(** A traversal that applies {!inject_draw} and {!inject_draw_silent} to every
+    [let]-binding in an expression, threading the precomputed [flags], so labels
+    are injected throughout the test body (nested [let]s, helper functions, match
+    arms, …). Each binding is at most one of a [draw] or a [draw_silent] on [tc],
+    so the two injectors compose (each leaves the other's bindings untouched).
     Draws nested inside a generation span are still suppressed at runtime by the
     depth gate, so labeling them is harmless. *)
 let label_injector ~tc_name flags =
@@ -333,7 +402,9 @@ let label_injector ~tc_name flags =
 
     method! expression e =
       let e = super#expression e in
-      Ppx_compat.map_let_value_bindings (List.map (inject_draw ~tc_name flags)) e
+      Ppx_compat.map_let_value_bindings
+        (List.map (fun vb -> inject_draw_silent ~tc_name (inject_draw ~tc_name flags vb)))
+        e
   end
 ;;
 

--- a/ppx/test/expect_tests/test_functions_printing.ml
+++ b/ppx/test/expect_tests/test_functions_printing.ml
@@ -1,0 +1,296 @@
+open! Core
+open Hegel
+open Generators
+
+(* swallow the failure the property raises so the expect block only sees what we printed. *)
+let run_failing body =
+  try
+    Hegel.run_hegel_test
+      ~settings:(settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal)
+      body
+  with
+  | _ -> ()
+;;
+
+let%hegel_test binding_name tc =
+  let f_gen =
+    functions
+      ~sexp_of_arg:sexp_of_int
+      ~returns:(integers ~min_value:0 ~max_value:1000 ())
+      ()
+  in
+  let f = draw_silent tc f_gen in
+  assert (f 42 < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "a function is named from its binding" =
+  (try binding_name () with
+   | _ -> ());
+  [%expect
+    {|
+    f 42 = 10
+    |}]
+;;
+
+let%hegel_test binding_name_inline tc =
+  let f =
+    draw_silent
+      tc
+      (functions
+         ~sexp_of_arg:sexp_of_int
+         ~returns:(integers ~min_value:0 ~max_value:1000 ())
+         ())
+  in
+  assert (f 42 < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "a function drawn inline is also named from its binding" =
+  (try binding_name_inline () with
+   | _ -> ());
+  [%expect
+    {|
+    f 42 = 10
+    |}]
+;;
+
+let%hegel_test explicit_name_beats_binding tc =
+  let f =
+    draw_silent
+      tc
+      (functions
+         ~name:"chosen"
+         ~sexp_of_arg:sexp_of_int
+         ~returns:(integers ~min_value:0 ~max_value:1000 ())
+         ())
+  in
+  assert (f 42 < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "an explicit ~name wins over the draw-site binding name" =
+  (try explicit_name_beats_binding () with
+   | _ -> ());
+  [%expect
+    {|
+    chosen 42 = 10
+    |}]
+;;
+
+let%expect_test "without a binding the function falls back to its default name" =
+  run_failing (fun tc ->
+    let f =
+      draw_silent
+        tc
+        (functions
+           ~sexp_of_arg:sexp_of_int
+           ~returns:(integers ~min_value:0 ~max_value:1000 ())
+           ())
+    in
+    assert (f 42 < 10));
+  [%expect
+    {|
+    function 42 = 10
+    |}]
+;;
+
+let%expect_test "an explicit ~name is used when there is no binding name" =
+  run_failing (fun tc ->
+    let f =
+      draw_silent
+        tc
+        (functions
+           ~name:"myfun"
+           ~sexp_of_arg:sexp_of_int
+           ~returns:(integers ~min_value:0 ~max_value:1000 ())
+           ())
+    in
+    assert (f 42 < 10));
+  [%expect
+    {|
+    myfun 42 = 10
+    |}]
+;;
+
+let%hegel_test functions2_binding tc =
+  let g =
+    draw_silent
+      tc
+      (functions2
+         ~sexp_of_arg1:sexp_of_int
+         ~sexp_of_arg2:sexp_of_bool
+         ~returns:(integers ~min_value:0 ~max_value:1000 ())
+         ())
+  in
+  assert (g 3 true < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "functions2 shows its table uncurried, named from its binding" =
+  (try functions2_binding () with
+   | _ -> ());
+  [%expect
+    {|
+    g (3 true) = 10
+    |}]
+;;
+
+let%hegel_test functions3_binding tc =
+  let h =
+    draw_silent
+      tc
+      (functions3
+         ~sexp_of_arg1:sexp_of_int
+         ~sexp_of_arg2:sexp_of_bool
+         ~sexp_of_arg3:sexp_of_int
+         ~returns:(integers ~min_value:0 ~max_value:1000 ())
+         ())
+  in
+  assert (h 1 true 2 < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "functions3 shows its table uncurried, named from its binding" =
+  (try functions3_binding () with
+   | _ -> ());
+  [%expect
+    {|
+    h (1 true 2) = 10
+    |}]
+;;
+
+(* The PPX injects [~name] into every [draw_silent] binding, but it is ignored
+   for non-function generators, which stay silent. *)
+let%hegel_test draw_silent_scalar_stays_silent tc =
+  let n = draw_silent tc (integers ~min_value:5 ~max_value:5 ()) in
+  ignore (n : int);
+  assert false
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "a scalar drawn with draw_silent prints nothing even when named" =
+  (try draw_silent_scalar_stays_silent () with
+   | _ -> ());
+  [%expect {| |}]
+;;
+
+let%hegel_test printable_function_draw tc =
+  let f =
+    draw
+      tc
+      (with_printer
+         (fun _ -> Sexp.Atom "<fun>")
+         (functions
+            ~sexp_of_arg:sexp_of_int
+            ~returns:(integers ~min_value:0 ~max_value:1000 ())
+            ()))
+  in
+  assert (f 42 < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "a printable function generator prints with its sexp_of" =
+  (try printable_function_draw () with
+   | _ -> ());
+  [%expect
+    {|
+    f = <fun>
+    f 42 = 10
+    |}]
+;;
+
+(* Drawn nested (inside a span, draw depth > 0) a function still gets its label
+   threaded into its pairs — here [inner], numbered because it is drawn inside a
+   thunk — but its [<fun>] value line is suppressed like any nested draw. It is
+   applied at the top level, so its pair still shows. *)
+let%hegel_test printable_function_drawn_nested tc =
+  let f =
+    group Labels.list tc (fun () ->
+      draw
+        tc
+        (with_printer
+           (fun _ -> Sexp.Atom "<fun>")
+           (functions
+              ~name:"f"
+              ~sexp_of_arg:sexp_of_int
+              ~returns:(integers ~min_value:0 ~max_value:1000 ())
+              ())))
+  in
+  assert (f 42 < 10)
+[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
+;;
+
+let%expect_test "a function drawn nested keeps its label but suppresses its value line" =
+  (try printable_function_drawn_nested () with
+   | _ -> ());
+  [%expect
+    {|
+    f 42 = 10
+    |}]
+;;
+
+(* A function applied inside a span (draw depth > 0) does not print its pair,
+   like any nested draw. Here [f] is applied only inside the [group], so nothing
+   is shown even though the property fails. *)
+let%hegel_test application_inside_span_is_suppressed tc =
+  let f =
+    draw_silent
+      tc
+      (functions
+         ~sexp_of_arg:sexp_of_int
+         ~returns:(integers ~min_value:0 ~max_value:1000 ())
+         ())
+  in
+  let r = group Labels.list tc (fun () -> f 42) in
+  ignore (r : int);
+  assert false
+[@@settings settings ~test_cases:100 ~seed:0 ()]
+;;
+
+let%expect_test "a function applied inside a span prints nothing" =
+  (try application_inside_span_is_suppressed () with
+   | _ -> ());
+  [%expect {| |}]
+;;
+
+let%hegel_test partially_printable_args_and_ret tc =
+  let f =
+    draw_silent
+      tc
+      (functions
+         ~sexp_of_arg:sexp_of_int
+         ~returns:(functions ~returns:(integers ()) ())
+         ())
+  in
+  let n = f 1 () in
+  assert (n = 0)
+[@@settings settings ~test_cases:100 ~seed:0 ()]
+;;
+
+let%expect_test "partially printable applications" =
+  (try partially_printable_args_and_ret () with
+   | _ -> ());
+  [%expect
+    {|
+    f 1 = <opaque>
+    function <opaque> = 1
+    |}]
+;;
+
+let%hegel_test unprintable_args_and_ret tc =
+  let f = draw_silent tc (functions ~returns:(functions ~returns:(integers ()) ()) ()) in
+  let n = f () () in
+  assert (n = 0)
+[@@settings settings ~test_cases:100 ~seed:0 ()]
+;;
+
+let%expect_test "unprintable applications" =
+  (try unprintable_args_and_ret () with
+   | _ -> ());
+  [%expect
+    {|
+    f <opaque> = <opaque>
+    function <opaque> = 1
+    |}]
+;;

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,7 @@
   test_generators_primitives
   test_generators_collections
   test_generators_combinators
+  test_generators_functions
   test_derive
   test_stateful
   test_single_test_case

--- a/test/test_generators_functions.ml
+++ b/test/test_generators_functions.ml
@@ -39,6 +39,22 @@ let test_functions_independent_e2e () =
   Alcotest.(check bool) "distinct args can differ" true !saw_differ
 ;;
 
+let test_functions_no_sexp_of_arg_e2e () =
+  let saw_differ = ref false in
+  run_hegel_test ~settings:(settings ~test_cases:100 ~seed:0 ()) (fun tc ->
+    let f =
+      draw_silent tc (functions ~returns:(integers ~min_value:0 ~max_value:5 ()) ())
+    in
+    let a0 = f 0 in
+    let a1 = f 1 in
+    if a0 <> a1 then saw_differ := true;
+    (* memo hit: same argument, same result even without a printer *)
+    assert (f 0 = a0);
+    assert (a0 >= 0 && a0 <= 5);
+    assert (a1 >= 0 && a1 <= 5));
+  Alcotest.(check bool) "distinct args differ without sexp_of_arg" true !saw_differ
+;;
+
 (** Test: [functions2] produces a curried two-argument function. Same arguments
     give the same result (memo hit); over many cases, varying the second
     argument must draw a different result at least once (the second argument is
@@ -98,6 +114,10 @@ let tests =
       `Quick
       test_functions_deterministic_e2e
   ; Alcotest.test_case "functions independent e2e" `Quick test_functions_independent_e2e
+  ; Alcotest.test_case
+      "functions no sexp_of_arg e2e"
+      `Quick
+      test_functions_no_sexp_of_arg_e2e
   ; Alcotest.test_case "functions2 curry e2e" `Quick test_functions2_e2e
   ; Alcotest.test_case "functions3 curry e2e" `Quick test_functions3_e2e
   ]

--- a/test/test_generators_functions.ml
+++ b/test/test_generators_functions.ml
@@ -1,0 +1,104 @@
+open Hegel
+open Generators
+
+(** Test: a drawn function is a genuine function within one test case — applying
+    it to the same argument twice yields the same result (the per-argument memo
+    table makes it stable, which properties like [foldr f] rely on). *)
+let test_functions_deterministic_e2e () =
+  run_hegel_test ~settings:(settings ~test_cases:50 ()) (fun tc ->
+    let f =
+      draw_silent tc (functions ~sexp_of_arg:Core.sexp_of_int ~returns:(integers ()) ())
+    in
+    let a = f 7 in
+    let b = f 7 in
+    assert (a = b))
+;;
+
+(** Test: distinct arguments get independent results (never a pre-chosen domain,
+    and results are not forced equal), and every result respects the [returns]
+    generator's bounds. Over many cases, [f 0] and [f 1] must differ at least
+    once. Re-applying [f 0] also exercises the memo-hit path. *)
+let test_functions_independent_e2e () =
+  let saw_differ = ref false in
+  run_hegel_test ~settings:(settings ~test_cases:100 ~seed:0 ()) (fun tc ->
+    let f =
+      draw_silent
+        tc
+        (functions
+           ~sexp_of_arg:Core.sexp_of_int
+           ~returns:(integers ~min_value:0 ~max_value:5 ())
+           ())
+    in
+    let a0 = f 0 in
+    let a1 = f 1 in
+    if a0 <> a1 then saw_differ := true;
+    (* memo hit: same argument, same result *)
+    assert (f 0 = a0);
+    assert (a0 >= 0 && a0 <= 5);
+    assert (a1 >= 0 && a1 <= 5));
+  Alcotest.(check bool) "distinct args can differ" true !saw_differ
+;;
+
+(** Test: [functions2] produces a curried two-argument function. Same arguments
+    give the same result (memo hit); over many cases, varying the second
+    argument must draw a different result at least once (the second argument is
+    part of the key); every result respects the [returns] bounds. *)
+let test_functions2_e2e () =
+  let saw_differ = ref false in
+  run_hegel_test ~settings:(settings ~test_cases:100 ~seed:0 ()) (fun tc ->
+    let f =
+      draw_silent
+        tc
+        (functions2
+           ~sexp_of_arg1:Core.sexp_of_int
+           ~sexp_of_arg2:Core.sexp_of_bool
+           ~returns:(integers ~min_value:0 ~max_value:9 ())
+           ())
+    in
+    let r = f 3 true in
+    let r' = f 3 false in
+    if r <> r' then saw_differ := true;
+    (* memo hit: same arguments, same result *)
+    assert (f 3 true = r);
+    assert (r >= 0 && r <= 9);
+    assert (r' >= 0 && r' <= 9));
+  Alcotest.(check bool) "different second arg can differ" true !saw_differ
+;;
+
+(** Test: [functions3] produces a curried three-argument function. Results are
+    consistent per argument triple (memo hit); over many cases, varying the
+    third argument must draw a different result at least once; every result
+    respects the [returns] bounds. *)
+let test_functions3_e2e () =
+  let saw_differ = ref false in
+  run_hegel_test ~settings:(settings ~test_cases:100 ~seed:0 ()) (fun tc ->
+    let f =
+      draw_silent
+        tc
+        (functions3
+           ~sexp_of_arg1:Core.sexp_of_int
+           ~sexp_of_arg2:Core.sexp_of_bool
+           ~sexp_of_arg3:Core.sexp_of_int
+           ~returns:(integers ~min_value:0 ~max_value:9 ())
+           ())
+    in
+    let r = f 1 true 2 in
+    let r' = f 1 true 3 in
+    if r <> r' then saw_differ := true;
+    (* memo hit: same arguments, same result *)
+    assert (f 1 true 2 = r);
+    assert (r >= 0 && r <= 9);
+    assert (r' >= 0 && r' <= 9));
+  Alcotest.(check bool) "different third arg can differ" true !saw_differ
+;;
+
+let tests =
+  [ Alcotest.test_case
+      "functions deterministic e2e"
+      `Quick
+      test_functions_deterministic_e2e
+  ; Alcotest.test_case "functions independent e2e" `Quick test_functions_independent_e2e
+  ; Alcotest.test_case "functions2 curry e2e" `Quick test_functions2_e2e
+  ; Alcotest.test_case "functions3 curry e2e" `Quick test_functions3_e2e
+  ]
+;;

--- a/test/test_hegel.ml
+++ b/test/test_hegel.ml
@@ -6,6 +6,7 @@ let () =
     ; "generators_primitives", Test_generators_primitives.tests
     ; "generators_collections", Test_generators_collections.tests
     ; "generators_combinators", Test_generators_combinators.tests
+    ; "generators_functions", Test_generators_functions.tests
     ; "derive", Test_derive.tests
     ; "stateful", Test_stateful.tests
     ; "single_test_case", Test_single_test_case.tests


### PR DESCRIPTION
```ocaml
let%hegel_test unprintable_args_and_ret tc =
  let f = draw_silent tc (functions ~returns:(functions ~returns:(integers ()) ()) ()) in
  let n = f () () in
  assert (n = 0)
[@@settings settings ~test_cases:100 ~seed:0 ()]
```

prints
```
f <opaque> = <opaque>
function <opaque> = 1
```

because no printer is provided for the args/return value.

```ocaml
let%hegel_test binding_name tc =
  let f_gen =
    functions
      ~sexp_of_arg:sexp_of_int
      ~returns:(integers ~min_value:0 ~max_value:1000 ())
      ()
  in
  let f = draw_silent tc f_gen in
  assert (f 42 < 10)
[@@settings settings ~test_cases:100 ~seed:0 () |> with_verbosity Normal]
```

prints

```
f 42 = 10
```

2 and 3 argument functions can also be generated.