### PR TITLE
ppx derive hegel_generator in module signatures

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Add support for deriving `hegel_generator` declarations in module signatures.
+This patch adds support for deriving `hegel_generator` declarations in module signatures.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add support for deriving `hegel_generator` declarations in module signatures.

--- a/ppx/ppx_hegel_generator.ml
+++ b/ppx/ppx_hegel_generator.ml
@@ -376,8 +376,39 @@ let generate_impl ~ctxt ((rec_flag, type_decls) : rec_flag * type_declaration li
   @ generator_items
 ;;
 
+let generate_intf ~ctxt:_ ((_rec_flag, type_decls) : rec_flag * type_declaration list)
+  : signature_item list
+  =
+  List.map
+    (fun (td : type_declaration) ->
+       let loc = td.ptype_loc in
+       (match td.ptype_params with
+        | [] -> ()
+        | _ :: _ ->
+          Location.raise_errorf
+            ~loc
+            "ppx_hegel_generator: parameterized types not supported");
+       let gen_name = generator_name td.ptype_name.txt in
+       let type_constr =
+         Ast_builder.Default.ptyp_constr ~loc { txt = Lident td.ptype_name.txt; loc } []
+       in
+       let gen_type =
+         [%type:
+           ([%t type_constr], Hegel.Generators.printable) Hegel.Generators.generator]
+       in
+       Ast_builder.Default.psig_value
+         ~loc
+         (Ast_builder.Default.value_description
+            ~loc
+            ~name:{ txt = gen_name; loc }
+            ~type_:gen_type
+            ~prim:[]))
+    type_decls
+;;
+
 let _deriver =
   Deriving.add
     "hegel_generator"
     ~str_type_decl:(Deriving.Generator.V2.make_noarg generate_impl)
+    ~sig_type_decl:(Deriving.Generator.V2.make_noarg generate_intf)
 ;;

--- a/ppx/test/test_ppx_derive.ml
+++ b/ppx/test/test_ppx_derive.ml
@@ -102,6 +102,23 @@ type char_and_float =
   }
 [@@deriving hegel_generator]
 
+(** Deriving in a module signature. *)
+module Signature_deriving : sig
+  type t [@@deriving hegel_generator]
+  type named [@@deriving hegel_generator]
+end = struct
+  type t = { value : int } [@@deriving hegel_generator]
+  type named = Named of string [@@deriving hegel_generator]
+end
+
+let (_ : (Signature_deriving.t, Hegel.printable) Hegel.generator) =
+  Signature_deriving.hegel_generator
+;;
+
+let (_ : (Signature_deriving.named, Hegel.printable) Hegel.generator) =
+  Signature_deriving.hegel_generator_named
+;;
+
 (** A module whose main type is [t]: derives a value named plain
     [hegel_generator] (no [_t] suffix), following the quickcheck convention. *)
 module Temperature_reading = struct


### PR DESCRIPTION
## Summary

- Allow for `[@@deriving hegel_generator]` in module signatures.
- Parameterized types (e.g. `'a t`) are currently not supported by the implementation, so the deriver for signatures rejects them. This is something we might want to address in the future, since Quickcheck does support parameterized types.

## Testing

- Added a small test to show that the ppx works as expected.