### PR TITLE
Remove default switch and closed PR caches

### DIFF
--- a/.github/actions/setup-opam/action.yml
+++ b/.github/actions/setup-opam/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: Extra flags passed to `opam install . --deps-only` (e.g. --with-test).
     required: false
     default: ""
-  bare:
-    description: Initialize opam with --bare (skips creating a default switch).
-    required: false
-    default: "false"
 runs:
   using: composite
   steps:
@@ -64,17 +60,12 @@ runs:
       if: steps.cache-opam.outputs.cache-hit != 'true'
       shell: bash
       env:
-        BARE: ${{ inputs.bare }}
         OCAML_VERSION: ${{ inputs.ocaml-version }}
       run: |
         # Cache may be partially restored via restore-keys (a different key
         # prefix matched); guard each step so it's idempotent.
         if [ ! -d "$HOME/.opam" ]; then
-          if [ "$BARE" = "true" ]; then
-            opam init --bare --disable-sandboxing --yes
-          else
-            opam init --disable-sandboxing --yes
-          fi
+          opam init --bare --disable-sandboxing --yes
         fi
         if ! opam switch list --short 2>/dev/null | grep -q "^${OCAML_VERSION}$"; then
           opam switch create "$OCAML_VERSION" --yes

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,24 @@
+name: Cache cleanup
+
+# This job frees a PR's caches the moment it closes
+
+on: # zizmor: ignore[dangerous-triggers] no checkout/execution of PR content, only reads the trusted PR number
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: delete PR caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches for this PR's ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          gh cache delete --all --ref "$PR_REF" --repo "$REPO" --succeed-on-no-caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,6 @@ jobs:
           cache-restore-keys: |
             opam-${{ runner.os }}-smoke-
           deps-flags: --with-test
-          bare: "true"
 
       - name: Stage libhegel from the matching GitHub release
         id: libhegel


### PR DESCRIPTION
opam creates a default switch we do not use (adds ~300 Mb of wasted space per cache). 
